### PR TITLE
Architecture specific peephole optimizations

### DIFF
--- a/iFKO/FKO/include/fko.h
+++ b/iFKO/FKO/include/fko.h
@@ -18,7 +18,8 @@
          fprintf(stderr, \
                  "\n\nassertion '%s' failed on line %d of %s, hanging:\n\n", \
                  Mstr(arg_), __LINE__, __FILE__);\
-         while(1); \
+         /*while(1);*/ \
+         exit(-1); \
       } \
    }
    #define assert MyAssert
@@ -86,6 +87,7 @@
 #define IFF_OPT2DPTR     0x800 /* optimize 2d array access with min reg & ptr */
 #define IFF_NODDE        0x1000 /* optimize 2d array access with min reg & ptr */
 #define IFF_BESTVEC      0x2000 /*analyze all vector methods and apply best one*/
+#define IFF_SHOWCOMMENTS 0x4000  /* show all comments in code, by default off */
 /*
  * Majedul: 
  *    As we will introduce more and more new optimizations, I will keep 

--- a/iFKO/FKO/include/fko_arch.h
+++ b/iFKO/FKO/include/fko_arch.h
@@ -140,6 +140,10 @@
    #else /* by default SSE4.1*/
       /*#define INT_VEC*/
       /*#define FKO_IVLEN 4*/
+/*
+ *    added synthetic inst in SSE to support mem broadcast
+ */
+      #define ArchHasMemBroadcast
       #define SSE3   /* sse4.1 includes sse3 */
       #define FP_VEC
       #define FKO_SVLEN 4
@@ -709,7 +713,7 @@
    #endif
 #else
    #ifdef X86_64
-      #define HAMMER
+      #define COREI
    #endif
    #ifdef PIII
       #define NCACHE 2
@@ -732,11 +736,25 @@
       #else
          extern short LINESIZE[NCACHE];
       #endif
-   #else /* P4/P4E defaults */
+   #elif defined(p4) /* P4/P4E */
       #define NCACHE 1
       #ifdef ARCH_DECLARE
          /*short LINESIZE[NCACHE] = {128};*/
          short LINESIZE[NCACHE] = {64};
+      #else
+         extern short LINESIZE[NCACHE];
+      #endif
+   #elif defined(COREI) /* corei, AMD defaults */
+      #define NCACHE 3
+      #ifdef ARCH_DECLARE
+         short LINESIZE[NCACHE] = {64,64,64};
+      #else
+         extern short LINESIZE[NCACHE];
+      #endif
+   #else /* defaults */
+      #define NCACHE 2
+      #ifdef ARCH_DECLARE
+         short LINESIZE[NCACHE] = {64,64};
       #else
          extern short LINESIZE[NCACHE];
       #endif

--- a/iFKO/FKO/include/fko_arch.h
+++ b/iFKO/FKO/include/fko_arch.h
@@ -127,6 +127,9 @@
    #endif
    #ifdef AVX
       #define ArchHasMemBroadcast
+      #define ArchHasFPthreeOps
+      #define ArchHasVFPthreeOps
+      #define ArchHasVINTthreeOps
       #define FP_VEC
       #define FKO_SVLEN 8
       #define DP_VEC

--- a/iFKO/FKO/include/fko_inst.h
+++ b/iFKO/FKO/include/fko_inst.h
@@ -74,6 +74,9 @@ enum inst
    CMPAND,                      /* cc0, r1, r2/c : set [cc] based on r1 & r2 */
    CMP,                         /* cc#, r1, r2/c: set [cc] based on r1 - r2 */
    NEG,                         /* [r0], [r1] : r0 = -r1 */
+   LEA2,                        /* lea r0, [r1, r2, 2] */ 
+   LEA4,                        /* lea r0, [r1, r2, 4] */ 
+   LEA8,                        /* lea r0, [r1, r2, 8] */ 
 /*   ABS, ; abs commented out because not widely supported */
 /*
  * 32-bit integer (64-bit systems only)
@@ -95,7 +98,10 @@ enum inst
    CMPS,                        /* set [cc](r0) based on r1 - r2 */
    MOVS,                        /* [r0], [r1] : r0 = r1 */
    NEGS,                        /* [r0], [r1] : r0 = -r1 */
