### PR TITLE
increase stack size of extract to allow for more recursion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ mydir=`pwd`
 srcdir=./TEST
 topd = $(mydir)/AtlasBase
 defs = -def topd $(topd) -def ext $(mydir)/$(srcdir)/xextract
+OS = $(shell uname -s)
+ifeq ($(OS),MINGW32_NT-6.1)
+CCFLAGS += -Wl,--stack,16777216
+endif
 
 $(srcdir) :
 	mkdir $(srcdir)


### PR DESCRIPTION
I've found that it is possible to compile all of ATLAS 3.10.0 with MinGW32 (entirely without Cygwin), with a few minor tweaks to the configure script (largely based upon the suggestions at http://stackoverflow.com/questions/9046454/mingw-system-system-call-and-path-behaviour). This was the simplest one -- extract requires a bigger stack than is given to it by default, to handle the recursion; I picked an arbitrary large number.

Making patches for the other issues will take more time, as I learn my way around the code-base. But I will proceed with providing patches for them, if you are interested.

(I just noticed that that this option is written ```-Wl,-stack_size,16777216``` on some systems, e.g. Mac, so maybe is would be better to only add this only if ```uname -s``` returns ```MINGW32_NT-6.1```)
