### PR TITLE
Mmtime changes

### DIFF
--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -28734,6 +28734,7 @@ void PrintUsage(char *name, int ierr, char *flag)
 char *GetFlags(int nargs, char **args, char *PRE, ATL_mmnode_t **lists)
 {
    int i, j=0, n, k;
+   int GotAnySumFile = 0;
    char pre='d', cpre, ch;
    char *outd=NULL;
    char *fn[2]={"uAMMRES.sum","uAMMKCLEAN.sum"};
@@ -28766,6 +28767,7 @@ char *GetFlags(int nargs, char **args, char *PRE, ATL_mmnode_t **lists)
             UIL++;
          break;
       case 'u':
+         GotAnySumFile = 1;
          switch(args[i][2])
          {
       @multidef i   0 1
@@ -28809,7 +28811,7 @@ char *GetFlags(int nargs, char **args, char *PRE, ATL_mmnode_t **lists)
    {
       const char pr=(i<NMMLISTS) ? pre : cpre;
       const int k = (i<NMMLISTS) ? i : i-NMMLISTS;
-      if (!lists[i])
+      if (!lists[i] && (!GotAnySumFile || (i&1==0)))
          lists[i] = ReadMMFileWithPath(pr, "res", fn[k]);
       if (!lists[i])
          fprintf(stderr, "CANNOT FIND FILE 'res/%c%s'!\n", pr, fn[k]);
@@ -29027,6 +29029,41 @@ void GenBlkH(char pre, char *outd, char *cn, ATL_mmnode_t *mb)
    CloseGenHeader(fp);
 }
 
+int StrFindReplace(char **org, char *find, char *replace)
+{
+   char *pre, *post, *final;
+   char *orig = *(org);
+   int idx = (strstr(orig, find) - orig) / sizeof(char);
+   int len = strlen(orig);
+   int flen = strlen(find);
+   int rlen = strlen(replace);
+   if (idx < 0) return(len); /* not found */
+   pre = malloc(sizeof(char)*idx + 1);
+   post = malloc(sizeof(char)*(len - idx - flen) + 1);
+   strncpy(pre, orig, idx);
+   pre[idx] = '\0';
+   strcpy(post, orig+idx+flen);
+   len = len - flen + rlen;
+   free(orig);
+   orig = malloc(sizeof(char)*(len) + 1);
+   strcpy(orig, pre);
+   strcat(orig, replace);
+   strcat(orig, post);
+   *org = orig;
+   return(len);
+}
+
+void AdjustCPNamesWithID(char pre, ATL_mmcp_t *cb)
+{
+   char find[24] = "";
+   char replace[24] = "";
+   ATL_mmcp_t *cp;
+   sprintf(find, "ATL_%c", pre);
+   sprintf(replace, "ATL_%cu%d", pre, UID);
+   for (cp=cb; cp; cp=cp->next)
+      cp->rtlen = StrFindReplace(&cp->rout, find, replace);
+}
+
 void GenCpyA(char pre, char *outd, char *cn, char dir, char alp, 
              ATL_mmnode_t *mb)
 // presently leaving alp='[1,n,X]', cn=[ge,sq,rk], dir='[F,T]' to caller
@@ -29066,6 +29103,7 @@ void GenCpyA(char pre, char *outd, char *cn, char dir, char alp,
          arrnm[transi] = ta;
          cb = GetMMCopyFromMMNodes(MMCopyEncode(pre, dir, mats[im], ta), mb);
          assert(cb);
+         AdjustCPNamesWithID(pre, cb);
          ucb = AddUniqueCopyNode(NULL, cb);
          arrnm[6] = '\0';
          PrintMMCpProtosA(fp, arrnm, ucb, dir, alp);
@@ -29087,6 +29125,7 @@ void GenCpyC(FILE *fp, char pre, char *outd, char *cn, char dir, char *type,
 
    cb = GetMMCopyFromMMNodes(MMCopyEncode(pre, dir, 'c', 'n'), mb);
    assert(cb);
+   AdjustCPNamesWithID(pre, cb);
    #ifdef Debug
       i = CountListEntries(cb, GetOffset(&cb->next, cb));
       j = CountListEntries(mb, GetOffset(&mb->next, mb));
@@ -29168,6 +29207,7 @@ void GenFullCpyC(char pre, char *outd, char dir, char *cn, ATL_mmnode_t *mb)
       fp = OpenMMGenHeader(outd, 0, pre, cn, 0, 0, "szC", mb);
       cb = GetMMCopyFromMMNodes(MMCopyEncode(pre, dir, 'c', 'n'), mb);
       assert(cb);
+      AdjustCPNamesWithID(pre, cb);
       ucb = AddUniqueCopyNode(NULL, cb);
       KillAllCopyNodes(cb);
 /*
@@ -29307,7 +29347,7 @@ void GenSumH(char pre, char *outd, ATL_mmnode_t *ub)
    int i;
 
    fp = OpenMMGenHeader(outd, 0, pre, unam, 0, 0, "sum", ub);
-   mf = PrintSum(fp, "ub", ub, 0.0);
+   mf = PrintSum(fp, unam, ub, 0.0);
    CloseGenHeader(fp);
 }
 
@@ -29356,12 +29396,12 @@ void GenAllHeaders(char pre, char *outd, ATL_mmnode_t **lists)
    GenAllCpyA(pre, outd, 'T', lists[IUSR]);
    GenAllCpyA(pre, outd, 'F', lists[IUSR]);
    GenAllCpyA(pr, outd, 'T', lists[IUSR+NMMLISTS]);
-   //GenAllCpyA(pr, outd, 'F', lists[IUSR+NMMLISTS]); // for now
+   GenAllCpyA(pr, outd, 'F', lists[IUSR+NMMLISTS]); // for now
 
    GenAllCpyC(pre, outd, 'F', lists[IUSR]);
    GenAllCpyC(pre, outd, 'T', lists[IUSR]);
    GenAllCpyC(pr, outd, 'F', lists[IUSR+NMMLISTS]);
-   //GenAllCpyC(pr, outd, 'T', lists[IUSR+NMMLISTS]); // for now
+   GenAllCpyC(pr, outd, 'T', lists[IUSR+NMMLISTS]); // for now
 }
 
 static void AddAlpBetSuf(char *rt, int rl, int ial, int ibe)
@@ -29593,15 +29633,15 @@ void GenMake(char pre, char *outd, ATL_mmnode_t *mb,
    fprintf(fp, "\n\nlib : %clib.grd\nall : %clib.grd\n%clib : %clib.grd\n",
            pre, pre, pre, pre);
    fprintf(fp, "%clib.grd : $(objs)\n", pre);
-   fprintf(fp, "\t$(ARCHIVER) $(ARFLAGS) $(ATLASlib) $(objs)\n");
-   fprintf(fp, "\t $(RANLIB) $(ATLASlib)\n");
+   fprintf(fp, "\t$(ARCHIVER) $(ARFLAGS) $(UAMMlib) $(objs)\n");
+   fprintf(fp, "\t $(RANLIB) $(UAMMlib)\n");
    fprintf(fp, "\t touch %clib.grd\n", pre);
    fprintf(fp, "clean : %cclean\n", pre);
    fprintf(fp, "%cclean:\n\t- rm -f $(objs)\n", pre);
    fprintf(fp, "killall : %ckillall\n", pre);
    fprintf(fp, "%ckillall : %cclean\n", pre, pre);
-   fprintf(fp, "\t- $(ARCHIVER) d $(ATLASlib) $(objs)\n");
-   fprintf(fp, "\t $(RANLIB) $(ATLASlib)\n");
+   fprintf(fp, "\t- $(ARCHIVER) d $(UAMMlib) $(objs)\n");
+   fprintf(fp, "\t $(RANLIB) $(UAMMlib)\n");
    fprintf(fp, "\t- rm -f ATL_%c*.[S,c]\n\n", pre);
 /*
  * Make targets for amm kerns
@@ -29740,18 +29780,33 @@ void GenAllFiles(char pre, char *outd, ATL_mmnode_t **lists)
    GetMMAllUniqueCopyFromMMNodes(pre, 'F', 'T', rb, &cpA, &cpC);
    GetMMAllUniqueCopyFromMMNodes(pre, 'T', 'F', rb, &cpA, &cpC);
    GetMMAllUniqueCopyFromMMNodes(cpr, 'F', 'T', ib, &cpA, &cpC);
-   //GetMMAllUniqueCopyFromMMNodes(cpr, 'T', 'F', ib, &cpA, &cpC); // for now
+   GetMMAllUniqueCopyFromMMNodes(cpr, 'T', 'F', ib, &cpA, &cpC); // for now
 /*
  * Now, kerns are compiled the same for real and complex, so reduce real
  * and complex to one unique list
  */
    rb = AddUniqueMMKernCompList(rb, ib);
    KillAllMMNodes(ib);
+   AdjustCPNamesWithID(pre, cpA);
+   AdjustCPNamesWithID(cpr, cpA);
+   AdjustCPNamesWithID(pre, cpC);
+   AdjustCPNamesWithID(cpr, cpC);
    GenAllKerns(pre, outd, rb, cpA, cpC);
    GenMake(pre, outd, rb, cpA, cpC);
    KillAllMMNodes(rb);
    KillAllCopyNodes(cpA);
    KillAllCopyNodes(cpC);
+}
+
+void AdjustMMNamesWithID(char pre, ATL_mmnode_t *mb)
+{
+   char find[24] = "";
+   char replace[24] = "";
+   ATL_mmnode_t *mp;
+   sprintf(find, "ATL_%c", pre);
+   sprintf(replace, "ATL_%cu%d", pre, UID);
+   for (mp=mb; mp; mp=mp->next)
+      StrFindReplace(&mp->auth, find, replace);
 }
 
 int main(int nargs, char **args)
@@ -29773,6 +29828,8 @@ int main(int nargs, char **args)
    {
       PrepMMForGen(pre, outd, "amm", lists[i]);
    }
+   for (i=0; i < 2*NMMLISTS; i++)
+      AdjustMMNamesWithID(pre, lists[i]);
 
    GenAllFiles(pre, outd, lists);
 

--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -28695,6 +28695,1090 @@ int main(int nargs, char **args)
    printf("BLOCKSIZE=%d\n", i);
    return(0);
 }
+@ROUT uammgen
+@extract -b @(topd)/cw.inc lang=C -def cwdate 2015 
+#include "atlas_misc.h"
+#include "atlas_mmgen.h"
+#include "atlas_sys.h"
+
+#define NMMLISTS 2
+#define IUSR   0
+#define IUSRK1 1
+
+   static int UID=0, UIL=1;
+   static char unam[16];
+
+@extract -b @(basd)/atlas.base rout=Mylcm
+void PrintUsage(char *name, int ierr, char *flag)
+{
+   if (ierr > 0)
+      fprintf(stderr, "Bad argument #%d: '%s'\n", ierr,
+              flag?flag:"OUT-OF_ARGUMENTS");
+   else if (ierr < 0)
+      fprintf(stderr, "ERROR: %s\n", flag);
+   fprintf(stderr, "USAGE: %s [flags]:\n", name);
+   fprintf(stderr, "   -p [s,d]: set type/precision prefix (d) \n");
+   fprintf(stderr, "      s/d will generate for complex (c/z) as well\n");
+   fprintf(stderr, "   -d <outdir>: directory to dump files to\n");
+   fprintf(stderr, 
+      "   -I <ID>: unique non-negative ID for header/kern files\n");
+   fprintf(stderr, "   -ub [r,c] <user-case kernel file> \n");
+   fprintf(stderr, "   -uk [r,c] <user-case KClean file (if needed)>\n");
+   exit(ierr ? ierr : -1);
+}
+
+
+/*
+ * RETURNS: precision prefix [s,d,c,z]
+ */
+char *GetFlags(int nargs, char **args, char *PRE, ATL_mmnode_t **lists)
+{
+   int i, j=0, n, k;
+   char pre='d', cpre, ch;
+   char *outd=NULL;
+   char *fn[2]={"uAMMRES.sum","uAMMKCLEAN.sum"};
+
+   for (i=0; i < 2*NMMLISTS; i++)
+      lists[i] = NULL;
+   for (i=1; i < nargs; i++)
+   {
+      if (args[i][0] != '-')
+         PrintUsage(args[0], i, args[i]);
+
+      switch(args[i][1])
+      {
+      case 'p':
+         if (++i >= nargs)
+            PrintUsage(args[0], i-1, NULL);
+         pre = tolower(args[i][0]);
+         if (pre == 'z')
+            pre = 'd';
+         else if (pre == 'c')
+            pre = 's';
+         assert(pre == 's' || pre == 'd');
+         cpre = (pre == 'd') ? 'z' : 'c';
+         break;
+      case 'I':
+         if (++i >= nargs)
+            PrintUsage(args[0], i-1, NULL);
+         UID = atoi(args[i]);
+         for (k=10; k<=UID; k*=10)
+            UIL++;
+         break;
+      case 'u':
+         switch(args[i][2])
+         {
+      @multidef i   0 1
+      @whiledef flg b k
+         case '@(flg)': /* [r,c] <file> */
+            if (++i >= nargs)
+               PrintUsage(args[0], i-1, NULL);
+            ch = args[i][0];
+            if (ch == 'c')
+               k = NMMLISTS + @(i);
+            else if (ch == 'r')
+               k = @(i);
+            else
+               PrintUsage(args[0],i, "1st arg to -u@(flg) must be 'r' or 'c'!");
+            if (++i >= nargs)
+               PrintUsage(args[0], i-1, NULL);
+            lists[k] = ReadMMFile(args[i]);
+            assert(lists[k]);
+            break;
+      @undef i
+      @endwhile
+         default:
+            PrintUsage(args[0], i, args[i]);
+         }
+         break;
+      case 'd':
+        if (++i >= nargs)
+            PrintUsage(args[0], i-1, NULL);
+        outd = DupString(args[i]);
+        break;
+      default:
+         PrintUsage(args[0], i, args[i]);
+      }
+   }
+   *PRE = pre;
+   sprintf(unam, "u%d", UID);
+/*
+ * Fill in any required list entry
+ */
+   for (i=0; i < 2*NMMLISTS; i++)
+   {
+      const char pr=(i<NMMLISTS) ? pre : cpre;
+      const int k = (i<NMMLISTS) ? i : i-NMMLISTS;
+      if (!lists[i])
+         lists[i] = ReadMMFileWithPath(pr, "res", fn[k]);
+      if (!lists[i])
+         fprintf(stderr, "CANNOT FIND FILE 'res/%c%s'!\n", pr, fn[k]);
+      if (i&1 == 0) assert(lists[i]);
+   }
+   return(outd);
+}
+
+double GenPerfH(char pre, char *outd, char *cn, double mfMax,
+                ATL_mmnode_t *mb, ATL_mmnode_t *k1)
+{
+   FILE *fp;
+   ATL_mmnode_t *mp;
+   #define NTHRSH 11
+   int THRSH[NTHRSH] = {25, 33, 50, 66, 75, 80, 85, 90, 95, 98, 99};
+   int idxT[NTHRSH];
+   ATL_mmnode_t *mpT[NTHRSH];
+   const int FNDMAX = (mfMax == 0.0);
+   int i, n, idxMax=0;
+   double fcnt;
+
+   fp = OpenMMGenHeader(outd, 0, pre, cn, 0, 0, "perf", mb);
+/*
+ * If not already set, compute the max perf & its index.  We'll use this
+ * max as the denominator in our PERF array.
+ */
+   if (FNDMAX)
+   {
+      for (i=0; i < NTHRSH; i++)
+         mpT[i] = NULL;
+      for (n=0,mp=mb; mp; n++, mp = mp->next)
+      {
+         if (mp->mflop[0] > mfMax)
+         {
+            mfMax = mp->mflop[0];
+            idxMax = n;
+         }
+      }
+   }
+/*
+ * If our denom comes from other file, just count the number of entries
+ */
+   else
+   {
+      for (n=0,mp=mb; mp; n++, mp = mp->next);
+      idxMax = -1;
+   }
+   fprintf(fp, "#define ATL_%sAMM_NCASES %d\n", cn, n);
+   fprintf(fp, "#define ATL_%sAMM_DENOM %le /* (%.2f)*/ \n", cn,
+           mfMax, mfMax);
+   fprintf(fp, "#define ATL_%sAMM_MAXMFLOPIDX %d\n\n", cn, idxMax);
+   if (FNDMAX)
+   {
+      for (n=0,mp=mb; mp; mp = mp->next, n++)
+      {
+         double mf = mp->mflop[0] / mfMax;
+         for (i=0; i < NTHRSH; i++)
+         {
+            if (!mpT[i] && THRSH[i]*0.01*mfMax < mp->mflop[0])
+            {
+               mpT[i] = mp;
+               idxT[i] = n;
+            }
+         }
+      }
+      for (i=0; i < NTHRSH; i++)
+      {
+         mp = mpT[i];
+         fprintf(fp, "#define ATL_%sAMM_%dLCMU %d\n", cn, THRSH[i],
+                 Mylcm(Mylcm(mp->mu,mp->nu),mp->ku));
+         fprintf(fp, "#define ATL_%sAMM_%dLCMMN %d\n", cn, THRSH[i],
+                 Mylcm(mp->mu,mp->nu));
+         fprintf(fp, "#define ATL_%sAMM_%dMB %d\n", cn, THRSH[i], mp->mbB);
+         fprintf(fp, "#define ATL_%sAMM_%dNB %d\n", cn, THRSH[i], mp->nbB);
+         fprintf(fp, "#define ATL_%sAMM_%dKB %d\n", cn, THRSH[i], mp->kbB);
+         fprintf(fp, "#define ATL_%sAMM_%dIDX %d\n", cn, THRSH[i], idxT[i]);
+      }
+      mp = ATL_FindLastNode(mb, GetOffset(&mb->next, mb));
+      fprintf(fp, "#define ATL_%sAMM_LCMU %d\n", cn, 
+              Mylcm(Mylcm(mp->mu,mp->nu),mp->ku));
+      fprintf(fp, "#define ATL_%sAMM_LCMMN %d\n", cn, Mylcm(mp->mu,mp->nu));
+      fprintf(fp, "\n");
+   }
+
+   fprintf(fp, "#if !defined(NOPERF) && !defined(NOARRS)\n");
+   fprintf(fp, "static const float ATL_%sAMM_PERF[%d] =\n", cn, n);
+   fprintf(fp, "{  /* %% of performance of best kernel */\n");
+   for (i=0,mp=mb; mp; i++,mp = mp->next)
+      fprintf(fp, "   %f%c  /* IDX=%d, KB=%d, mf=%.0f */\n", mp->mflop[0]/mfMax,
+              (mp->next)?',':' ', i, mp->kbB, mp->mflop[0]);
+   fprintf(fp, "};\n#endif\n\n");
+
+   if (k1)
+   {
+      ATL_mmnode_t *kp;
+      fprintf(fp, "#if !defined(NOK1RATIO) && !defined(NOARRS)\n");
+      fprintf(fp, "static const float ATL_%sAMM_K1RATIO[%d] =\n", cn, n);
+      fprintf(fp, "{  /* ratio of %sAMM perf wt that of its K=1 K-cleaner */\n",
+              cn);
+      for (i=0,mp=mb,kp=k1; mp; i++,mp = mp->next,kp = kp->next)
+         fprintf(fp, "   %f%c  /* IDX=%d, KB=%d IDs=[%d,%d]*/\n", 
+                 kp->mflop[0]/mp->mflop[0], (mp->next)?',':' ', i, mp->kbB,
+                 mp->ID, kp->ID);
+      fprintf(fp, "};\n#endif\n\n");
+   }
+
+   fprintf(fp, "#if !defined(NOTIME) && !defined(NOARRS)\n");
+   fprintf(fp, "static const float ATL_%sAMM_TIME[%d] =\n", cn, n);
+   fprintf(fp, "{  /* actual seconds to compute one block */\n");
+   for (i=0,mp=mb; mp; i++,mp = mp->next)
+   {
+      if (mp->blask == 0)
+         fcnt = (2.0*mp->mbB)*mp->nbB*mp->kbB;  /* gemm flop count */
+      else
+         fcnt = (1.0*mp->mbB)*mp->nbB*mp->kbB;  /* roughly right */
+      fprintf(fp, "   %e%c  /* IDX=%d, B=(%d,%d,%d) */\n",
+              fcnt / (mp->mflop[0]*1.0e6),
+              (mp->next)?',':' ', i, mp->mbB, mp->nbB, mp->kbB);
+   }
+   fprintf(fp, "};\n#endif\n");
+   CloseGenHeader(fp);
+   return(mfMax);
+}
+
+void GenKernH
+   (char pre, char *outd, char *cn, ATL_mmnode_t *mb, ATL_mmnode_t *mkb,
+    ATL_mmnode_t *ub)
+{
+   FILE *fp;
+   int ib, inxt, iaut;
+   char bes[3] = {'0', '1', 'n'};
+
+   inxt = GetOffset(&mb->next, mb);
+   iaut = GetOffset(&ub->auth, ub);
+   fp = OpenMMGenHeader(outd, 0, pre, cn, 0, 0, "kern", mb);
+   for (ib=0; ib < 3; ib++)
+      PrintMMProtos(fp, pre, "KERN", ub, iaut, bes[ib]);
+   for (ib=0; ib < 3; ib++)
+   {
+      PrintStrArrAtOff(fp, pre, "KERN", mb, inxt, iaut, "ammkern_t", 
+                       0, 0, bes[ib]);
+      if (mkb)
+         PrintStrArrAtOff(fp, pre, "KERN_K1", mkb, inxt, iaut, "ammkern_t", 
+                          0, 0, bes[ib]);
+   }
+   CloseGenHeader(fp);
+}
+
+void PrintFlagArr(FILE *fp, ATL_mmnode_t *mb)
+{
+   ATL_mmnode_t *mp;
+   int n;
+
+   n = CountListEntries(mb, GetOffset(&mb->next, mb));
+   fprintf(fp, "#ifndef NOKFLAG\n");
+   fprintf(fp, "static const unsigned char ATL_AMM_KFLAG[%d] =\n{\n", n);
+   for (n=0,mp=mb; mp; n++, mp = mp->next)
+   {
+      unsigned char flag=FLAG_IS_SET(mp->flag, MMF_KRUNTIME) ? 1 : 0;
+      if (FLAG_IS_SET(mp->flag, MMF_KVEC))
+         flag |= 2;
+      fprintf(fp, "%6d%c   /* IDX=%d */\n", flag, mp->next ? ',':' ', n);
+   }
+   fprintf(fp, "};\n");
+   fprintf(fp, "   #define ATL_AMM_KRUNTIME(idx_) (ATL_AMM_KFLAG[idx_] & 1)\n");
+   fprintf(fp, "   #define ATL_AMM_KMAJOR(idx_) (ATL_AMM_KFLAG[idx_] & 2)\n");
+   fprintf(fp, "#endif\n");
+}
+void GenBlkH(char pre, char *outd, char *cn, ATL_mmnode_t *mb)
+{
+   FILE *fp;
+   ATL_mmnode_t *mp;
+   int *KUs;
+   int i, n, inxt;
+
+   fp = OpenMMGenHeader(outd, 0, pre, cn, 0, 0, "blk", mb);
+   inxt = GetOffset(&mb->next, mb);
+   mp = ATL_FindLastNode(mb, inxt);
+   fprintf(fp, "#define ATL_%sAMM_LASTMB %d\n", cn, mp->mbB);
+   fprintf(fp, "#define ATL_%sAMM_LASTNB %d\n", cn, mp->nbB);
+   fprintf(fp, "#define ATL_%sAMM_LASTKB %d\n", cn, mp->kbB);
+   fprintf(fp, "\n");
+/*
+ * Save original KUs, and overwrite compile-time-K KUs with kbB for printing
+ */
+   n = CountListEntries(mb, inxt);
+   KUs = malloc(sizeof(int)*n*3);
+   assert(KUs);
+   for (i=0,mp=mb; mp; i++,mp = mp->next)
+   {
+      KUs[i] = mp->ku;
+      KUs[i+n] = mp->kbmin;
+      KUs[i+n+n] = mp->kbmax;
+      #if 0
+      if (FLAG_IS_SET(mp->flag,MMF_KUISKB))
+         mp->kbmin = mp->kbmax = mp->ku = mp->kbB;
+      else if (!FLAG_IS_SET(mp->flag, MMF_KRUNTIME))
+         mp->kbmin = mp->kbmax = mp->kbB;
+      #endif
+   }
+   @multidef st VLENs KBMAXs KBMINs KUs NUs MUs KBs NBs MBs
+   @whiledef iv vlen  kbmax  kbmin  ku  nu  mu  kbB nbB mbB
+@skip   PrintMMIntOffArr(fp, pre, "@(st)", mb, GetOffset(&mb->@(iv), mb));
+   PrintIntArrAtOff(fp, pre, "@(st)", mb, inxt, GetOffset(&mb->@(iv), mb),0,0);
+      @undef st
+   @endwhile
+   for (i=0,mp=mb; mp; i++,mp = mp->next)
+   {
+      mp->ku = KUs[i];
+      mp->kbmin = KUs[i+n];
+      mp->kbmax = KUs[i+n+n];
+   }
+   PrintFlagArr(fp, mb);
+   free(KUs);
+   CloseGenHeader(fp);
+}
+
+void GenCpyA(char pre, char *outd, char *cn, char dir, char alp, 
+             ATL_mmnode_t *mb)
+// presently leaving alp='[1,n,X]', cn=[ge,sq,rk], dir='[F,T]' to caller
+{
+   FILE *fp;
+   const int nt = (pre == 'd' || pre == 's') ? 2 : 4;
+   int flag=0, i, j, it, im;
+   char tas[4] = {'N', 'T', 'C', 'H'};
+   char mats[2] = {'A', 'B'};
+   char arrnm[12]={'x', 'x', '2', 'B', 'L', 'K', '_', 'a', alp, '\0'};
+   char fn[12];
+   int mati, transi;
+
+   if (dir == 'T')
+   {
+      sprintf(fn, "cm2am_a%c", alp);
+      mati = 0; transi = 1;
+   }
+   else
+   {
+      sprintf(fn, "am2cm_a%c", alp);
+      sprintf(arrnm, "BLK2xx_a%c", alp);
+      mati = 4; transi = 5;
+   }
+   fp = OpenMMGenHeader(outd, 0, pre, cn, 0, 0, fn, mb);
+   fn[6] = 't'; fn[7] = '\0';  /* switch fn to type name */
+
+   for (im=0; im < 2; im++)
+   {
+      arrnm[mati] = mats[im];
+      for (it=0; it < nt; it++)
+      {
+         ATL_mmcp_t *cb, *ucb;
+         int i;
+         const char ta = tas[it]; 
+
+         arrnm[transi] = ta;
+         cb = GetMMCopyFromMMNodes(MMCopyEncode(pre, dir, mats[im], ta), mb);
+         assert(cb);
+         ucb = AddUniqueCopyNode(NULL, cb);
+         arrnm[6] = '\0';
+         PrintMMCpProtosA(fp, arrnm, ucb, dir, alp);
+         KillAllCopyNodes(ucb);
+         PrintStrArrAtOff(fp, pre, arrnm, cb, GetOffset(&cb->next, cb),
+                          GetOffset(&cb->rout, cb), fn, ta, alp, 0);
+         KillAllCopyNodes(cb);
+      }
+   }
+   CloseGenHeader(fp);
+}
+
+void GenCpyC(FILE *fp, char pre, char *outd, char *cn, char dir, char *type, 
+             char alp, char bet, ATL_mmnode_t *mb)
+{
+   char *arrnm = (dir == 'T') ? "C2BLK" : "BLK2C";
+   ATL_mmcp_t *cb, *ucb;
+   int flag=0, i, j;
+
+   cb = GetMMCopyFromMMNodes(MMCopyEncode(pre, dir, 'c', 'n'), mb);
+   assert(cb);
+   #ifdef Debug
+      i = CountListEntries(cb, GetOffset(&cb->next, cb));
+      j = CountListEntries(mb, GetOffset(&mb->next, mb));
+      fprintf(stderr, "ncpy=%d, nmm=%d!\n", i, j);
+   #endif
+   ucb = AddUniqueCopyNode(NULL, cb);
+   PrintMMCpProtosC(fp, arrnm, ucb, dir, alp, bet);
+   KillAllCopyNodes(ucb);
+   PrintStrArrAtOff(fp, pre, arrnm, cb, GetOffset(&cb->next, cb),
+                    GetOffset(&cb->rout, cb), type, 0, alp, bet);
+   KillAllCopyNodes(cb);
+}
+
+void PrintDiv(FILE *fp, char *exp, int v)
+/* 
+ * Prints either exp/v or exp>>lg2(v), dep on v being power of 2 or not 
+ * caller must put parens where appropriate (if exp is not a simple variable
+ * name, it must have parens to produce the right answer!).
+ */
+{
+   int p;
+   assert(v > 0);  /* 0 cannot be supported, no need for neg now */
+   if (v == 1)
+      fprintf(fp, "%s", exp);
+   for (p=1; (1<<p) < v; p++);
+   if (v == (1<<p))
+      fprintf(fp, "%s>>%d", exp, p);
+   else
+      fprintf(fp, "%s/%d", exp, v);
+}
+void PrintCeil(FILE *fp, char *exp, int v)
+/* 
+ * Prints either ((exp+v-1)/v)*v or same things wt shifts if power of 2.
+ */
+{
+   int p;
+   assert(v > 0);  /* 0 cannot be supported, no need for neg now */
+   if (v == 1)
+      fprintf(fp, "%s", exp);
+   for (p=1; (1<<p) < v; p++);
+   if (v == (1<<p))
+      fprintf(fp, "((%s+%d)>>%d)", exp, v-1, p);
+   else
+      fprintf(fp, "((%s+%d)/%d)", exp, v-1, v);
+}
+void PrintCeilMul(FILE *fp, char *exp, int v)
+{
+   int p;
+   assert(v > 0);  /* 0 cannot be supported, no need for neg now */
+   if (v == 1)
+      fprintf(fp, "%s", exp);
+   for (p=1; (1<<p) < v; p++);
+   if (v == (1<<p))
+      fprintf(fp, "(((%s+%d)>>%d)<<%d)", exp, v-1, p, p);
+   else
+      fprintf(fp, "(((%s+%d)/%d)*%d)", exp, v-1, v, v);
+}
+
+void GenFullCpyC(char pre, char *outd, char dir, char *cn, ATL_mmnode_t *mb)
+{
+   ATL_mmnode_t *mp;
+   FILE *fp;
+   int ib, NEEDSZF=0;
+   char rt[16];
+   char bets[4] = {'0', '1', 'n', 'X'};
+
+/*
+ * Create atlas_<pre><cn>szC.h if necessary
+ */
+   for (mp=mb; mp; mp = mp->next)
+      if (FLAG_IS_SET(mp->flag, MMF_KVEC) && ib == -1 &&
+          (mp->mu*mp->nu) % mp->vlen != 0)
+         break;
+   if (mp)
+   {
+      ATL_mmcp_t *cb, *ucb, *cp;
+      int n;
+      NEEDSZF=1;
+      fp = OpenMMGenHeader(outd, 0, pre, cn, 0, 0, "szC", mb);
+      cb = GetMMCopyFromMMNodes(MMCopyEncode(pre, dir, 'c', 'n'), mb);
+      assert(cb);
+      ucb = AddUniqueCopyNode(NULL, cb);
+      KillAllCopyNodes(cb);
+/*
+ *    Generate needed funcs for size query
+ */
+      for (cp=ucb; cp; cp = cp->next)
+      {
+         const unsigned int mu=cp->mu, nu=cp->nu, kvec=cp->kvec, b = mu*nu;
+         const unsigned int B = (kvec > 1) ? ((b+kvec-1)/kvec)*kvec : 0;
+         fprintf(fp, "#define uint unsigned int\n");
+         if (b != B)
+         {
+            assert(!cp->ID);
+            fprintf(fp, "static uint ATL_szC_%dx%d(uint M, uint N, "
+                        "uint mu, uint nu, uint vlen)", mu, nu);
+            fprintf(fp, "\n{\n");
+            fprintf(fp, "   return(");
+            PrintCeilMul(fp, "M", mu);
+            fprintf(fp, "*");
+            PrintCeilMul(fp, "N", nu);
+            fprintf(fp, "*");
+            fprintf(fp, "%d);\n", B);
+            fprintf(fp, "}\n");
+         }
+         fprintf(fp, "typedef uint (*szC_t)(uint,uint,uint,uint,uint);\n");
+         fprintf(fp, "#undef uint\n");
+         for (n=0,cp=cb; cp; n++, cp = cp->next);
+         fprintf(fp, "static szC_t ATL_AMM_SZCW[%d] =\n{\n", n);
+         for (cp=cb,n=0; cp; cp = cp->next,n++)
+         {
+            const unsigned int mu=cp->mu, nu=cp->nu, kvec=cp->kvec, b = mu*nu;
+            const unsigned int B = (kvec > 1) ? ((b+kvec-1)/kvec)*kvec : 0;
+            fprintf(fp, "/* IDX=%d */ ", n);
+            if (b != B)
+               fprintf(fp, "ATL_szC_%dx%d", mu, nu);
+            else
+               fprintf(fp, "NULL"); 
+            if (cp->next)
+               fprintf(fp, ",\n");
+            else
+               fprintf(fp, "\n");
+         }
+      }
+      KillAllCopyNodes(cb);
+      CloseGenHeader(fp);
+   }
+#if 0
+#endif
+
+   if (dir == 'T')
+      strcpy(rt, "cmat2ablk");
+   else
+      strcpy (rt, "ablk2cmat");
+
+   fp = OpenMMGenHeader(outd, 0, pre, cn, 0, 0, rt, mb);
+   if(NEEDSZF)
+   {
+      fprintf(fp, "#ifndef NOSZC\n");
+      fprintf(fp, "   #include \"atlas_%c%sszC.h\"\n", pre, cn);
+      fprintf(fp, "#endif\n");
+   }
+   rt[9] = '_'; rt[10] = 't'; rt[11] = '\0';
+@skip   strcpy(rt, dir == 'T' ? "cmat2ablk_t" : "ablk2cmat_t");
+   for (ib=0; ib < 4; ib++)
+   {
+      int ia;
+      char alps[3] = {'1', 'n', 'X'};
+      const char bet = bets[ib];
+
+      for (ia=0; ia < 3; ia++)
+         GenCpyC(fp, pre, outd, cn, dir, rt, alps[ia], bet, mb);
+   }
+   CloseGenHeader(fp);
+}
+
+void GenAllCpyC(char pre, char *outd, char dir, ATL_mmnode_t *ub)
+{
+   if (ub)
+      GenFullCpyC(pre, outd, dir, unam, ub);
+}
+void GenAllCpyA(char pre, char *outd, char dir, ATL_mmnode_t *ub)
+// presently leaving dir='[F,T]' to caller
+{
+   int ia;
+   char alps[3] = {'1', 'n', 'X'};
+
+   for (ia=0; ia < 3; ia++)
+   {
+      if (ub)
+         GenCpyA(pre, outd, unam, dir, alps[ia], ub);
+   }
+}
+
+double PrintSum(FILE *fp, char *cn, ATL_mmnode_t *b, double mfGE)
+{
+   int inxt, max, i, kvec;
+   double mf;
+   ATL_mmnode_t *mp;
+
+   inxt = GetOffset(&b->next, b);
+   fprintf(fp, "#define ATL_%sAMM_NCASES %d\n", cn, CountListEntries(b, inxt));
+   mp = ATL_FindLastNode(b, inxt);
+   fprintf(fp, "#define ATL_%sAMM_LASTMB %d\n", cn, mp->mbB);
+   fprintf(fp, "#define ATL_%sAMM_LASTNB %d\n", cn, mp->nbB);
+   fprintf(fp, "#define ATL_%sAMM_LASTKB %d\n", cn, mp->kbB);
+   mf = mp->mflop[0];
+   fprintf(fp, "#define ATL_%sAMM_LASTMU %d\n", cn, mp->mu);
+   fprintf(fp, "#define ATL_%sAMM_LASTNU %d\n", cn, mp->nu);
+   fprintf(fp, "#define ATL_%sAMM_LASTKU %d\n", cn, mp->nu);
+   fprintf(fp, "#define ATL_%sAMM_LASTLCMMN %d\n\n", cn, Mylcm(mp->mu, mp->nu));
+   fprintf(fp, "#define ATL_%sAMM_LASTLCMU %d\n\n", cn,
+           Mylcm(Mylcm(mp->mu, mp->nu),mp->ku));
+   #if 0
+   fprintf(fp, "#define ATL_%sAMM_LASTMFLOP %e\n", cn, mf);
+   if (mfGE > 0.0)
+      fprintf(fp, "#define ATL_%sAMM_MFLOP_RATIO %e\n", cn, mf/mfGE);
+   #endif
+   for (kvec=0,mp=b; mp; mp = mp->next)
+      if (FLAG_IS_SET(mp->flag, MMF_KVEC))
+         kvec = Mmax(kvec, mp->vlen);
+   fprintf(fp, "#ifndef  ATL_%sAMM_MAXKVEC\n", cn);
+   fprintf(fp, "   #define ATL_%sAMM_MAXKVEC %d\n", cn, kvec);
+   fprintf(fp, "#endif\n");
+   fprintf(fp, "\n");
+   return(mf);
+}
+
+void GenSumH(char pre, char *outd, ATL_mmnode_t *ub)
+/*
+ * cn:[u%d]
+ * For [u%d] report: ncases, max[nb,mb,kb]
+ * -> for maxB, report: perf,time,ratio wt best user-case
+ */
+{
+   FILE *fp;
+   double mf;
+   int i;
+
+   fp = OpenMMGenHeader(outd, 0, pre, unam, 0, 0, "sum", ub);
+   mf = PrintSum(fp, "ub", ub, 0.0);
+   CloseGenHeader(fp);
+}
+
+void GenAllHeaders(char pre, char *outd, ATL_mmnode_t **lists)
+{
+   ATL_mmcp_t *cb;
+   char *nm="perf";
+   double mfMax;
+   int i, k, SKSAME;
+   char pr;
+
+/*
+ * Handle [perf,blk,flag,sum] which require only ordered lists
+ */
+   for (pr=pre,k=0; k < 2*NMMLISTS; k += NMMLISTS)
+   {
+      mfMax = GenPerfH(pr, outd, unam, 0.0, lists[k+IUSR], lists[k+IUSRK1]);
+
+      GenBlkH(pr, outd, unam, lists[k+IUSR]); 
+      pr = (pre == 'd') ? 'z' : 'c';
+   }
+   GenSumH(pre, outd, lists[IUSR]);
+   GenSumH(pr, outd, lists[IUSR+NMMLISTS]);
+/*
+ * Create lists of only the unique kernels for [ub] in real & cplx
+ * for use in prototyping.  We combine kern & K1 lists for each.
+ * We can now gen [kern].
+ */
+   for (pr=pre,k=0; k < 2; k++)
+   {
+      for (i=0; i < 1; i++)
+      {
+         ATL_mmnode_t *ulst;  /* unordered list of only unique kernels */
+         const int h = i+i+k*NMMLISTS, u=k+i;
+         ulst = AddUniqueMMKernCompList(NULL, lists[h]);
+         ulst = AddUniqueMMKernCompList(ulst, lists[h+1]);
+         GenKernH(pr, outd, unam, lists[h], lists[h+1], ulst);
+         KillAllMMNodes(ulst);  /* done with these! */
+      }
+      pr = (pre == 's') ? 'c' : 'z';
+   }
+/*
+ * [cmat2ablk_a[1,n,X]_b[0,1,n,X],ablk2cmat_a?_b?,am2cm_a[1,n,X]]
+ * -> have never genned, can we?: am2rm_a[1,n,X],
+ */
+   GenAllCpyA(pre, outd, 'T', lists[IUSR]);
+   GenAllCpyA(pre, outd, 'F', lists[IUSR]);
+   GenAllCpyA(pr, outd, 'T', lists[IUSR+NMMLISTS]);
+   //GenAllCpyA(pr, outd, 'F', lists[IUSR+NMMLISTS]); // for now
+
+   GenAllCpyC(pre, outd, 'F', lists[IUSR]);
+   GenAllCpyC(pre, outd, 'T', lists[IUSR]);
+   GenAllCpyC(pr, outd, 'F', lists[IUSR+NMMLISTS]);
+   //GenAllCpyC(pr, outd, 'T', lists[IUSR+NMMLISTS]); // for now
+}
+
+static void AddAlpBetSuf(char *rt, int rl, int ial, int ibe)
+/*
+ * Add _aXbX suffix to rt, which is presently of length rl
+ */
+{
+   rt[rl] = '_';
+   rt[rl+1] = 'a';
+   if (ial == -1)
+      rt[rl+2] = 'n';
+   else if (ial == 2)
+      rt[rl+2] = 'X';
+   else
+      rt[rl+2] = ial+48;
+   rt[rl+3] = 'b';
+   if (ibe == -1)
+      rt[rl+4] = 'n';
+   else if (ibe > 1)
+      rt[rl+4] = 'X';
+   else
+      rt[rl+4] = ibe+48;
+}
+
+void GenAllKerns(char pre, char *outd, ATL_mmnode_t *rb, 
+                 ATL_mmcp_t *cpA, ATL_mmcp_t *cpC)
+{
+   ATL_mmcp_t *last, *cp;
+   ATL_mmnode_t *mp;
+   char *sgen;
+   int i, len, dlen, mID, mU;
+   char pr=pre;
+/*
+ * join all copy routs into one list temporarily
+ */
+   last = FindLastCopyNode(cpA);
+   last->next = cpC;
+/*
+ * Get a string of max length for all system calls
+ */
+   mID=mU=len=i=0;
+   for (cp=(!i)?cpA:cpC; cp; cp = cp->next)
+   {
+      len = Mmax(len, cp->rtlen);
+      mID = Mmax(mID, cp->ID);
+      mU = Mmax(mU, cp->mu);
+      mU = Mmax(mU, cp->nu);
+      mU = Mmax(mU, cp->kvec);
+   }
+   dlen = strlen(outd);
+   len += dlen + 1;  /* outd */
+   len += 17;  /* " > /dev/null 2>&1" */
+   assert(mID == 0);  /* just until we support user copies */
+   len += 64 - 2*4;  /* C format string */
+   len += 4*NumDecDigits(mU); /* mu,nu,kvec */
+   len += 2;                  /* extra for syrk */
+   sgen = malloc(len+1);
+   assert(sgen);
+/*
+ * Generate all needed copy routines
+ */
+   printf("\nGENERATING MMCOPY FILES\n");
+   for (cp=cpA; cp; cp = cp->next)
+   {
+      int flag = cp->flag;
+      int k;
+      char pr;
+      pr = MMCopyGetPre(cp->flag);
+      printf("   -> %s\n", cp->rout);
+      if (flag & (1<<MMCP_CBLK))
+      {
+         if (flag & (1<<MMCP_SYRK))
+         {
+            k = sprintf(sgen, 
+"make genall_syblk2C pre=%c vec=NA vlen=%d mu=%d nu=%d cpvlen=1 rt=%s/%s.c",
+                        pr, cp->kvec ? cp->kvec:1, cp->mu, cp->nu, outd, cp->rout);
+         }
+         else if (flag & (1<<MMCP_CBLK))
+         {
+            k = sprintf(sgen, 
+      "make genall_%s pre=%c vec=NA vlen=%d mu=%d nu=%d cpvlen=1 rt=%s/%s.c",
+                        (flag&(1<<MMCP_TOBLK)) ? "C2blk":"blk2C", pr, 
+                        cp->kvec ? cp->kvec:1, cp->mu, cp->nu, outd, cp->rout);
+         }
+      }
+      else /* generate A/B copy */
+      {
+         char *targ;
+         if (flag & (1<<MMCP_REAL))
+            targ = (flag & (1<<MMCP_TOBLK)) ? "A2blk":"blk2A";
+         else
+            targ = (flag & (1<<MMCP_TOBLK)) ? "cA2blk":"cblk2A";
+         k = sprintf(sgen, 
+             "make genall_%s pre=%c kmaj=%d vlen=%d UR=%d cpvlen=1 rt=%s/%s.c",
+                     targ, pr, cp->kvec, cp->kvec ? cp->kvec:1, 
+                     cp->nu, outd, cp->rout);
+      }
+      assert(k < len);
+      k += sprintf(sgen+k, " > /dev/null 2>&1");
+      assert(k <= len);
+      if ((k=system(sgen)))
+      {
+         fprintf(stderr, "\n\ncpgenstr='%s' returns %d!\n\n", sgen, k);
+         exit(k);
+      }
+   }
+   printf("DONE GENERATING MMCOPY FILES\n");
+   last->next = NULL;  /* disconnect A/C lists */
+/*
+ * Generate/copy all required kernels.  This list has files with compile-time
+ * K repeated, but we'll check ID to avoid repeated copies of user-supplied, 
+ * and generated kernels need a new generation for each required KB.
+ */
+   printf("\nGENERATING AMM KERNS:\n");
+   for (mp=rb; mp; mp = mp->next)
+   {
+      const int id=mp->ID;
+      if (!id)
+      {
+         printf("   -> %s\n", mp->rout);
+         assert(mp->genstr);
+         if ( (i=system(mp->genstr)) )
+         {
+            fprintf(stderr, "GENSTR RETURNS %d:\n'%s'\n", i, mp->genstr);
+            exit(i);
+         }
+      }
+      else /* user-supplied kernel */
+      {
+         ATL_mmnode_t *p;
+         for (p=rb; p != mp && p->ID != id; p = p->next);
+         if (p == mp)  /* this is first mention of this ID */
+         {
+            printf("   %s -> %s\n", mp->genstr, mp->rout);
+            i = strlen(mp->genstr) + strlen(mp->rout) + dlen + 16;
+            if (i > len)
+            {
+               free(sgen);
+               sgen = malloc(i*sizeof(char));
+               assert(sgen);
+               len = i;
+            }
+            sprintf(sgen, "cp AMMCASES/%s %s/%s", mp->genstr, outd, mp->rout);
+            
+            if ( (i=system(sgen)) )
+            {
+               fprintf(stderr, "FAILED CP='%s'\n", sgen);
+               exit(i);
+            }
+         }
+         else /* they better have same filename! */
+         {
+            if (strcmp(mp->rout, p->rout))
+            {
+               printf("rout=(%s,%s)!\n", mp->rout, p->rout);
+               exit(1);
+            }
+         }
+      }
+   }
+   printf("DONE GENERATING AMM KERNS.\n");
+   free(sgen);
+}
+
+void GenMake(char pre, char *outd, ATL_mmnode_t *mb,
+             ATL_mmcp_t *cpA, ATL_mmcp_t *cpC)
+/*
+ * mb files have already been made at least compile-time unique (same source
+ * file might occur multiple times due to need to compile with -DKB)
+ */
+{
+   FILE *fp;
+   char *fn;
+   ATL_mmcp_t *cp;
+   ATL_mmnode_t *mp;
+   char *sals[3] = {"1", "N1", "X"};
+   char als[3] = {'1', 'n', 'X'};
+   char *sbes[4] = {"0", "1", "N1", "X"};
+   char bes[4] = {'0', '1', 'n', 'X'};  /* use 1st 3 for mmkerns */
+   char ctas[4] = {'N', 'T', 'C', 'H'};
+   char dcomp[8] = {'$', '(', 'D', 'M', 'C', ')', '\0'};
+   char dflags[12] = {'$','(','D','M','C','F','L','A','G','S',')','\0'};
+
+
+   fn = malloc(strlen(outd)+11);
+   assert(fn);
+   sprintf(fn, "%s/%cMake_amm", outd, pre);
+   fp = fopen(fn, "w");
+   assert(fp);
+   free(fn);
+   fprintf(fp, "include ../Make.inc\n");
+   fprintf(fp, "CDEFS2=$(CDEFS)\n\n");
+/*
+ * Spew out kernels to be compiled
+ */
+   fprintf(fp, "objs =");
+   for (mp=mb; mp; mp = mp->next)
+   {
+      int ib;
+      for (ib=0; ib < 3; ib++)
+         fprintf(fp, " \\\n       %s_b%c.o", mp->auth, bes[ib]);
+   }
+   for (cp=cpC; cp; cp = cp->next)  /* C copy routs */
+   {
+      int ib;
+      for (ib=0; ib < 4; ib++)
+      {
+         int ia;
+         for (ia=0; ia < 3; ia++)
+            fprintf(fp, " \\\n       %s_a%cb%c.o", cp->rout, als[ia], bes[ib]);
+      }
+   }
+
+   for (cp=cpA; cp; cp = cp->next)  /* A/B copy routs */
+   {
+      const int NTA = (cp->flag & (1<<MMCP_REAL)) ? 2:4;
+      int it;
+      for (it=0; it < NTA; it++)
+      {
+         int ia;
+         for (ia=0; ia < 3; ia++)
+            fprintf(fp, " \\\n       %s_%ca%c.o", cp->rout, ctas[it], als[ia]);
+      }
+   }
+   fprintf(fp, "\n");
+/*
+ * library make targets
+ */
+   fprintf(fp, "\n\nlib : %clib.grd\nall : %clib.grd\n%clib : %clib.grd\n",
+           pre, pre, pre, pre);
+   fprintf(fp, "%clib.grd : $(objs)\n", pre);
+   fprintf(fp, "\t$(ARCHIVER) $(ARFLAGS) $(ATLASlib) $(objs)\n");
+   fprintf(fp, "\t $(RANLIB) $(ATLASlib)\n");
+   fprintf(fp, "\t touch %clib.grd\n", pre);
+   fprintf(fp, "clean : %cclean\n", pre);
+   fprintf(fp, "%cclean:\n\t- rm -f $(objs)\n", pre);
+   fprintf(fp, "killall : %ckillall\n", pre);
+   fprintf(fp, "%ckillall : %cclean\n", pre, pre);
+   fprintf(fp, "\t- $(ARCHIVER) d $(ATLASlib) $(objs)\n");
+   fprintf(fp, "\t $(RANLIB) $(ATLASlib)\n");
+   fprintf(fp, "\t- rm -f ATL_%c*.[S,c]\n\n", pre);
+/*
+ * Make targets for amm kerns
+ */
+   fprintf(fp, "#\n#  AMM kernel rules\n#\n");
+   fn = (pre == 'd' || pre == 'z') ?  "-DDREAL=1" : "-DSREAL";
+   for (mp=mb; mp; mp = mp->next)
+   {
+      int ib;
+      char *comp, *flgs;
+
+      comp = GetMMKernComp(mp, dcomp, dflags, &flgs);
+      for (ib=0; ib < 3; ib++)
+      {
+         char *sp=" ";
+         fprintf(fp, "%s_b%c.o : %s\n", mp->auth, bes[ib], mp->rout);
+         fprintf(fp, "\t%s $(CDEFS2) %s -DBETA%s=1 \\\n", comp, fn, sbes[ib]);
+         if (!FLAG_IS_SET(mp->flag, MMF_KRUNTIME))
+            fprintf(fp, "        -DMB=%d -DNB=%d -DKB=%d", 
+                    mp->mbB, mp->nbB, mp->kbB);
+         else
+            sp = "        ";
+   @whiledef mtx C B A
+         if (FLAG_IS_SET(mp->flag, MMF_MV@(mtx)))
+         {
+            fprintf(fp, "%s-DATL_MOVE@(mtx)", sp);
+            sp = " ";
+         }
+   @endwhile
+         fprintf(fp, " \\\n        %s \\\n", flgs);
+         fprintf(fp, 
+                 "        -DATL_USERMM=%s_b%c \\\n        -c -o %s_b%c.o \\\n",
+                 mp->auth, bes[ib], mp->auth, bes[ib]);
+         fprintf(fp, "        %s\n", mp->rout);
+      }
+   }
+/*
+ * Make targets for C copy routines
+ */
+   fprintf(fp, "#\n#  C copy rules\n#\n");
+   dflags[3] = dcomp[3] = 'K';
+   for (cp=cpC; cp; cp = cp->next)  /* C copy routs */
+   {
+      char *styp;
+      int ib;
+      char pr;
+
+      styp = MMCopyGetCompType(cp->flag);
+      for (ib=0; ib < 4; ib++)
+      {
+         int ia;
+         for (ia=0; ia < 3; ia++)
+         {
+            fprintf(fp, "%s_a%cb%c.o : %s.c\n", cp->rout, als[ia], bes[ib], 
+                    cp->rout);
+            fprintf(fp, "\t%s %s -c $(CDEFS) -D%s=1 -DBETA%s=1 -DALPHA%s=1",
+                    dcomp, dflags, styp, sbes[ib], sals[ia]);
+            fprintf(fp, 
+            " \\\n           -DATL_USERCPMM=%s_a%c_b%c -DATL_MU=%d -DATL_NU=%d",
+                    cp->rout, als[ia], bes[ib], cp->mu, cp->nu);
+            fprintf(fp, " \\\n           -o %s_a%cb%c.o %s.c\n", 
+                    cp->rout, als[ia], bes[ib], cp->rout);
+         }
+      }
+   }
+/*
+ * Make targets for A/B copy routines
+ */
+   fprintf(fp, "#\n#  A/B copy rules\n#\n");
+   for (cp=cpA; cp; cp = cp->next) 
+   {
+      char *styp, *cnj[2] = {"", "-DConj_=1"};
+      const int flag = cp->flag;
+      const int NC = (flag&(1<<MMCP_REAL)) ? 1 : 2;
+      int ic;
+      char pr;
+      styp = MMCopyGetCompType(cp->flag);
+      for (ic=0; ic < NC; ic++)
+      {
+         int it;
+         for (it=0; it < 2; it++)
+         {
+            int ia;
+            const int itc = ic*NC+it;
+            for (ia=0; ia < 3; ia++)
+            {
+               fprintf(fp, "%s_%ca%c.o : %s.c\n", cp->rout, ctas[itc], 
+                       als[ia], cp->rout);
+               fprintf(fp, "\t%s %s -c $(CDEFS) -D%s=1 -DALPHA%s=1",
+                       dcomp, dflags, styp, sals[ia]);
+               fprintf(fp, " \\\n           -DATL_NU=%d -DTRANS%c_=1 %s", 
+                       cp->nu, ctas[it],  cnj[ic]);
+               fprintf(fp, " \\\n           -DATL_USERCPMM=%s_%ca%c", cp->rout, 
+                       ctas[itc], als[ia]);
+               fprintf(fp, " \\\n           -o %s_%ca%c.o %s.c\n", 
+                       cp->rout, ctas[itc], als[ia], cp->rout);
+            }
+         }
+      }
+   }
+   fclose(fp);
+}
+
+void GenAllFiles(char pre, char *outd, ATL_mmnode_t **lists)
+{
+   FILE *fp;
+   int i, RCSAME;
+   ATL_mmnode_t *rb=NULL, *ib=NULL, *mp;
+   ATL_mmcp_t *cpA=NULL, *cpC=NULL, *ncp;
+   const char cpr = (pre == 'd') ? 'z' : 'c';
+/*
+ * First, generate performance files, which require routs separated by
+ * various lists
+ */
+   printf("\nGENERATING HEADER FILES\n");
+   GenAllHeaders(pre, outd, lists);
+   printf("DONE HEADER GENERATION\n");
+
+/*
+ * Generating kernels & Makefile do not care which list kernels came from,
+ * or their order, so combine them all into one list for each data type 
+ * (2 lists total: real,complex), and remove any redundancies.
+ * NOTE2: I think we should generate copy routs at this time and then
+ *        can pass info to GenAllKerns & GenMake.
+ */
+   for (i=0; i < NMMLISTS; i++)
+   {
+      rb = AddUniqueMMKernCompList(rb, lists[i]);
+      KillAllMMNodes(lists[i]);
+      ib = AddUniqueMMKernCompList(ib, lists[NMMLISTS+i]);
+      KillAllMMNodes(lists[NMMLISTS+i]);
+   }
+/*
+ * Now create lists of copy routines for both real & complex
+ */
+   GetMMAllUniqueCopyFromMMNodes(pre, 'F', 'T', rb, &cpA, &cpC);
+   GetMMAllUniqueCopyFromMMNodes(pre, 'T', 'F', rb, &cpA, &cpC);
+   GetMMAllUniqueCopyFromMMNodes(cpr, 'F', 'T', ib, &cpA, &cpC);
+   //GetMMAllUniqueCopyFromMMNodes(cpr, 'T', 'F', ib, &cpA, &cpC); // for now
+/*
+ * Now, kerns are compiled the same for real and complex, so reduce real
+ * and complex to one unique list
+ */
+   rb = AddUniqueMMKernCompList(rb, ib);
+   KillAllMMNodes(ib);
+   GenAllKerns(pre, outd, rb, cpA, cpC);
+   GenMake(pre, outd, rb, cpA, cpC);
+   KillAllMMNodes(rb);
+   KillAllCopyNodes(cpA);
+   KillAllCopyNodes(cpC);
+}
+
+int main(int nargs, char **args)
+{
+   char *outd;
+   ATL_mmnode_t *lists[2*NMMLISTS];
+   int i;
+   char pre, cpr;
+
+   outd = GetFlags(nargs, args, &pre, lists);
+   cpr = (pre == 'd') ? 'z' : 'c';
+/*
+ * Prep file for generation.  Free present values, and replace with:
+ * ->auth  : kernel name without _b[1,n,0] suffix
+ * ->genstr: for ID=0: genstr, else user kernel name (came in ->rout)
+ * ->rout  : correct present filename
+ */
+   for (i=0; i < 2*NMMLISTS; i++)
+   {
+      PrepMMForGen(pre, outd, "amm", lists[i]);
+   }
+
+   GenAllFiles(pre, outd, lists);
+
+   free(outd);
+   return(0);
+}
 @ROUT ammgen
 @extract -b @(topd)/cw.inc lang=C -def cwdate 2015 
 #include "atlas_misc.h"
@@ -31697,7 +32781,7 @@ char *GetFlags(int nargs, char **args, char *PRE, int *C, int *MVS,
 
             b0 = atoi(args[i+1]);
             bn = atoi(args[i+2]);
-            incB = atoi(args[i+4]);
+            incB = atoi(args[i+3]);
             n = 1 + (bn-b0)/incB;
             mbs = malloc(n*sizeof(int));
             nbs = malloc(n*sizeof(int));
@@ -31749,12 +32833,13 @@ char *GetFlags(int nargs, char **args, char *PRE, int *C, int *MVS,
          }
          if (++i >= nargs)
             PrintUsage(args[0], i-1, NULL);
-         *NN = N = atoi(args[i]);
+         N = atoi(args[i]);
          if (N < 0)
          {
             ALL = (N == -2) ? 32 : -1;  /* -2: don't force MB */
             N = 36;
          }
+         *NN = N;
          assert(N > 0);
          nbs = malloc(N*sizeof(int));
          assert(nbs);

--- a/AtlasBase/Clint/atlas-make.base
+++ b/AtlasBase/Clint/atlas-make.base
@@ -2329,6 +2329,7 @@ kmaj=0
 mvA=1
 mvB=1
 mvC=0
+CFLUSH="-1"
 outF=
 bcast=1
 vlen=1
@@ -2505,6 +2506,8 @@ xprefparse : $(mySRCdir)/prefparse.c $(parsedeps)
 	$(XCC) $(XCCFLAGS) -o $@ $(mySRCdir)/prefparse.c
 xammgen :  $(mySRCdir)/ammgen.c $(parsedeps) $(INCSdir)/atlas_mmgen.h
 	$(XCC) $(XCCFLAGS) -o $@ $(mySRCdir)/ammgen.c -lm
+xuammgen :  $(mySRCdir)/uammgen.c $(parsedeps) $(INCSdir)/atlas_mmgen.h
+	$(XCC) $(XCCFLAGS) -o $@ $(mySRCdir)/uammgen.c -lm
 xemit_amm : $(mySRCdir)/emit_amm.c $(parsedeps)
 	$(XCC) $(XCCFLAGS) -o $@ $(mySRCdir)/emit_amm.c -lm
 xemit_uamm : $(mySRCdir)/emit_uamm.c $(parsedeps)
@@ -2695,6 +2698,7 @@ res/@(pre)@(rt) : xgmmsearch
 	make @(pre)install_uamm_noclean ID=0
 	cp res/@(pre)uAMMFRC.sum $(BLDdir)/src/threads/lapack/amm/sumd/.
 
+@beginskip
 @(pre)install_uamm: res/@(pre)uAMMFRC.sum res/@(pre)UMMKCLEAN.sum \
               res/@(pre)UMMKCLEANBYNB.sum xemit_uamm
 @skip	- cd $(AMMdir)/UKERNEL ; $(PMAKE) -f @(pre)Make_amm @(pre)killall
@@ -2708,6 +2712,45 @@ res/@(pre)@(rt) : xgmmsearch
             -i res/@(pre)uAMMFRC.sum 
 	mv $(AMMdir)/UKERNEL/*.h $(INCAdir)/.
 	cd $(AMMdir)/UKERNEL ; $(PMAKE) -f @(pre)Make_amm
+@endskip
+@multidef pt c r
+   @ptyp s
+      @multidef pp c s
+   @ptyp d
+      @multidef pp z d
+   @ptyp s d
+@declare "@(pre)install_uamm_noclean: " y n 
+   xuammgen
+   @whiledef pp
+         res/@(pp)uAMMRES.sum
+   @endwhile
+@enddeclare
+	- cd $(AMMdir)/UKERNEL ; $(PMAKE) -f @(pre)Make_amm @(pre)killall
+	./xuammgen -p @(pre) -d $(AMMdir)/UKERNEL -I $(ID)
+	mv $(AMMdir)/UKERNEL/*.h $(INCAdir)/.
+	cd $(AMMdir)/UKERNEL ; $(PMAKE) -f @(pre)Make_amm
+   @ptyp s
+      @multidef pp c s
+   @ptyp d
+      @multidef pp z d
+@declare "@(pre)install_uamm: " y n 
+   xuammgen
+   @whiledef pp
+      @whiledef rt uAMMRES uAMMKCLEAN
+         res/@(pp)@(rt).sum
+      @endwhile
+   @endwhile
+@enddeclare
+	- cd $(AMMdir)/UKERNEL ; $(PMAKE) -f @(pre)Make_amm @(pre)killall
+	./xuammgen -p @(pre) -d $(AMMdir)/UKERNEL -I $(ID)
+	mv $(AMMdir)/UKERNEL/*.h $(INCAdir)/.
+	cd $(AMMdir)/UKERNEL ; $(PMAKE) -f @(pre)Make_amm
+   @ptyp z c
+@(pre)install_uamm_noclean: 
+	$(MAKE) @(upr)install_uamm_noclean
+@(pre)install_uamm: 
+	$(MAKE) @(upr)install_uamm
+   @ptyp !
 @(pre)install_ammm: @(pre)install_amm
    @ptyp s
       @multidef pp c s
@@ -2879,6 +2922,9 @@ x@(pre)nbtune : @(pre)nbtune.o @(pre)ammlib
 @(pre)trstime_pt.o : $(mySRCdir)/mmtime_pt.c
 	$(KC) $(KCFLAGS) -c -DTIME_TRMVK=1 -D@(typ)=1 \
               -o @(pre)trstime_pt.o $(mySRCdir)/mmtime_pt.c
+@(pre)trstime_pt3f.o : $(mySRCdir)/mmtime_pt3f.c
+	$(KC) $(KCFLAGS) -c -DTIME_TRMVK=1 -D@(typ)=1 $(TDEFS) \
+              -o @(pre)trstime_pt3f.o $(mySRCdir)/mmtime_pt3f.c
 @ptyp z c
    @define trsm @ATL_@(pre)ctrsmKL_rk2.o@
 @ptyp d s
@@ -2894,6 +2940,26 @@ x@(pre)trstime_pt : @(pre)trstime_pt.o $(L3Bdir)/kernel/@(trsm)
 	$(ATLRUN) $(MMTdir) x@(pre)trstime_pt -p $(NPROC) $(TIDLIST) \
            -m $(mb) -n $(nb) -k $(mb) -um 1 -un 1 -uk 1 $(FMFS) \
            -Ma 0 -Mb 0 -Mc 1 $(outF)
+x@(pre)trstime_pt3f : @(pre)trstime_pt3f.o $(L3Bdir)/kernel/@(trsm)
+	$(CLINKER) $(CLINKFLAGS) -o $@ @(pre)trstime_pt3f.o \
+         $(SYSdir)/time.o $(L3Bdir)/kernel/@(trsm) $(ATLASlib) $(LIBS)
+
+@ptyp d s
+bn = _b${betan}
+@(pre)ammtime_pt3f${bn}.o : $(mySRCdir)/mmtime_pt3f.c
+	$(KC) $(KCFLAGS) -c -DBETA${betan}=1 -D@(typ)=1 -DTIME_GEMMK=1 \
+              -o @(pre)ammtime_pt3f${bn}.o $(mySRCdir)/mmtime_pt3f.c
+x@(pre)ammtime_pt3f : $(SYSdir)/time.o force_build
+	rm -f @(pre)mm.c
+	$(MAKE) @(pre)ammtime_pt3f${bn}.o
+	@(MCC) @(MMFLAGS) -DBETA$(betan)=1 -DMB=$(mb) -DNB=$(nb) \
+	    -DKB=$(kb) -D@(typ)=1 $(kmoves) -o @(pre)ammmKT.o -c $(mmrout)
+	$(CLINKER) $(CLINKFLAGS) -o x@(pre)ammtime_pt3f \
+	    @(pre)ammtime_pt3f${bn}.o @(pre)ammmKT.o $(SYSdir)/time.o $(LIBS)
+	$(ATLRUN) $(MMTdir) x@(pre)ammtime_pt3f -p $(NPROC) $(TIDLIST) \
+           -m $(mb) -n $(nb) -k $(kb) -um $(mu) -un $(nu) -uk $(ku) $(FMFS) \
+           -V $(vlen) -Ma $(mvA) -Mb $(mvB) -Mc $(mvC) -F $(CFLUSH) $(outF)
+@ptyp !
 
 @skip @(pre)txover.o : $(mySRCdir)/txover.c
 @skip 	$(KC) $(KCFLAGS) -c -D@(typ) -o @(pre)txover.o $(mySRCdir)/txover.c
@@ -6045,7 +6111,7 @@ mySRCdir = $(SRCdir)/src/blas/level3/kernel
       @PTYP D S
 @skip         ATL_@(pre)trsmK_LLNU_a1.o
          ATL_@(pre)trsmKL_rk4.o ATL_@(pre)trsmKR_rk4.o ATL_@(pre)trsmKL_amm.o
-         ATL_@(pre)trsmK_L2blk.o
+         ATL_@(pre)trsmK_L2blk.o ATL_@(pre)trsmKLU_rk4.o
          @whiledef a X 1
             ATL_@(pre)sycopyU_a@(a).o ATL_@(pre)sycopyL_a@(a).o
             ATL_@(pre)trcopyL2U_N_a@(a).o ATL_@(pre)trcopyL2L_N_a@(a).o
@@ -6204,6 +6270,8 @@ ATL_@(pre)trsmKL_amm.o : $(mySRCdir)/ATL_trsmKL_amm.c
 	$(@up@(pre)KC) -o $@ -c $(@(pre)KCFLAGS) -D@(typ) -DLeft_ $(mySRCdir)/ATL_trsmKL_amm.c
 ATL_@(pre)trsmKL_rk4.o : $(mySRCdir)/ATL_trsmKL_rk4.c
 	$(@up@(pre)KC) -o $@ -c $(@(pre)KCFLAGS) -D@(typ) -DLeft_ $(mySRCdir)/ATL_trsmKL_rk4.c
+ATL_@(pre)trsmKLU_rk4.o : $(mySRCdir)/ATL_trsmKL_rk4.c
+	$(@up@(pre)KC) -o $@ -c $(@(pre)KCFLAGS) -D@(typ) -DLeft_ -DATL_KERN_L4U $(mySRCdir)/ATL_trsmKL_rk4.c
       @whiledef al 1 X
          @whiledef rout sycopyL sycopyU
 ATL_@(pre)@(rout)_a@(al).o : $(mySRCdir)/ATL_@(rout).c $(dep)

--- a/AtlasBase/Clint/atlas-mmkg.base
+++ b/AtlasBase/Clint/atlas-mmkg.base
@@ -1781,7 +1781,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @ROUT C2blk 
             { 
                const register @(typ) rc=C@(h)[@(ir)], ic=C@(h)[@(ii)];
-               const register @(typ) rr=pr[@(k)], ir=pi[@(k)];
+               register @(typ) rr=pr[@(k)], ir=pi[@(k)];
                rr += rc * ra;
                ir += ic * ra;
                rr -= ic * ia;
@@ -2028,7 +2028,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @ROUT C2blk 
             { 
                const register @(typ) rc=C@(j)[@(ir)], ic=C@(j)[@(ii)];
-               const register @(typ) rr=pr[@(k)], ir=pi[@(k)];
+               register @(typ) rr=pr[@(k)], ir=pi[@(k)];
                rr += rc * ra;
                ir += ic * ra;
                rr -= ic * ia;
@@ -2053,7 +2053,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @ROUT C2blk 
             { 
                const register @(typ) rc=C@(j)[@(ir)], ic=C@(j)[@(ii)];
-               const register @(typ) rr = -pr[@(k)], ir = -pi[@(k)];
+               register @(typ) rr = -pr[@(k)], ir = -pi[@(k)];
                rr += rc * ra;
                ir += ic * ra;
                rr -= ic * ia;
@@ -2126,9 +2126,9 @@ void @(rtnm)
    @ROUT C2blk
    const @(typ) *C,     /* matrix to be copied to access-major format */
    const size_t ldc,    /* stride between row elements */
-   const @(typ) beta,   /* scalar for C */
+   const @(typ) *beta,  /* scalar for C */
    @(typ) *rC,          /* real block stored in @(mu)x@(nu)-major order */
-   @(typ) *iC,          /* imag block stored in @(mu)x@(nu)-major order */
+   @(typ) *iC           /* imag block stored in @(mu)x@(nu)-major order */
    @ROUT C2blk blk2C
 )
 @endiif

--- a/AtlasBase/Clint/atlas-parse.base
+++ b/AtlasBase/Clint/atlas-parse.base
@@ -3996,6 +3996,234 @@ void MMFixGenK(char pre, ATL_mmnode_t *mb, int K)
 }
 @iexp ip @(ip) 1 +
 /* procedure @(ip) */
+double TimeMMKernel3F
+(
+   int verb,                    /* 0: no output, 1 min output, 2: full output */
+   int flag,                   /* 1: ignore any prior output file */
+   ATL_mmnode_t *mmp,           /* ptr to mmkern struct */
+   char pre,                    /* type/prec prefix: z,c,d,s */
+   int mb, int nb, int kb,      /* dimensions to time */
+   int beta,                    /* beta to time */
+   int mflop,                   /* >0: force mflop MFLOPs in each time interv */
+   int cflush,                  /* >=0: size of cache flush, else ignored */
+   int aFL,                     /* >=0: size of cache flush, else ignored */
+   int bFL,                     /* >=0: size of cache flush, else ignored */
+   int cFL                      /* >=0: size of cache flush, else ignored */
+)
+/*
+ * flag - take actions the following actions if bit location is set:
+ *    0 : ignore any prior output file on output
+ *    1 : time in serial rather than parallel
+ */
+{
+   char fnam[128], ln[4096];  /* security from 1991 */
+   const char *LO = FLAG_IS_SET(mmp->flag, MMF_AOUTER) ? "IJK": "JIK";
+   const int vl=mmp->vlen;
+   const int ku=mmp->ku;
+   const int KB = (!FLAG_IS_SET(mmp->flag,MMF_KVEC)) ? kb : ((kb+vl-1)/vl)*vl;
+   const int FORCETIME = flag&1, SERIAL=flag&2;
+   int KU=mmp->ku;
+   int DOTIME=1;
+   int MV=3;  /* bit pattern on move CBA (C=4, B=2, A=1) */
+   char *be, *gs0=mmp->genstr;
+   int i, j;
+   char ch;
+   double *dp;
+   MV = ((mmp->flag) >> MMF_MVA)&7;
+/*
+ * If it's a emit_mm generated file with a missing or bad genstring, make it
+ */
+
+   if (FLAG_IS_SET(mmp->flag, MMF_KUISKB))
+      KU = KB;
+   else if (ku > KB)
+      KU = KB;
+   if (mmp->ID == 0 && (KB != mmp->kbB || KU != mmp->ku || !mmp->genstr))
+   {
+      int kb0=mmp->kbB, ku0=mmp->ku;
+      mmp->kbB = KB;
+      mmp->ku = KU;
+      mmp->genstr = MMGetGenString(pre, mmp);
+      mmp->kbB = kb0;
+      mmp->ku = ku0;
+   }
+/*
+ * If the file is generated, call generator to create it
+ */
+   if (mmp->genstr)
+      assert(!MMDoGenString(verb, mmp->genstr));
+   else if (verb > 2)
+      printf("NO genstr\n");
+/*
+ * Figure out the name of the output file
+ */
+   if (FORCETIME)
+      strcpy(fnam, "res/tmpout.ktim");
+/*
+ * PREammID_MBxNBxKB_MUxNUxKU_FLAG_v[M,K]VLENbBETA_CFLUSH
+ */
+   else
+   {
+      if (mmp->vlen < 2)
+         ch = 'S';
+      else
+         ch = (FLAG_IS_SET(mmp->flag,MMF_KVEC)) ? 'K' : 'M';
+
+      sprintf(fnam,
+      "res/%cammm%d_%dx%dx%d_%dx%dx%d_%x_v%c%db%d_pf%xx%d_%d.ktim",
+              pre, mmp->ID, mb, nb, KB, mmp->mu, mmp->nu, KU,
+              mmp->flag, ch, mmp->vlen, beta, mmp->pref, mmp->pfLS, cflush);
+      if (mmp->blask == 1)
+      {
+         fnam[5] = 's';
+         fnam[6] = 'y';
+         fnam[7] = 'r';
+         fnam[8] = 'k';
+      }
+      else if (mmp->blask == 2)
+      {
+         fnam[5] = 's';
+         fnam[6] = 'y';
+         fnam[7] = 'm';
+         fnam[8] = 'm';
+      }
+      else if (mmp->blask == 3)
+      {
+         fnam[5] = 't';
+         fnam[6] = 'r';
+         fnam[7] = 'm';
+         fnam[8] = 'm';
+      }
+   }
+/*
+ * If we actually need to do timing, must also construct timer call
+ */
+   if (!FORCETIME)
+      DOTIME = !FileExists(fnam);
+   #define RESACT 2   /* want average frm ReadResultsFile for parallel */
+   if (DOTIME)
+   {
+      char *nm="amm";
+      if (mmp->blask == 1)
+         nm = "syk";
+      else if (mmp->blask == 2)
+         nm = "sym";
+      else if (mmp->blask == 3)
+         nm = "trm";
+      i = sprintf(ln, "make x%c%stime_pt3f mb=%d nb=%d kb=%d",
+                  pre, nm, mb, nb, KB);
+      if (mflop)
+         i += sprintf(ln+i, " FMFS=\"-Rf %d\"", mflop);
+      if (SERIAL)
+         i += sprintf(ln+i, " NPROC=1");
+      if (mmp->genstr)
+         i += sprintf(ln+i, " mmrout=%s", mmp->rout);
+      else
+         i += sprintf(ln+i, " mmrout=AMMCASES/%s", mmp->rout);
+      i += sprintf(ln+i, " mu=%d nu=%d ku=%d", mmp->mu, mmp->nu, KU);
+    if (mmp->vlen)
+       i += sprintf(ln+i, " vlen=%d", mmp->vlen);
+    if (mmp->szExtra)
+       i += sprintf(ln+i, " szExtra=%d", mmp->szExtra);
+    if (mmp->szC)
+       i += sprintf(ln+i, " szC=%d", mmp->szC);
+    if (mmp->szB)
+       i += sprintf(ln+i, " szB=%d", mmp->szB);
+    if (mmp->szA)
+       i += sprintf(ln+i, " szA=%d", mmp->szA);
+      i += sprintf(ln+i, " mvA=%d mvB=%d mvC=%d", ((mmp->flag >> MMF_MVA)&1),
+                   ((mmp->flag >> MMF_MVB)&1), ((mmp->flag >> MMF_MVC)&1));
+      i += sprintf(ln+i, " kmoves=\"");
+      if (FLAG_IS_SET(mmp->flag, MMF_MVA))
+         i += sprintf(ln+i, " -DATL_MOVEA");
+      if (FLAG_IS_SET(mmp->flag, MMF_MVB))
+         i += sprintf(ln+i, " -DATL_MOVEB");
+      if (FLAG_IS_SET(mmp->flag, MMF_MVC))
+      i += sprintf(ln+i, " -DATL_MOVEC");
+      i += sprintf(ln+i, "\"");
+      //if (cflush > 0 || aFL > 0 || bFL > 0 || cFL > 0)
+      {
+         if (cflush > 0)
+               i+= sprintf(ln+i, " CFLUSH=\"%d ", cflush);
+            else
+               i+= sprintf(ln+i, " CFLUSH=\"%d", -1);
+            if (aFL > 0)
+               i+= sprintf(ln+i, " -Fa %d ", aFL);
+            if (bFL > 0)
+               i+= sprintf(ln+i, " -Fb %d ", bFL);
+            if (cFL > 0)
+               i+= sprintf(ln+i, " -Fc %d ", cFL);
+            i+= sprintf(ln+i, " \"");
+      }
+      if (mmp->pref)
+      {
+         if (mmp->pfLS)
+            i += sprintf(ln+i, " pf=%d pfLS=%d", mmp->pref, mmp->pfLS);
+         else
+            i += sprintf(ln+i, " pf=%d", mmp->pref);
+      }
+      if (beta == 1 || beta == 0)
+         i += sprintf(ln+i, " beta=%d", beta);
+      else
+         i += sprintf(ln+i, " beta=-1 betan=\"N1\"");
+      ch = (pre == 'c' || pre == 's') ? 'S' : 'D';
+      if (mmp->comp)
+         i += sprintf(ln+i, " %cMC=\"%s\"", ch, mmp->comp);
+      if (mmp->cflags)
+         i += sprintf(ln+i, " %cMCFLAGS=\"%s\"", ch, mmp->cflags);
+      i += sprintf(ln+i, " outF=\"-f %s\"", fnam);
+   }
+   if (FORCETIME || !FileExists(fnam))
+   {
+      if (verb < 3)
+         i += sprintf(ln+i, " > /dev/null 2>&1\n");
+      else
+         i += sprintf(ln+i, "\n");
+      if (verb > 1)
+         fprintf(stdout, "SYSTEM: %s", ln);
+      if (i=system(ln))
+      {
+         fprintf(stderr, "ERROR %d IN COMMAND: %s", i, ln);
+         fprintf(stderr, "   PROPOSED FILENAME: %s\n", fnam);
+         if (mmp->genstr)
+            fprintf(stderr, "   GENSTR='%s'\n", mmp->genstr);
+         sprintf(ln, "rm -f %s\n", fnam);
+         assert(!system(ln));
+         exit(-1);
+      }
+   }
+   if (mmp->genstr != gs0)  /* put genstr back to original value */
+   {
+      free(mmp->genstr);
+      mmp->genstr = gs0;
+   }
+   dp = ReadResultsFile(RESACT, 0, fnam);
+   if (!dp)
+   {
+      fprintf(stderr, "\nEmpty file '%s'!\n", fnam);
+      fprintf(stderr, "From command: '%s'\n", ln);
+      fprintf(stderr, "DOTIME=%d, genstr='%s'\n", DOTIME,
+              (mmp->genstr) ? mmp->genstr : "");
+      exit(-1);
+   }
+   if (mmp->genstr && DOTIME)
+   {
+      sprintf(ln, "rm %s\n", mmp->rout);
+      i = system(ln);  /* return value unused, just to shut gcc up */
+   }
+   if (kb != KB)
+   {
+      double mf;
+      mf = *((double*)ReadResultsFile(RESACT, 0, fnam));
+      mf = (mf / KB)*kb;
+      return(mf);
+   }
+   return(*((double*)ReadResultsFile(RESACT, 0, fnam)));
+   #undef RESACT
+}  /* end TimeMMKernel3F */
+
+@iexp ip @(ip) 1 +
+/* procedure @(ip) */
 double TimeMMKernel
 (
    int verb,                    /* 0: no output, 1 min output, 2: full output */

--- a/AtlasBase/Clint/atlas-trsm.base
+++ b/AtlasBase/Clint/atlas-trsm.base
@@ -2686,6 +2686,38 @@ ATL_SINLINE void ATL_rk4(ATL_CINT M, const TYPE *A, ATL_CINT lda,
 
 #if NRHS == 3
 /*
+ * Solve 4x4 L with 3 RHS symbolically for unit diagonal
+ * Answer is output into rBxx regs, which are live on input and output
+ */
+#define  ATL_trsmL4U(L_, ldl_, r_, ldr_) \
+{ \
+   const RTYPE L10=L_[1], L20=L_[2], L30=L_[3]; \
+   const RTYPE L21=L_[ldl_+2], L31=a[ldl_+3]; \
+   const RTYPE L32=L_[2*(ldl_)+3]; \
+/* \
+ * x1 = (b1 - L10 * x0) \
+ */ \
+   rB10 = (rB10 - L10*rB00);  \
+   rB11 = (rB11 - L10*rB01); \
+   rB12 = (rB12 - L10*rB02); \
+   ATL_pfl1W(r_ + ((ldr_)<<2)); \
+/* \
+ * x2 = (b2 - L20*x0 - L21*x1) \
+ */ \
+   rB20 = (rB20 - L20*rB00 - L21*rB10); \
+   rB21 = (rB21 - L20*rB01 - L21*rB11); \
+   rB22 = (rB22 - L20*rB02 - L21*rB12); \
+   ATL_pfl1W(r_ + ldr_+((ldr_)<<2)); \
+/* \
+ * x3 = (b3 - L30*x0 - L31*x1 - L32*x2) \
+ */ \
+   rB30 = (rB30 - L30*rB00 - L31*rB10 - L32*rB20); \
+   rB31 = (rB31 - L30*rB01 - L31*rB11 - L32*rB21); \
+   rB32 = (rB32 - L30*rB02 - L31*rB12 - L32*rB22); \
+   ATL_pfl1W(r_ + ((ldr_)<<1)+((ldr_)<<2)); \
+}  /* complete 4x4 NRHS=3 solve block */
+
+/*
  * Solve 4x4 L with 3 RHS symbolically
  * Answer is output into rBxx regs, which are live on input and output
  */
@@ -2763,6 +2795,42 @@ ATL_SINLINE void ATL_rk4(ATL_CINT M, const TYPE *A, ATL_CINT lda,
    rB02 = (rB02 - U01*rB12 - U02*rB22 - U03*rB32) * U00; \
 }  /* complete M=4, N=3 solve block */
 #elif NRHS == 4
+/*
+ * Solve 4x4 L with 4 RHS symbolically for unit diagonal
+ * Answer is output into rBxx regs, which are live on input and output
+ */
+#define  ATL_trsmL4U(L_, ldl_, r_, ldr_) \
+{ \
+   const RTYPE L10=L_[1], L20=L_[2], L30=L_[3]; \
+   const RTYPE L21=L_[ldl_+2], L31=a[ldl_+3]; \
+   const RTYPE L32=L_[2*(ldl_)+3]; \
+   ATL_pfl1W(r_ + ((ldr_)<<2)); \
+/* \
+ * x1 = (b1 - L10 * x0) \
+ */ \
+   rB10 = (rB10 - L10*rB00);  \
+   rB11 = (rB11 - L10*rB01); \
+   rB12 = (rB12 - L10*rB02); \
+   rB13 = (rB13 - L10*rB03); \
+   ATL_pfl1W(r_ + ldr_ +((ldr_)<<2)); \
+/* \
+ * x2 = (b2 - L20*x0 - L21*x1) \
+ */ \
+   rB20 = (rB20 - L20*rB00 - L21*rB10); \
+   rB21 = (rB21 - L20*rB01 - L21*rB11); \
+   rB22 = (rB22 - L20*rB02 - L21*rB12); \
+   rB23 = (rB23 - L20*rB03 - L21*rB13); \
+   ATL_pfl1W(r_ + ((ldr_)<<1)+((ldr_)<<2)); \
+/* \
+ * x3 = (b3 - L30*x0 - L31*x1 - L32*x2) \
+ */ \
+   rB30 = (rB30 - L30*rB00 - L31*rB10 - L32*rB20); \
+   rB31 = (rB31 - L30*rB01 - L31*rB11 - L32*rB21); \
+   ATL_pfl1W(r_ + ldr_+((ldr_)<<1)+((ldr_)<<2)); \
+   rB32 = (rB32 - L30*rB02 - L31*rB12 - L32*rB22); \
+   rB33 = (rB33 - L30*rB03 - L31*rB13 - L32*rB23); \
+}  /* complete 4x4 solve block */
+
 /*
  * Solve 4x4 L with 4 RHS symbolically
  * Answer is output into rBxx regs, which are live on input and output
@@ -3059,8 +3127,15 @@ static void ATL_trsmLLN
    }            /* end loop over RHS */
 }  /* end of static func ATL_trsmLLN */
 @ROUT ATL_trsmKL_rk4
-#define ATL_trsmLLN Mjoin(PATL,ktrsmLLN_rk4)
+#ifdef ATL_KERN_L4U
+   #define ATL_trsmLLNU Mjoin(PATL,ktrsmLLNU_rk4)
+   #define trsmL4 ATL_trsmL4U  /* use unit-diag kernel */
+void ATL_trsmLLNU
+#else
+   #define ATL_trsmLLN Mjoin(PATL,ktrsmLLN_rk4)
+   #define trsmL4 ATL_trsmL4  /* use non-unit-diag kernel */
 void ATL_trsmLLN
+#endif
 (
    ATL_CINT  M,   /* size of orig triangular matrix A */
    ATL_CINT  N,   /* number of RHS in B */
@@ -3126,7 +3201,7 @@ void ATL_trsmLLN
 /*
  *       Solve M=4 NRHS=4 TRSM symbolically
  */
-         ATL_trsmL4(a, lda, b, ldb);
+         trsmL4(a, lda, b, ldb);
 /*
  *       Write solved 4x4 block out to original workspace (final answer)
  *       Handle most common case with only one if
@@ -4317,7 +4392,11 @@ int Mjoin(PATL,trsmKL_rk2)   /* returns 0 on success */
    return(0);
 }
 @ROUT ATL_trsmKL_rk4
+#ifdef ATL_KERN_L4U
+int Mjoin(PATL,trsmKLU_rk4)   /* returns 0 on success */
+#else
 int Mjoin(PATL,trsmKL_rk4)   /* returns 0 on success */
+#endif
 (
    enum ATLAS_SIDE Side,
    enum ATLAS_UPLO Uplo,
@@ -4365,7 +4444,11 @@ int Mjoin(PATL,trsmKL_rk4)   /* returns 0 on success */
       cpypadL(Diag, M, A, lda, a, M4);
       if (t)
          free(t);
-      ATL_trsmLLN(M, N, alpha, a, B, ldb, w);
+      #ifdef ATL_KERN_L4U
+         ATL_trsmLLNU(M, N, alpha, a, B, ldb, w);
+      #else
+         ATL_trsmLLN(M, N, alpha, a, B, ldb, w);
+      #endif
    }
    else  /* Uplo == AtlasUpper */
    {

--- a/AtlasBase/Clint/atlas.base
+++ b/AtlasBase/Clint/atlas.base
@@ -35511,6 +35511,905 @@ gemm(...)
    if (M == 1 || N == 1) /* possible gemv */
    else if (K == 1)      /* possible ger */
 }
+@ROUT mmtime_pt3f
+#ifdef ATL_NCPU
+   #if ATL_NCPU < 2
+      #undef ATL_NCPU
+   #endif
+#endif
+#ifdef ATL_NCPU
+   #define _GNU_SOURCE 1 /* what manpage says you need to get CPU_SET */
+   #define __USE_GNU   1 /* what you actually need set on linuxes I've seen */
+   #include <sched.h>    /* must include this before pthreads */
+   #include <pthread.h>
+   #define dumb_prand(is_) ( 0.5 - ((double)rand_r(is_))/((double)RAND_MAX) )
+#else
+   #define dumb_prand(is_) ( 0.5 - ((double)rand())/((double)RAND_MAX) )
+#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+
+#define uint unsigned int
+#ifndef ATL_SZA
+   uint ATL_getszA(uint M, uint K, uint mu, uint ku, uint vlen)
+   {
+      uint nmu=(M+mu-1)/mu;
+      return(nmu*mu*K);
+   }
+#endif
+#ifndef ATL_SZB
+   uint ATL_getszB(uint K, uint N, uint ku, uint nu, uint vlen)
+   {
+      uint nnu=(N+nu-1)/nu;
+      return(nnu*nu*K);
+   }
+#endif
+#ifndef ATL_SZC
+   uint ATL_getszC(uint M, uint N, uint mu, uint nu, uint vlen)
+   {
+      uint nmu=(M+mu-1)/mu, nnu=(N+nu-1)/nu, blksz=((mu*nu+vlen-1)/vlen)*vlen;
+      return(nmu*nnu*blksz);
+   }
+#endif
+#ifdef TIME_TRMVK
+   #include "atlas_misc.h"
+#else
+   double ATL_walltime(void);
+   #define ATL_CSZT const size_t
+   #if defined(SREAL) || defined(SCPLX)
+      #define TYPE float
+   #elif defined(DREAL) || defined(DCPLX)
+      #define TYPE double
+   #endif
+   #ifdef SREAL
+      #define ATL_MulBySize(i_) ((i_)<<2)
+      #define ATL_DivBySize(i_) ((i_)>>2)
+   #elif defined(DREAL) || defined(SCPLX)
+      #define ATL_MulBySize(i_) ((i_)<<3)
+      #define ATL_DivBySize(i_) ((i_)>>3)
+   #else
+      #define ATL_MulBySize(i_) ((i_)<<4)
+      #define ATL_DivBySize(i_) ((i_)>>4)
+   #endif
+   #if defined(SCPLX) || defined(DCPLX)
+      #define SHIFT << 1
+      #define TCPLX 1
+   #else
+      #define TREAL 1
+      #define SHIFT
+   #endif
+   #define ATL_Cachelen 128
+   #define ATL_AlignPtr(vp) \
+      (void*) ( ATL_Cachelen + ((((size_t) (vp))>>7)<<7) )
+#endif
+#define CINT const int
+
+#ifdef TIME_TRMVK
+   #ifdef TCPLX
+      #error "Complex TRSM kernel timing not yet supported!"
+   #else
+      #ifdef SD_Right
+         #error "Side=Right not yet supported!"
+      #else
+         #ifdef UDIAG
+            #define my_trsmk Mjoin(PATL,ktrsmLLNU_rk4)
+         #else
+            #define my_trsmk Mjoin(PATL,ktrsmLLN_rk4)
+         #endif
+      void my_trsmk(ATL_CINT M, ATL_CINT N, const SCALAR alpha,
+          const TYPE *T, TYPE *B, ATL_CINT ldb, TYPE *W);
+      #endif
+   #endif
+#elif defined(TCPLX)
+   size_t rszA, rszB, rszC;
+   void CAMM_b0(ATL_CSZT mblks, ATL_CSZT nblks, ATL_CSZT K, const TYPE *A,
+                const TYPE *B, TYPE *C, const TYPE *pAn, const TYPE *pBn,
+                const TYPE *pCn);
+   void CAMM_b1(ATL_CSZT mblks, ATL_CSZT nblks, ATL_CSZT K, const TYPE *A,
+                const TYPE *B, TYPE *C, const TYPE *pAn, const TYPE *pBn,
+                const TYPE *pCn);
+   void CAMM_bn(ATL_CSZT mblks, ATL_CSZT nblks, ATL_CSZT K, const TYPE *A,
+                 const TYPE *B, TYPE *C, const TYPE *pAn, const TYPE *pBn,
+                 const TYPE *pCn);
+   #ifdef BETA0
+      void KMM(ATL_CSZT mblks, ATL_CSZT nblks, ATL_CSZT K, const TYPE *Ai,
+               const TYPE *Bi, TYPE *Ci, const TYPE *pAn, const TYPE *pBn,
+               const TYPE *pCn)
+      {
+         extern size_t rszA, rszB, rszC;
+         const TYPE *Ar=Ai+rszA, *Br=Bi+rszB;
+         TYPE *Cr = Ci + rszC;
+         #ifdef CORDER
+            CAMM_b0(mblks, nblks, K, Ai, Bi, Cr, Ar, Br, Cr);
+            CAMM_bn(mblks, nblks, K, Ar, Br, Cr, Ar, Bi, Ci);
+            CAMM_b0(mblks, nblks, K, Ar, Bi, Ci, Ai, Br, Ci);
+            CAMM_b1(mblks, nblks, K, Ai, Br, Ci, pAn, pBn, pCn);
+         #else
+            CAMM_b0(mblks, nblks, K, Ai, Bi, Cr, Ai, Br, Ci);
+            CAMM_b0(mblks, nblks, K, Ai, Br, Ci, Ar, Br, Cr);
+            CAMM_bn(mblks, nblks, K, Ar, Br, Cr, Ar, Bi, Ci);
+            CAMM_b1(mblks, nblks, K, Ar, Bi, Ci, pAn, pBn, pCn);
+         #endif
+      }
+   #elif defined(BETA1)
+      void KMM(ATL_CSZT mblks, ATL_CSZT nblks, ATL_CSZT K, const TYPE *Ai,
+               const TYPE *Bi, TYPE *Ci, const TYPE *pAn, const TYPE *pBn,
+               const TYPE *pCn)
+      {
+         extern size_t rszA, rszB, rszC;
+         const TYPE *Ar=Ai+rszA, *Br=Bi+rszB;
+         TYPE *Cr = Ci + rszC;
+         #ifdef CORDER
+            CAMM_bn(mblks, nblks, K, Ai, Bi, Cr, Ar, Br, Cr);
+            CAMM_bn(mblks, nblks, K, Ar, Br, Cr, Ar, Bi, Ci);
+            CAMM_b1(mblks, nblks, K, Ar, Bi, Ci, Ai, Br, Ci);
+            CAMM_b1(mblks, nblks, K, Ai, Br, Ci, pAn, pBn, pCn);
+         #else
+            CAMM_bn(mblks, nblks, K, Ai, Bi, Cr, Ai, Br, Ci);
+            CAMM_b1(mblks, nblks, K, Ai, Br, Ci, Ar, Br, Cr);
+            CAMM_bn(mblks, nblks, K, Ar, Br, Cr, Ar, Bi, Ci);
+            CAMM_b1(mblks, nblks, K, Ar, Bi, Ci, pAn, pBn, pCn);
+         #endif
+      }
+   #else
+      void KMM(ATL_CSZT mblks, ATL_CSZT nblks, ATL_CSZT K, const TYPE *Ai,
+               const TYPE *Bi, TYPE *Ci, const TYPE *pAn, const TYPE *pBn,
+               const TYPE *pCn)
+      {
+         extern size_t rszA, rszB, rszC;
+         const TYPE *Ar=Ai+rszA, *Br=Bi+rszB;
+         TYPE *Cr = Ci + rszC;
+         #ifdef CORDER
+            CAMM_b1(mblks, nblks, K, Ai, Bi, Cr, Ar, Br, Cr);
+            CAMM_b1(mblks, nblks, K, Ar, Br, Cr, Ar, Bi, Ci);
+            CAMM_bn(mblks, nblks, K, Ar, Bi, Ci, Ai, Br, Ci);
+            CAMM_bn(mblks, nblks, K, Ai, Br, Ci, pAn, pBn, pCn);
+         #else
+            CAMM_b1(mblks, nblks, K, Ai, Bi, Cr, Ai, Br, Ci);
+            CAMM_bn(mblks, nblks, K, Ai, Br, Ci, Ar, Br, Cr);
+            CAMM_b1(mblks, nblks, K, Ar, Br, Cr, Ar, Bi, Ci);
+            CAMM_bn(mblks, nblks, K, Ar, Bi, Ci, pAn, pBn, pCn);
+         #endif
+      }
+   #endif
+#else
+   #ifndef KMM
+      #define KMM ATL_USERMM
+   #endif
+   void KMM(ATL_CSZT mblks, ATL_CSZT nblks, ATL_CSZT K, const TYPE *A,
+            const TYPE *B, TYPE *C, const TYPE *pAn, const TYPE *pBn,
+            const TYPE *pCn);
+#endif
+
+struct kmm_struct{
+   int mb, nb, kb;                      /* C: mbxnb, At: kbxmb, B: kbXnb */
+   int mu, nu, ku;                      /* needed to compute mblks/nblks */
+   int movA, movB, movC;                /* which mat move in flush array? */
+   long FLSIZE;                       /* min area to move in in bytes */
+   long flA, flB, flC;                /* individual flush sizes in bytes*/
+   int reps;                            /* # calls to kmm in one timing */
+   int vlen;                            /* vector length */
+   int iam;                             /* thread rank */
+   int p;                               /* total number of threads */
+   int *pids;                           /* IDs of processors for affinity */
+   double mf;                           /* mflop returned by timing */
+   volatile unsigned char *chkin;       /* P-len array to signal start/done */
+};
+
+static double getMflops(double m, double n, double k)
+{
+   #ifdef TIME_TRMVK
+     return(1e-6*m*m*n);
+   #elif defined(TIME_SYRKK)
+      return(1e-6*n*(n+1)*k);
+   #else
+      return(1e-6*2.0*m*n*k);
+   #endif
+}
+static size_t getSetSz(int mvA, int mvB, int mvC,
+                       size_t szA, size_t szB, size_t szC, size_t *NOMVSZ)
+{
+   size_t nomvsz=0, setsz=0;
+   if (mvA)
+      setsz += szA;
+   else
+      nomvsz += szA;
+   if (mvB)
+      setsz += szB;
+   else
+      nomvsz += szB;
+   if (mvC)
+      setsz += szC;
+   else
+      nomvsz += szC;
+   if (NOMVSZ)
+      *NOMVSZ = nomvsz;
+   return(setsz);
+}
+
+#if 1
+
+double GetKmmMflop
+(
+   CINT mb, CINT nb, CINT kb,           /* C: mbxnb, At: kbxmb, B: kbXnb */
+   CINT mu, CINT nu, CINT ku, CINT vlen,
+   int movA, int movB, int movC,        /* which mat move in flush array? */
+   long FLSIZE,                         /* min area to move in in bytes */
+   long flA, long flB, long flC,        /* min area to move in in bytes */
+   CINT reps                            /* # calls to kmm in one timing */
+)
+/*
+ * Returns MFLOP rate of matmul kernel KMM
+ */
+{
+   CINT mblks = mb/mu, nblks = nb/nu;
+   const int NOMOVE = !(movA|movB|movC);
+   size_t szA, szB, szC, extra, setsz, nsets, tsz, i, j, incA, incB, incC, n;
+   TYPE *C, *A, *B, *a, *b, *c;
+   TYPE *ep, *sp;  /* extra & set ptrs */
+   double t0, t1, mf;
+   const TYPE alpha=1.0;
+   TYPE beta=1.0;
+   void *vp=NULL;
+   unsigned int seed = mb*kb + (nb<<14);
+   size_t nseta, nsetb, nsetc, ja, jb, jc;
+/*
+ * Get size for each matrix, and round up to ensure we keep alignment
+ */
+   szA = ATL_getszA(mb, kb, mu, ku, vlen);
+   szB = ATL_getszB(kb, nb, ku, nu, vlen);
+   szC = ATL_getszC(mb, nb, mu, nu, vlen);
+/*
+ * Compute the setsz & extra
+ * setsz: size of moving mats, extra: size of stationary mats
+ */
+   setsz = getSetSz(movA, movB, movC, szA, szB, szC, &extra);
+   if (!NOMOVE && FLSIZE)
+      nsets = (ATL_DivBySize(FLSIZE)+setsz-1) / setsz;
+   else
+      movA = movB = movC = nsets = 0;
+   extra += (mu+mu)*nu;
+   tsz = ATL_Cachelen << 1;
+   tsz = ATL_DivBySize(tsz);
+   if (flA > 0 || flB > 0 || flC > 0)
+   {
+      nseta = (ATL_DivBySize(flA)+szA-1) / szA;
+      nsetb = (ATL_DivBySize(flA)+szB-1) / szB;
+      nsetc = (ATL_DivBySize(flA)+szC-1) / szC;
+      if (!movA || nseta < 1) nseta = 1;
+      if (!movB || nsetb < 1) nsetb = 1;
+      if (!movC || nsetc < 1) nsetc = 1;
+
+      tsz += nseta*szA + nsetb*szB + nsetc*szC + extra;
+      vp = malloc(6*ATL_Cachelen + ATL_MulBySize(tsz));
+   }
+   else
+   {
+      nseta = nsetb = nsetc = nsets;
+      if (!movA || nseta < 1) nseta = 1;
+      if (!movB || nsetb < 1) nsetb = 1;
+      if (!movC || nsetc < 1) nsetc = 1;
+      tsz += nsets*setsz+extra;
+      vp = malloc(8*ATL_Cachelen + ATL_MulBySize(tsz));
+   }
+   assert(vp);
+   sp = ATL_AlignPtr(vp);
+   if (flA > 0 || flB > 0 || flC > 0)
+      ep = sp + nseta*szA + nsetb*szB + nsetc*szC;
+   else
+      ep = sp + nsets*setsz;
+   ep += ATL_DivBySize(3*ATL_Cachelen);
+   ep = ATL_AlignPtr(ep);
+   if (movA)
+   {
+      A = sp;
+      incA = szA SHIFT;
+      sp += incA * nseta;
+      sp = ATL_AlignPtr(sp);
+   }
+   else
+   {
+      A = ep;
+      ep += szA SHIFT;
+      ep = ATL_AlignPtr(ep);
+      incA = 0;
+   }
+   if (movB)
+   {
+      B = sp;
+      incB = szB SHIFT;
+      sp += incB * nsetb;
+      sp = ATL_AlignPtr(sp);
+   }
+   else
+   {
+      B = ep;
+      ep += szB SHIFT;
+      ep = ATL_AlignPtr(ep);
+      incB = 0;
+   }
+   if (movC)
+   {
+      C = sp;
+      incC = szC SHIFT;
+   }
+   else
+   {
+      C = ep;
+      incC = 0;
+   }
+   /* OLD Init *//*
+   sp = ATL_AlignPtr(vp);
+   for (i=0; i < (tsz+ATL_DivBySize(5*ATL_Cachelen)); i++)
+      sp[i] = dumb_prand(&seed);
+   */
+   for (i=0; i<nseta*szA; i++)
+      A[i] = dumb_prand(&seed);
+   for (i=0; i<nsetb*szB; i++)
+      B[i] = dumb_prand(&seed);
+   for (i=0; i<nsetc*szC; i++)
+      C[i] = dumb_prand(&seed);
+
+   a = A; b = B; c = C;
+   t0 = ATL_walltime();
+   for (ja=jb=jc=0,i=reps; i; i--)
+   {
+      TYPE *an, *bn, *cn;
+      if (++ja != nseta)
+         an = a+incA;
+      else
+      {
+         ja = 0; an = A;
+      }
+      if (++jb != nsetb)
+         bn = b+incB;
+      else
+      {
+         jb = 0; bn = B;
+      }
+      if (++jc != nsetc)
+         cn = c+incC;
+      else
+      {
+         jc = 0; cn = C;
+      }
+      #ifdef TIME_TRMVK
+         my_trsmk(mb, nb, 1.0, a, c, mb, b);
+      #elif defined(TIME_SYRKK)
+         KMM(mblks, nblks, kb, a, a, c, an, an, cn);
+      #else
+         KMM(mblks, nblks, kb, a, b, c, an, bn, cn);
+      #endif
+      a = an;
+      b = bn;
+      c = cn;
+   }
+   t1 = ATL_walltime() - t0;
+   mf = reps*getMflops(mb, nb, kb) / t1;
+   #ifdef TCPLX
+      mf *= 4.0;
+   #endif
+   free(vp);
+   return(mf);
+}
+
+#else
+
+double GetKmmMflop
+(
+   CINT mb, CINT nb, CINT kb,           /* C: mbxnb, At: kbxmb, B: kbXnb */
+   CINT mu, CINT nu, CINT ku, CINT vlen,
+   int movA, int movB, int movC,        /* which mat move in flush array? */
+   long FLSIZE,                       /* min area to move in in bytes */
+   CINT reps                            /* # calls to kmm in one timing */
+)
+/*
+ * Returns MFLOP rate of matmul kernel KMM
+ */
+{
+   CINT mblks = mb/mu, nblks = nb/nu;
+   const int NOMOVE = !(movA|movB|movC);
+   size_t szA, szB, szC, extra, setsz, nsets, tsz, i, j, incA, incB, incC, n;
+   TYPE *C, *A, *B, *a, *b, *c;
+   TYPE *ep, *sp;  /* extra & set ptrs */
+   double t0, t1, mf;
+   const TYPE alpha=1.0;
+   TYPE beta=1.0;
+   void *vp=NULL;
+   unsigned int seed = mb*kb + (nb<<14);
+/*
+ * Get size for each matrix, and round up to ensure we keep alignment
+ */
+   szA = ATL_getszA(mb, kb, mu, ku, vlen);
+   szB = ATL_getszB(kb, nb, ku, nu, vlen);
+   szC = ATL_getszC(mb, nb, mu, nu, vlen);
+/*
+ * Compute the setsz & extra
+ * setsz: size of moving mats, extra: size of stationary mats
+ */
+   setsz = getSetSz(movA, movB, movC, szA, szB, szC, &extra);
+   if (!NOMOVE && FLSIZE)
+      nsets = (ATL_DivBySize(FLSIZE)+setsz-1) / setsz;
+   else
+      movA = movB = movC = nsets = 0;
+   extra += (mu+mu)*nu;
+   tsz = ATL_Cachelen << 1;
+   tsz = ATL_DivBySize(tsz);
+   tsz += nsets*setsz+extra;
+   vp = malloc(2*ATL_Cachelen + ATL_MulBySize(tsz));
+   assert(vp);
+   sp = ATL_AlignPtr(vp);
+   ep = sp + nsets*setsz;
+   ep = ATL_AlignPtr(ep);
+   if (movA)
+   {
+      A = sp;
+      incA = szA SHIFT;
+      sp += incA * nsets;
+      sp = ATL_AlignPtr(sp);
+   }
+   else
+   {
+      A = ep;
+      ep += szA SHIFT;
+      ep = ATL_AlignPtr(ep);
+      incA = 0;
+   }
+   if (movB)
+   {
+      B = sp;
+      incB = szB SHIFT;
+      sp += incB * nsets;
+      sp = ATL_AlignPtr(sp);
+   }
+   else
+   {
+      B = ep;
+      ep += szB SHIFT;
+      ep = ATL_AlignPtr(ep);
+      incB = 0;
+   }
+   if (movC)
+   {
+      C = sp;
+      incC = szC SHIFT;
+   }
+   else
+   {
+      C = ep;
+      incC = 0;
+   }
+   sp = ATL_AlignPtr(vp);
+   for (i=0; i < tsz; i++)
+      sp[i] = dumb_prand(&seed);
+
+   a = A; b = B; c = C;
+   t0 = ATL_walltime();
+   for (j=0,i=reps; i; i--)
+   {
+      TYPE *an, *bn, *cn;
+      if (++j != nsets)
+      {
+         an = a+incA;
+         bn = b+incB;
+         cn = c+incC;
+      }
+      else
+      {
+         j = 0;
+         an = A; bn = B; cn = C;
+      }
+      #ifdef TIME_TRMVK
+         my_trsmk(mb, nb, 1.0, a, c, mb, b);
+      #elif defined(TIME_SYRKK)
+         KMM(mblks, nblks, kb, a, a, c, an, an, cn);
+      #else
+         KMM(mblks, nblks, kb, a, b, c, an, bn, cn);
+      #endif
+      a = an;
+      b = bn;
+      c = cn;
+   }
+   t1 = ATL_walltime() - t0;
+   mf = reps*getMflops(mb, nb, kb) / t1;
+   #ifdef TCPLX
+      mf *= 4.0;
+   #endif
+   free(vp);
+   return(mf);
+}
+
+#endif
+
+#ifdef PRINT_COREID
+   #include <utmpx.h>
+#endif
+//#define PRINT_NUMAIDS
+#ifdef PRINT_NUMAIDS
+   #define _GNU_SOURCE 1
+   #include <unistd.h>
+   #include <sys/syscall.h>
+#endif
+void *TimeOnCore(void *vp)
+{
+   struct kmm_struct *kp = vp;
+   const int P = kp->p;
+   int i;
+   volatile unsigned char *chkin = kp->chkin;
+   #ifdef PRINT_COREID
+      printf("core=%d\n", sched_getcpu());
+   #endif
+#ifdef PRINT_NUMAIDS
+    unsigned cpu, node;
+    syscall(SYS_getcpu, &cpu, &node, NULL);
+    printf("cpu=%u, node=%u\n", cpu, node);
+#endif
+/*
+ * First we barrier, so that all cores are active.  Otherwise, 1st core to
+ * start may run with bus to himself, and not give us a measure of true
+ * parallel performance.  Want full-on contention as in perfect parallel code.
+ * We wait on chkin array to have all non-zero entries.  Even on weakly-ordered
+ * caches this should work, though the delay may be long.
+ */
+   #ifdef ATL_NCPU
+      chkin[kp->iam] = 1;
+      for (i=0; i < P; i++)
+         while(!chkin[i]);
+   #endif
+   kp->mf = GetKmmMflop(kp->mb, kp->nb, kp->kb, kp->mu, kp->nu, kp->ku,
+                        kp->vlen, kp->movA, kp->movB, kp->movC,
+                        kp->FLSIZE, kp->flA, kp->flB, kp->flC, kp->reps);
+   return(NULL);
+}
+
+
+#ifndef ATL_NCPU
+double *TimeOnCores(struct kmm_struct *kb)
+{
+   double *mflops;
+   int i, p;
+
+   mflops = malloc(sizeof(double));
+   assert(mflops);
+   p = kb->p;
+   kb->iam = 0;
+   TimeOnCore(kb);
+   free(kb->pids);
+   mflops[0] = kb->mf;
+   return(mflops);
+}
+#else
+double *TimeOnCores(struct kmm_struct *kb)
+{
+   struct kmm_struct *kp;
+   pthread_t *threads;
+   pthread_attr_t *attr;
+   cpu_set_t *cpuset;
+   double *mflops;
+   int i, p;
+   unsigned char *chkin;
+
+   p = kb->p;
+/*
+ * On PowerPC Linux, pthread_attr_setaffinity_np sometimes attempts to
+ * realloc the cpuset variable, so it must be malloced not taken from
+ * the stack.  This is crazy behaviour, but it is what happens.
+ */
+   cpuset = malloc(sizeof(cpu_set_t));
+   kp = malloc(sizeof(struct kmm_struct)*p);
+   threads = malloc(sizeof(pthread_t)*p);
+   attr = malloc(sizeof(pthread_attr_t)*p);
+   mflops = malloc(sizeof(double)*p);
+   chkin = malloc(sizeof(char)*p);
+   assert(cpuset && kp && threads && attr && mflops && chkin);
+   for (i=0; i < p; i++)   /* init chkin to 0 before starting any threads */
+      chkin[i] = 0;        /* when all entries non-zero, all thrds started */
+   for (i=0; i < p; i++)
+   {
+      memcpy(kp+i, kb, sizeof(struct kmm_struct));
+      kp[i].chkin = (volatile char*)chkin;
+      kp[i].iam = i;
+      CPU_ZERO(cpuset);
+      CPU_SET(kp->pids[i], cpuset);
+      assert(!pthread_attr_setaffinity_np(attr+i, sizeof(cpuset), cpuset));
+      assert(!pthread_attr_setdetachstate(attr+i, PTHREAD_CREATE_JOINABLE));
+      assert(!pthread_create(threads+i, attr+i, TimeOnCore, kp+i));
+   }
+   for (i=0; i < p; i++)
+   {
+      pthread_join(threads[i], NULL);
+      mflops[i] = kp[i].mf;
+   }
+   free(kp->pids);
+   free(kp);
+   free(threads);
+   free(attr);
+   return(mflops);
+}
+#endif
+
+void GetStat(int n, double *d, double *min, double *max, double *avg)
+{
+   int i;
+   double dmin, dmax, dsum;
+
+   dmin = dmax = dsum = d[0];
+   for (i=1; i < n; i++)
+   {
+      dmax = (dmax >= d[i]) ? dmax : d[i];
+      dmin = (dmin <= d[i]) ? dmin : d[i];
+      dsum += d[i];
+   }
+   *min = dmin;
+   *max = dmax;
+   *avg = dsum / (double)n;
+}
+
+void PrintUsage(char *name, int iarg, char *arg)
+{
+   fprintf(stderr, "\nERROR around arg %d (%s).\n", iarg, arg ? arg:"unknown");
+   fprintf(stderr, "USAGE: %s [flags], where flags are:\n", name);
+   fprintf(stderr, "   -p <#> : use # threads (with affinity)\n");
+   fprintf(stderr, "   -tl <#> id1 ... id# : spawn # threads to given IDs\n");
+   fprintf(stderr, "   -B <#> : mb = nb = kb = #\n");
+   fprintf(stderr, "   -m <#> : mb = #\n");
+   fprintf(stderr, "   -n <#> : nb = #\n");
+   fprintf(stderr, "   -k <#> : kb = #\n");
+   fprintf(stderr, "   -V <veclen>\n");
+   fprintf(stderr, "   -u[mnk] <#> : M/N/K loop unrolling is #\n");
+   fprintf(stderr, "   -r <#> : set the # of times to call KMM\n");
+   fprintf(stderr, "   -R <mf>: set # reps to force <mf> MFLOPs\n");
+   fprintf(stderr, "   -F <kb> : set flush size in kilobytes\n");
+   fprintf(stderr, "   -M[a,b,c] <#> : mov[A,B,C] = #\n");
+   fprintf(stderr, "   -F[a,b,c] <kb> : set flush size for [A,B,C]\n");
+   exit(iarg ? iarg : -1);
+}
+
+struct kmm_struct *GetFlags(int nargs, char **args, FILE **fpout)
+{
+   FILE *fp;
+   struct kmm_struct *kp;
+   double mflops=750.0;
+   int i, j, IGMF=0;  /* ignore mflops.frc file? */
+
+   *fpout = NULL;
+   kp = malloc(sizeof(struct kmm_struct));
+   assert(kp);
+   kp->pids = NULL;
+   kp->p = 1;
+   kp->mb = kp->nb = kp->kb = 40;
+   kp->mu = kp->nu = 4;
+   kp->ku = 1;
+   kp->movA = kp->movB = kp->movC = 0;
+   kp->FLSIZE = L2SIZE;
+   kp->flA = kp->flB = kp->flC = -1;
+   kp->reps = 0;
+   kp->vlen = 1;
+   for (i=1; i < nargs; i++)
+   {
+      if (args[i][0] != '-')
+         PrintUsage(args[0], i, args[i]);
+      switch(args[i][1])
+      {
+      case 'f':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         *fpout = fopen(args[i], "w");
+         break;
+      case 'V':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         kp->vlen = atoi(args[i]);
+         break;
+      case 'F':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         switch(args[i-1][2])
+         {
+         case 'c':
+         case 'C':
+            kp->flC = atoi(args[i]) * 1024;
+            break;
+         case 'b':
+         case 'B':
+            kp->flB = atoi(args[i]) * 1024;
+            break;
+         case 'a':
+         case 'A':
+            kp->flA = atoi(args[i]) * 1024;
+            break;
+         case 0:
+            kp->FLSIZE = atoi(args[i]) * 1024;
+            break;
+         default:
+            PrintUsage(args[0], i-1, "unknown flush operand");
+         }
+         break;
+      case 'u':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         j = atoi(args[i]);
+         if (args[i-1][2] == 'k')
+            kp->ku = j;
+         else if (args[i-1][2] == 'n')
+            kp->nu = j;
+         else
+            kp->mu = j;
+         break;
+      case 'R':
+         if (args[i][2] == 'f')
+            IGMF=1;
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         mflops = atof(args[i]);
+         break;
+      case 'r':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         kp->reps = atoi(args[i]);
+         break;
+      case 't':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         kp->p = atoi(args[i]);
+         kp->pids = malloc(sizeof(int)*kp->p);
+         assert(kp->pids);
+         for (j=0; j < kp->p; j++)
+         {
+            if (++i >= nargs)
+               PrintUsage(args[0], i, "out of arguments");
+            kp->pids[j] = atoi(args[i]);
+         }
+         break;
+      case 'p':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         kp->p = atoi(args[i]);
+         break;
+      case 'm':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         kp->mb = atoi(args[i]);
+         break;
+      case 'n':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         kp->nb = atoi(args[i]);
+         break;
+      case 'k':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         kp->kb = atoi(args[i]);
+         break;
+      case 'B':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         kp->mb = kp->nb = kp->kb = atoi(args[i]);
+         break;
+      case 'M':
+         if (++i >= nargs)
+            PrintUsage(args[0], i, "out of arguments");
+         switch(args[i-1][2])
+         {
+         case 'c':
+         case 'C':
+            kp->movC = atoi(args[i]);
+            break;
+         case 'b':
+         case 'B':
+            kp->movB = atoi(args[i]);
+            break;
+         case 'a':
+         case 'A':
+            kp->movA = atoi(args[i]);
+            break;
+         default:
+            PrintUsage(args[0], i-1, "unknown mov matrix");
+         }
+         break;
+      default:
+         PrintUsage(args[0], i, args[i]);
+      }
+   }
+/*
+ * If there is a tuned <upr>mflops.frc file, use this in preference to the
+ * commandline argument unless the -Rf override flag was used
+ */
+   if (!IGMF)
+   {
+      char fn[16] = {'s', 'm', 'f', 'o', 'p', 's', '.', 'f', 'r', 'c', '\0'};
+      #if defined(DREAL) || defined(DCPLX)
+         fn[0] = 'd';
+      #endif
+      fp = fopen(fn, "r");
+      if (fp)
+      {
+         assert(fscanf(fp, "%le", &mflops) == 1);
+         fclose(fp);
+      }
+   }
+   if (!kp->reps)
+   {
+      kp->reps = (mflops*1000000.0/((2.0*kp->mb)*kp->nb*kp->kb));
+      if (kp->reps < 1)
+         kp->reps = 1;
+   }
+   if (!kp->pids)
+   {
+      kp->pids = malloc(sizeof(int)*kp->p);
+      assert(kp->pids);
+      #ifdef ATL_ARCH_XeonPHI
+      {
+         int n4 = ((kp->p)>>2)<<2, nr = kp->p - n4;
+         for (j=0; j < n4; j += 2)
+         {
+            kp->pids[j] = 2*j;
+            kp->pids[j+1] = 2*j+1;
+         }
+         switch(nr)
+         {
+         case 3:
+            kp->pids[j+2] = 2*(j+2);
+         case 2:
+            kp->pids[j+1] = 2*j+1;
+         case 1:
+            kp->pids[j] = 2*j;
+            break;
+         case 0:;
+         }
+      }
+      #else
+         for (j=0; j < kp->p; j++)
+             kp->pids[j] = j;
+      #endif
+   }
+   #ifdef TIME_SYRKK
+      kp->movB = 0;
+   #endif
+   if (kp->FLSIZE <= 0)
+      kp->FLSIZE = L2SIZE;
+   if (kp->flA > 0 || kp->flB > 0 || kp->flC > 0)
+   {
+      if (kp->flA < 0) kp->flA = kp->FLSIZE;
+      if (kp->flB < 0) kp->flB = kp->FLSIZE;
+      if (kp->flC < 0) kp->flC = kp->FLSIZE;
+   }
+   return(kp);
+}
+
+int main(int nargs, char **args)
+{
+   struct kmm_struct *kp;
+   int i, p;
+   double *dp;
+   double min, max, avg;
+   FILE *fpout = stdout;
+
+   kp = GetFlags(nargs, args, &fpout);
+   p = kp->p;
+   #ifndef ATL_NCPU
+      assert(p < 2);
+   #endif
+   dp = TimeOnCores(kp);
+   free(kp);
+   GetStat(p, dp, &min, &max, &avg);
+   printf("PER-CORE: %le", dp[0]);
+   for (i=1; i < p; i++)
+      printf(", %le", dp[i]);
+   printf("\nALL CORES: min=%.2f, max=%.2f, avg=%.2f\n", min, max, avg);
+   if (fpout)
+   {
+      fprintf(fpout, "%d 1\n", p);
+      for (i=0; i < p; i++)
+         fprintf(fpout, "%e\n", dp[i]);
+   }
+   free(dp);
+   if (fpout && fpout != stdout && fpout != stderr)
+      fclose(fpout);
+   exit(0);
+}
 @ROUT mmtime_pt
 #ifdef ATL_NCPU
    #if ATL_NCPU < 2
@@ -35829,7 +36728,7 @@ double GetKmmMflop
          an = A; bn = B; cn = C;
       }
       #ifdef TIME_TRMVK
-         Mjoin(PATL,ktrsmLLN_rk4)(mb, nb, 1.0, A, c, mb, B);
+         Mjoin(PATL,ktrsmLLN_rk4)(mb, nb, 1.0, a, c, mb, B);
       #elif defined(TIME_SYRKK)
          KMM(mblks, nblks, kb, a, a, c, an, an, cn);
       #else

--- a/AtlasBase/make.base
+++ b/AtlasBase/make.base
@@ -370,6 +370,7 @@ tar cvf atlas.tar \
      ATLAS/tune/blas/gemm/tfc.c \
      ATLAS/tune/blas/gemm/mmflagsearch.c ATLAS/tune/blas/gemm/szblk.c \
      ATLAS/tune/blas/gemm/mmtime_pt.c ATLAS/tune/blas/gemm/*.base \
+     ATLAS/tune/blas/gemm/mmtime_pt3f.c  ATLAS/tune/blas/gemm/uammgen.c \
      ATLAS/tune/blas/gemm/emit_amm.c ATLAS/tune/blas/gemm/emit_uamm.c \
      ATLAS/tune/blas/gemm/ammsearch.c ATLAS/tune/blas/gemm/uammsrch.c \
      ATLAS/tune/blas/gemm/gmmsearch.c ATLAS/tune/blas/gemm/prefparse.c \
@@ -1569,7 +1570,7 @@ basfn = $(basdRCW)/atlas-lvl2.base
 basfn = $(basdRCW)/atlas.base
 @multidef rt 
    @skip hcsearch ummsearch userflag usercomb userindex 
-   tfc fc findCE ATL_resfind mmtime_pt
+   tfc fc findCE ATL_resfind mmtime_pt mmtime_pt3f 
    GetSysSum mmtst
 @skip   txover
 @endmultidef
@@ -1617,7 +1618,7 @@ all : $(files)
 @skip @ROUT ATLAS/tune/blas/gemv `emit_head.c emit_rmvT.c mvgen_sse.c atlas-l2g.base`
 @ROUT ATLAS/tune/blas/gemv `atlas-l2g.base`
 @skip @ROUT ATLAS/tune/blas/gemm `emit_mm.c vnbmmsearch.c emit_vKB.c mm_old2new.c vmmf_gccsub.c`
-@ROUT ATLAS/tune/blas/gemm `emit_mm.c mmflagsearch.c uammsrch.c uammsearch.c gmmsearch.c ammsearch.c emit_uamm.c emit_amm.c ammgen.c cm2amtst.c peaktim.c cnbtune.c prefparse.c szblk.c`
+@ROUT ATLAS/tune/blas/gemm `emit_mm.c mmflagsearch.c uammsrch.c uammsearch.c gmmsearch.c ammsearch.c emit_uamm.c emit_amm.c uammgen.c ammgen.c cm2amtst.c peaktim.c cnbtune.c prefparse.c szblk.c`
 @ROUT ATLAS/tune/sysinfo `emit_typ.c emit_lamch.c cacheSweep.c`
 @enddeclare
 
@@ -1679,7 +1680,7 @@ atlas-mmg.base : $(basd)/atlas-mmg.base
 
 mmflagsearch.c : $(basfn) $(incf)
 	$(extC) -b $(basfn) -o $@ rout=$*
-@multidef rt gmmsearch prefparse szblk ammgen
+@multidef rt gmmsearch prefparse szblk ammgen uammgen
 @whiledef rt uammsrch uammsearch ammsearch emit_amm emit_uamm cm2amtst peaktim cnbtune
 @(rt).c : $(basdRCW)/atlas-ammm.base $(incf)
 	$(extC) -b $(basdRCW)/atlas-ammm.base -o $@ rout=$*


### PR DESCRIPTION
1. added unit-diagonal based trsm kernel in ATL_trsmKL_rk4.c under a macro and added appropriate Makefile targets to automatically compile both during ATLAS install. 

2. Added new mmtime_pt that can take individual flushing parameters. Also, added a new TimeMMKernel routine in atlas_mmtesttime.h that takes 3 flushing parameters and calls the new mmtime_pt .

3. Wrote a new uammgen.c based on ammgen.c to generate and compile .

4. Renamed all the routines to to start with ATL_<pre>u<UID> and all these routines are added to libuamm.a .

5. Fixed reverse copy (typos in the base file) for complex in uammgen.c 