-   ABSS,
+   LEAS2,                        /* lea r0, [r1, r2, 2] */ 
+   LEAS4,                        /* lea r0, [r1, r2, 4] */ 
+   LEAS8,                        /* lea r0, [r1, r2, 8] */ 
+   /*ABSS,*/
 /*
  * Jump instructions
  */
@@ -502,6 +508,9 @@ char *instmnem[] =
    "CMPAND",
    "CMP",
    "NEG",
+   "LEA2",
+   "LEA4",
+   "LEA8",
 /*   ABS, ; abs commented out because not widely supported */
 /*
  * 32-bit integer (64-bit systems only)
@@ -523,7 +532,10 @@ char *instmnem[] =
    "UDIVS",
    "CMPS",
    "NEGS",
-   "ABSS",
+   "LEAS2",
+   "LEAS4",
+   "LEAS8", 
+   /*"ABSS",*/
 /*
  * Jump instructions
  */
@@ -960,7 +972,8 @@ char *instmnem[] =
                       (i_) == FCMOVD1 || (i_) == FCMOVD2 || (i_) == VFCMOV1 || \
                       (i_) == VFCMOV2 || (i_) == VDCMOV1 || (i_) == VDCMOV2 || \
                       (i_) == CMOV1 || (i_) == CMOV2 || (i_) == VSCMOV1 || \
-                      (i_) == VSCMOV2 || (i_) == VICMOV1 || (i_) == VICMOV2 )
+                      (i_) == VSCMOV2 || (i_) == VICMOV1 || (i_) == VICMOV2 || \
+                      (i_) == LEA2 || (i_) == LEA4 || (i_) == LEA8 )
 /*
  * NOTE: FMA4 in AMD can be re ordered, src2 can be mem. need to consider
  * this again while implemting other FMAC like: FMA3 ... 
@@ -974,8 +987,9 @@ char *instmnem[] =
  * Majedul: These are the instructions where destination is inherently used as
  * one of the sources. This is due to map 4 operands instruction into our 
  * three operand LIL instruction.
- * NOTE: SHUFFLE and ireg2vreg instructions may keep the destination unchanged
+ * NOTE: 1. SHUFFLE and ireg2vreg instructions may keep the destination unchanged
  * at certain positions. So, destination is also implicitly used for them
+ *       2. DIV, UDIV, DIVS, UDIVS : handled specially 
  */
 #define IS_DEST_INUSE_IMPLICITLY(i_) ((i_) == FMAC || (i_) == FMACD || \
                                       (i_) == VFMAC || (i_) == VDMAC || \
@@ -1007,7 +1021,7 @@ char *instmnem[] =
                               (i_) == MULS   || (i_) == UMULS || \
                               (i_) == DIVS   || (i_) == UDIVS || \
                               (i_) == CMPS   || (i_) == MOVS || \
-                              (i_) == NEGS   || (i_) == ABSS )
+                              (i_) == NEGS  )
 
 #define IS_SHUFFLE_OP(i_)   ( (i_) == VFSHUF   || (i_) == VDSHUF || \
                               (i_) == VSSHUF   || (i_) == VISHUF )

--- a/iFKO/FKO/include/fko_optloop.h
+++ b/iFKO/FKO/include/fko_optloop.h
@@ -22,7 +22,7 @@ void AddLoopControl(LOOPQ *lp, INSTQ *ipinit, INSTQ *ipupdate, INSTQ *ippost,
 void KillLoopControl(LOOPQ *lp);
 ILIST *FindIndexRef(BLIST *scope, short I);
 ILIST *FindIndexRefInArray(BLIST *scope, short I);
-void UpdatePointerLoads(BLIST *scope, struct ptrinfo *pbase, int UR);
+void UpdatePointerLoads(BLIST *scope, struct ptrinfo *pbase, int UR, int unroll);
 INSTQ *KillPointerUpdates(struct ptrinfo *pbase, int UR);
 struct ptrinfo *FindMovingPointers(BLIST *scope);
 void UnrollCleanup(LOOPQ *lp, int unroll);

--- a/iFKO/FKO/include/fko_optreg.h
+++ b/iFKO/FKO/include/fko_optreg.h
@@ -19,4 +19,5 @@ int DoRemoveOneUseLoads(BLIST *scope);
 int DoLastUseLoadRemoval(BLIST *scope);
 int DoReverseCopyProp(BLIST *scope);
 int DoEnforceLoadStore(BLIST *scope);
+int DoOptArchSpecInst(BLIST *scope);
 #endif

--- a/iFKO/FKO/src/h2l.c
+++ b/iFKO/FKO/src/h2l.c
@@ -697,7 +697,7 @@ void DoArith(short dest, short src0, char op, short src1)
          else
             InsNewInst(NULL, NULL, NULL, LD, -rs1, SToff[src1-1].sa[2], 0);
          InsNewInst(NULL, NULL, NULL, DIV, -rd, -rs0, -rs1);
-         fprintf(stderr, "DIV %d, %d, %d\n", -rd, -rs0, -rs1);
+         /*fprintf(stderr, "DIV %d, %d, %d\n", -rd, -rs0, -rs1);*/
          LocalStore(dest, rd);
          GetReg(-1);
          return;

--- a/iFKO/FKO/src/h2l.c
+++ b/iFKO/FKO/src/h2l.c
@@ -658,20 +658,17 @@ void Handle2dArrayPtrArith(short dest, short src0, char op, short src1)
    }
 }
 
-
 void DoArith(short dest, short src0, char op, short src1)
 {
-   short rd, rs0, rs1, type;
+   short rd, rs0, rs1, rs2, type;
    enum inst inst;
    extern int DTnzerod, DTnzero, DTabs, DTabsd;
 
    if (IS_PTR(STflag[dest-1]))
    {
-#if 1
       if (SToff[dest-1].sa[3]) /* 2D array pointer? */
          Handle2dArrayPtrArith(dest, src0, op, src1);
       else
-#endif
          HandlePtrArith(dest, src0, op, src1);
       return;
    }
@@ -706,7 +703,52 @@ void DoArith(short dest, short src0, char op, short src1)
          return;
       }
    #endif
-   rd = rs0 = LocalLoad(src0);
+/*
+ * if 3 operands supported and dest != src0, use separate regs for destination
+ * NOTE: for MAC, dest is also in use, so load dest later
+ */
+   rs0 = LocalLoad(src0);
+   if (op != 'm' && dest != src0)
+   {
+      switch (type)
+      {
+         case T_INT:
+            #ifdef ArchHasINTthreeOps
+               rd = GetReg(type);
+            #else
+               rd = rs0;
+            #endif
+            break;
+         case T_FLOAT: case T_DOUBLE: 
+            #ifdef ArchHasFPthreeOps
+               rd = GetReg(type);
+            #else
+               rd = rs0;
+            #endif
+            break;
+         case T_VINT:
+            #ifdef ArchHasVINTthreeOps
+               rd = GetReg(type);
+            #else
+               rd = rs0;
+            #endif
+            break;
+         case T_VFLOAT: case T_VDOUBLE:
+            #ifdef ArchHasVFPthreeOps
+               rd = GetReg(type);
+            #else
+               rd = rs0;
+            #endif
+            break;
+         default: 
+            fko_error(__LINE__, "Unknown type!!!");
+      }
+   }
+   else
+      rd = rs0;
+/*
+ * 2nd src
+ */
    if (op != 'n' && op != 'a')
    {
       if (src0 != src1)
@@ -720,6 +762,9 @@ void DoArith(short dest, short src0, char op, short src1)
    if ( (op == '%' || op == '>' || op == '<') && 
         (type != T_INT && type != T_SHORT) )
       fko_error(__LINE__,"modulo and shift not defined for non-integer types");
+/*
+ * find appropriate inst
+ */
    switch(op)
    {
    case '+': /* dest = src0 + src1 */
@@ -734,14 +779,12 @@ void DoArith(short dest, short src0, char op, short src1)
       case T_DOUBLE:
          inst = FADDD;
          break;
-#if 1
       case T_VFLOAT:
          inst = VFADD;
          break;
       case T_VDOUBLE:
          inst = VDADD;
          break;
-#endif
       }
       break;
    case '-': /* dest = src0 - src1 */
@@ -756,14 +799,12 @@ void DoArith(short dest, short src0, char op, short src1)
       case T_DOUBLE:
          inst = FSUBD;
          break;
-#if 1
       case T_VFLOAT:
          inst = VFSUB;
          break;
       case T_VDOUBLE:
          inst = VDSUB;
          break;
-#endif
       }
       break;
    case '*': /* dest = src0 * src1 */
@@ -778,14 +819,12 @@ void DoArith(short dest, short src0, char op, short src1)
       case T_DOUBLE:
          inst = FMULD;
          break;
-#if 1
       case T_VFLOAT:
          inst = VFMUL;
          break;
       case T_VDOUBLE:
          inst = VDMUL;
          break;
-#endif
       }
       break;
    case '/': /* dest = src0 / src1 */
@@ -800,14 +839,12 @@ void DoArith(short dest, short src0, char op, short src1)
       case T_DOUBLE:
          inst = FDIVD;
          break;
-#if 1
       case T_VFLOAT:
          inst = VFDIV;
          break;
       case T_VDOUBLE:
          inst = VDDIV;
          break;
-#endif
       }
       break;
    case '%': /* dest = src0 % src1 */
@@ -827,48 +864,56 @@ void DoArith(short dest, short src0, char op, short src1)
          #ifdef ArchHasMAC
             rd = LocalLoad(dest);
             if (type == T_FLOAT) inst = FMAC;
-#if 1            
             else if (type == T_DOUBLE) inst = FMACD;
             else if (type == T_VFLOAT) inst = VFMAC;
             else if (type == T_VDOUBLE) inst = VDMAC;
             else 
                fko_error(__LINE__, "MAC not supported with this type!");
-#else
-            else inst = FMACD; /*Majedul: was a typo, corrected it. */
-#endif
          #else
-            if (type == T_FLOAT)
+            switch(type)
             {
-               InsNewInst(NULL, NULL, NULL, FMUL, -rs0, -rs0, -rs1);
-               inst = FADD;
+               case T_FLOAT: 
+                  #ifdef ArchHasFPthreeOps
+                     rs2 = GetReg(type);
+                  #else
+                     rs2 = rs0;
+                  #endif
+                  InsNewInst(NULL, NULL, NULL, FMUL, -rs2, -rs0, -rs1);
+                  inst = FADD;
+                  break;
+               case T_DOUBLE:
+                  #ifdef ArchHasFPthreeOps
+                     rs2 = GetReg(type);
+                  #else
+                     rs2 = rs0;
+                  #endif
+                  InsNewInst(NULL, NULL, NULL, FMULD, -rs2, -rs0, -rs1);
+                  inst = FADDD;
+                  break;
+               case T_VFLOAT: 
+                  #ifdef ArchHasVFPthreeOps
+                     rs2 = GetReg(type);
+                  #else
+                     rs2 = rs0;
+                  #endif
+                  InsNewInst(NULL, NULL, NULL, VFMUL, -rs2, -rs0, -rs1);
+                  inst = VFADD;
+               case T_VDOUBLE:
+                  #ifdef ArchHasVFPthreeOps
+                     rs2 = GetReg(type);
+                  #else
+                     rs2 = rs0;
+                  #endif
+                  InsNewInst(NULL, NULL, NULL, VDMUL, -rs2, -rs0, -rs1);
+                  inst = VDADD;
+                  break;
+               default: 
+                  fko_error(stderr, "MAC not supported with this type!");
             }
-#if 1
-            else if (type == T_DOUBLE)
-            {
-               InsNewInst(NULL, NULL, NULL, FMULD, -rs0, -rs0, -rs1);
-               inst = FADDD;
-            }
-            else if (type == T_VFLOAT)
-            {
-               InsNewInst(NULL, NULL, NULL, VFMUL, -rs0, -rs0, -rs1);
-               inst = VFADD;
-            }
-            else if (type == T_VDOUBLE)
-            {
-               InsNewInst(NULL, NULL, NULL, VDMUL, -rs0, -rs0, -rs1);
-               inst = VDADD;
-            }
-            else
-               fko_error(__LINE__, "MAC not supported with this type!");
-
-#else
-            else
-            {
-               InsNewInst(NULL, NULL, NULL, FMULD, -rs0, -rs0, -rs1);
-               inst = FADDD;
-            }
-#endif            
-            rs1 = rs0;
+/*
+ *          for addition, dest is also src0
+ */
+            rs1 = rs2;
             rs0 = rd = LocalLoad(dest);
          #endif
       }

--- a/iFKO/FKO/src/inst.c
+++ b/iFKO/FKO/src/inst.c
@@ -415,7 +415,6 @@ void PrintThisInst(FILE *fpout, int i, INSTQ *ip)
  *    This is to print LIL without live-vars. To enable live-vars prints,
  *    enable the #if and enable header prints in PrintInst function
  */   
-      //fprintf(stderr,"%d->%s\n",inst,instmnem[inst]);
       fprintf(fpout, shortform, i, instmnem[inst], op1, op2str(op1),
               op2, op2str(op2), op3, op2str(op3));
 #endif

--- a/iFKO/FKO/src/l2a.c
+++ b/iFKO/FKO/src/l2a.c
@@ -1872,12 +1872,12 @@ struct assmln *lil2ass(BBLOCK *bbase)
                if (op3 < 0 )
                   ap->next = PrintAssln("\tvaddss\t%s,%s,%s\n", 
                                         archxmmregs[GetDregID(op3)],
-	                                archxmmregs[-FREGBEG-op1],
+	                                archxmmregs[-FREGBEG-op2],
 	                                archxmmregs[-FREGBEG-op1]);
                else
                   ap->next = PrintAssln("\tvaddss\t%s,%s,%s\n", 
                                         GetDregOrDeref(op3),
-	                                archxmmregs[-FREGBEG-op1],
+	                                archxmmregs[-FREGBEG-op2],
 	                                archxmmregs[-FREGBEG-op1]);
 
             #else
@@ -3212,7 +3212,7 @@ struct assmln *lil2ass(BBLOCK *bbase)
 /*
  *       Allow scalar to vector reg to reg move
  *       two variation :
- * 1. VDMOVS vr0, sr, vr1  // vr0[0] = vr2[0], vr0[vlen-1: 1] = vr1[vlen-1: 1]
+ * 1. VDMOVS vr0, sr, vr1  // vr0[0] = sr, vr0[vlen-1: 1] = vr1[vlen-1: 1]
  * 2. VDMOVS sr, vr, 0     // sr = vr[0]
  *       here vr0 and vr1 should be vector register
  */

--- a/iFKO/FKO/src/l2a.c
+++ b/iFKO/FKO/src/l2a.c
@@ -1281,6 +1281,41 @@ struct assmln *lil2ass(BBLOCK *bbase)
          #endif
          break;
    #ifdef X86_64
+      case LEAS2: LEAS4: LEAS8:
+         fko_error(__LINE__, "Not implemented LEA for short!!");
+         break;
+   #endif
+   #ifdef X86  
+/*
+ *    HERE HERE, we implement LEA for only following specific cases where we can
+ *    reduce register usage using this special instruction:
+ *       1) pA += incA;
+ *       2) pA = pA0 + incA;
+ *    NOTE: it's not a general implementation of lea in x86
+ */
+      case LEA2:
+         assert(op1 < 0 && op2 < 0 && op3 < 0);
+         ap->next = PrintAssln("\tlea\t(%s, %s, 2), %s\n", 
+                                  archiregs[-IREGBEG-op2], 
+                                  archiregs[-IREGBEG-op3], 
+                                  archiregs[-IREGBEG-op1]);
+         break;
+      case LEA4:
+         assert(op1 < 0 && op2 < 0 && op3 < 0);
+         ap->next = PrintAssln("\tlea\t(%s, %s, 4), %s\n", 
+                                  archiregs[-IREGBEG-op2], 
+                                  archiregs[-IREGBEG-op3], 
+                                  archiregs[-IREGBEG-op1]);
+         break;
+      case LEA8:
+         assert(op1 < 0 && op2 < 0 && op3 < 0);
+         ap->next = PrintAssln("\tlea\t(%s, %s, 8), %s\n", 
+                                  archiregs[-IREGBEG-op2], 
+                                  archiregs[-IREGBEG-op3], 
+                                  archiregs[-IREGBEG-op1]);
+         break;
+   #endif
+   #ifdef X86_64
       case CVTSI: /* convert 32bit to 64 bit int*/
 /*
  *    Majedul: we are using  movslq for this 
@@ -4696,6 +4731,9 @@ struct assmln *lil2ass(BBLOCK *bbase)
  *          7654 3211
  *          7654 3322
  *          7654 3232
+ *          
+ *          FIXME: legacy SSE may get converted into VEX.128 instruction using
+ *          -mavx. But all VEX.128 zeros the upper-half of the YMM register
  */
             /* 7654 7654 */
             if (cp[7] == 7 && cp[6] == 6 && cp[5] == 5 && cp[4] == 4 &&

--- a/iFKO/FKO/src/misc.c
+++ b/iFKO/FKO/src/misc.c
@@ -336,7 +336,7 @@ void fko_error(int errno, ...)
    vfprintf(stderr, form, argptr);
    va_end(argptr);
    fprintf(stderr, "\nExiting iFKO with error number %d\n", errno);
-#if 0
+#if 1
    exit(errno); 
 #else
     while(1);

--- a/iFKO/FKO/src/optsimd.c
+++ b/iFKO/FKO/src/optsimd.c
@@ -16296,7 +16296,7 @@ int CheckRedVarforVectors(SLP_VECTOR *vlist, BBLOCK *blk)
          vl->redvar = rvar;
          /*fprintf(stderr, "vec=%s, redvar=%s\n", STname[vl->vec-1], 
                STname[rvar-1]);*/
-         fprintf(stderr, "vec=%s, redvar=%s\n", STname[vl->vec-1], 
+         fko_warn(__LINE__, "vec=%s, redvar=%s\n", STname[vl->vec-1], 
                STname[rvar-1]);
       }
    }
@@ -17749,7 +17749,8 @@ int PreSLPchecking(LOOPQ *lp)
  */
    if (!lp->posttails || lp->posttails->next)
    {
-      fprintf(stderr, "only one posttails is considered in SLP\n");
+      /*fprintf(stderr, "only one posttails is considered in SLP\n");*/
+      fko_warn(__LINE__, "only one posttails is considered in SLP\n");
       return(1);
    }
 /*
@@ -17757,7 +17758,8 @@ int PreSLPchecking(LOOPQ *lp)
  */
    if (!lp->blocks || lp->blocks->next)
    {
-      fprintf(stderr, "only one block is considered in SLP\n");
+      /*fprintf(stderr, "only one block is considered in SLP\n");*/
+      fko_warn(__LINE__, "only one block is considered in SLP\n");
       return(1);
    }
 #if 0   
@@ -18510,9 +18512,6 @@ int BlkPrivateVariableRename(BBLOCK *blk)
             vp = STstrlookup(vnam);
             if (!vp)
                vp = InsertNewLocal(vnam, FLAG2TYPE(STflag[sp[i]-1]));
-            //PrintVars(stderr, "ip->set: ", ip->set);
-            //PrintThisInst(stderr, 0, ip);
-            //fprintf(stderr, "var = %s(%d)\n", STname[sp[i]-1], sp[i]);
             assert(ip->inst[1] > 0);
             assert(STpts2[ip->inst[1]-1] == sp[i]);
             /*if (STpts2[ip->inst[1]-1] != sp[i])
@@ -19234,8 +19233,10 @@ SLP_VECTOR *DoSingleBlkSLP(BBLOCK *blk, INT_BVI ivin, SLP_VECTOR *vi,
  */
             else if (nelem) 
             {
-               PrintVectors(stderr, vl);
-               fprintf(stderr, "mixed up=%s(%d,%d) !!", STname[vl->vec-1], 
+               /*PrintVectors(stderr, vl);*/
+               /*fprintf(stderr, "mixed up=%s(%d,%d) !!", STname[vl->vec-1], 
+                       nelem, vl->vlen);*/
+               fko_warn(__LINE__, "mixed up=%s(%d,%d) !!", STname[vl->vec-1], 
                        nelem, vl->vlen);
                mixed = 1;
 /*
@@ -19450,7 +19451,7 @@ int IsSlpConsistent(SLP_VECTOR *v0, SLP_VECTOR *v1, SLP_VECTOR *v2,
  * recompute CFG and it will destroy the loop structure... we need to figure
  * out live-out vectors without recomputing data-flow.
  */
-   //fprintf(stderr, "++++++checking consistency at prehead -> loop\n");
+   /*fprintf(stderr, "++++++checking consistency at prehead -> loop\n");*/
    res = IsSlpFlowConsistent(loop->preheader, loop->header, v1, v0, 
             loop->header->ins, loop->preheader->outs);
 #if 0
@@ -19463,10 +19464,10 @@ int IsSlpConsistent(SLP_VECTOR *v0, SLP_VECTOR *v1, SLP_VECTOR *v2,
       if (vl->isused)
          PrintThisVector(stderr,vl);
 #endif
-   //fprintf(stderr, "+++++checking consistency at loop -> posttail\n");
+   /*fprintf(stderr, "+++++checking consistency at loop -> posttail\n");*/
    res += IsSlpFlowConsistent(loop->tails->blk, loop->posttails->blk, v0, v2, 
             loop->posttails->blk->ins, loop->tails->blk->outs);
-   //fprintf(stderr, "+++++checking consistency at posttail -> prehead\n");
+   /*fprintf(stderr, "+++++checking consistency at posttail -> prehead\n");*/
    res += IsSlpFlowConsistent(loop->posttails->blk, loop->preheader, v2, v1, 
             loop->preheader->ins, loop->posttails->blk->outs);
 
@@ -19673,14 +19674,15 @@ SLP_VECTOR *DoLoopNestVec(LPLIST *lpl, short *ptrs, int *err, int *vres)
 /*
  * exit condition of the recursion: when it reaches optloop
  */
-   if (!lpl->next ) //optloop
+   if (!lpl->next ) /*optloop*/
    {
       if (VECT_FLAG & VECT_SLP)
       {
          assert(lpl->loop->blocks && !lpl->loop->blocks->next); //single blk
          if (PreSLPchecking(lpl->loop)) /* needed for other optimizations */
          {
-            fprintf(stderr, "Prechecking failed for SLP\n");
+            /*fprintf(stderr, "Prechecking failed for SLP\n");*/
+            fko_warn(__LINE__, "Prechecking failed for SLP\n");
             *err = 1;
             (*vres) = 0;
             return(NULL);
@@ -19690,31 +19692,17 @@ SLP_VECTOR *DoLoopNestVec(LPLIST *lpl, short *ptrs, int *err, int *vres)
          ins = BitVecCopy(ins, blk->ins);
          FilterOutRegs(ins);
          vo = NULL;
-#if 0
-         fprintf(stderr, "*****************Applying SLP on optloop\n");
-         fprintf(stderr, "Scalar codes:\n");
-         PrintThisInstQ(stderr, lpl->loop->blocks->blk->inst1);
-         fprintf(stderr, "==================================\n");
-#endif
          vo = DoSingleBlkSLP(lpl->loop->blocks->blk, ins, vo, ptrs, err, 0);
          KillBitVec(ins);
          if (*err)
          {
-            fprintf(stderr, "SLP fails in optloop!\n");
+            /*fprintf(stderr, "SLP fails in optloop!\n");*/
+            fko_warn(__LINE__, "SLP fails in optloop!\n");
             KillVlist(vo);
             (*vres) = 0;
             return NULL;
          }
          (*vres) = 1;
-#if 0
-         {
-            //extern BBLOCK *bbbase;
-            fprintf(stderr, "vectorized loop block:\n");
-            //PrintInst(stderr, bbbase);
-            PrintThisInstQ(stderr, lpl->loop->blocks->blk->inst1); 
-            //exit(0);
-         }
-#endif
 /*
  *       NOTE: no need, since we ensure there is no scalar and vector inst  
  *       for a varibale at the same time
@@ -19748,25 +19736,12 @@ SLP_VECTOR *DoLoopNestVec(LPLIST *lpl, short *ptrs, int *err, int *vres)
          /*FinalizeVectorCleanup(lpl->loop, 1);*/
          SKIP_PELOGUE = 0;
          /*SKIP_PEELING = 0;*/  
-#if 0
-         {
-            extern BBLOCK *bbbase;
-            fprintf(stderr, "vectorized loop block:\n");
-            PrintInst(stderr, bbbase);
-            exit(0);
-         }
-#endif
 /*
  *       NOTE: generating these vectors from optloop won't help slp for next 
  *       steps except the posttail's vvrsum codes. They are main controlled by
  *       NSLP_ACC and NSLP_SCAL flag
  */
          vo = CreateVlistFromLoop(lpl->loop);
-#if 0
-         fprintf(stderr, "generated vectors");
-         PrintVectors(stderr, vo);
-         exit(0);
-#endif
          return(vo);
       }
       else 
@@ -20103,7 +20078,10 @@ int LoopNestVec(short *ptrs, int *bvlpl)
 
 #endif
    KillAllLPlist(ll); 
-
+/*
+ * Optimize loop control 
+ */
+   OptimizeLoopControl(optloop, 1, 1, NULL);
 /*
  * recompute the CFG
  */
@@ -20151,7 +20129,7 @@ int LoopNestOpt()
       if (optloop && IsLoopUnswitchable(lpnest))
       {
          /*fprintf(stderr, "Loop unswitchable!!\n");*/
-         fprintf(stderr, "Loop unswitchable!!\n");
+         fko_warn(__LINE__, "Loop unswitchable!!\n");
          LoopUnswitch(lpnest);
          InvalidateLoopInfo();
          bbbase = NewBasicBlocks(bbbase);

--- a/iFKO/FKO/src/symtab.c
+++ b/iFKO/FKO/src/symtab.c
@@ -17,7 +17,6 @@
  *    already freed)
  *
  */
-
 char **STname;
 union valoff *SToff;
 int *STflag;
@@ -34,9 +33,10 @@ static int nviloc=0;
 
 int LOCSIZE=0, LOCALIGN=0, NPARA=0;
 
-#define STCHUNK 1024    /* increased for safety ...*/
+#define STCHUNK 1024 
 #define DTCHUNK 1024
 #define DCCHUNK 256
+#define MAXENTRY 32767 
 
 static void GetNewSymtab(int chunk)
 {
@@ -86,6 +86,9 @@ static short STnew(char *name, int flag, union valoff off)
    STflag[N] = flag;
    SToff[N] = off;
    STpts2[N] = 0;
+#if 1
+   assert(N!=MAXENTRY);
+#endif
    return(++N);
 }
 
@@ -154,6 +157,9 @@ short AddSTarr(short ptr, short ndim, short *ldas)
  */
    STarr[Narr].cldas = NULL; 
    STarr[Narr].colptrs = NULL; 
+#if 1
+   assert(Narr!=MAXENTRY);
+#endif
    return (++Narr);
 }
 
@@ -202,6 +208,9 @@ static int DTCnew(INT_DTC val)
    if (Ndc == TNdc)
       GetNewDtcTable(DCCHUNK);
    DTcon[Ndc] = val;
+#if 1
+   assert(Ndc!=MAXENTRY);
+#endif
    return(++Ndc);
 }
 


### PR DESCRIPTION
Added following updates:
1. Added peephole optimization to use LEA in X86 when possible
2. Added Arch Macro for three operands ops to reduce register to register move
3. Added a strategy to remove duplicate prefetch insts considering cahce linesize when unrolling
4. Some issues fixed: assertion on symbol table overflow, doubled chunk size each time in bvec, etc.
