### PR TITLE
new syrk supporting mu!=nu (when one is multiple of other)

### DIFF
--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -855,6 +855,16 @@ int Mjoin(PATL,herk_@(rt))
     const TYPE, const TYPE*, ATL_CSZT, const TYPE, TYPE*,ATL_CSZT);
 #endif
 @endwhile
+@whiledef rt op ip
+int Mjoin(PATL,@(rt)syrk)
+   (const enum ATLAS_UPLO, const enum ATLAS_TRANS, ATL_CSZT, ATL_CSZT,
+    const SCALAR, const TYPE*, ATL_CSZT, const SCALAR, TYPE*,ATL_CSZT);
+#ifdef TCPLX
+int Mjoin(PATL,@(rt)herk)
+   (const enum ATLAS_UPLO, const enum ATLAS_TRANS, ATL_CSZT, ATL_CSZT,
+    const TYPE, const TYPE*, ATL_CSZT, const TYPE, TYPE*,ATL_CSZT);
+#endif
+@endwhile
 /*
  * Functions for testing Info return flag
  */

--- a/AtlasBase/Clint/atlas-make.base
+++ b/AtlasBase/Clint/atlas-make.base
@@ -2720,8 +2720,10 @@ gen_@(rt) : $(BINdir)/xextract $(mySRCdir)/atlas-mmkg.base
                 -def cpvl $(cpvlen) -def beta $(beta) -def alpha $(alpha)
 @endwhile
 @whiledef rt blk2C C2blk
-gen_sy@(rt) : $(BINdir)/xextract $(mySRCdir)/atlas-mmkg.base
-	$(extC) -b $(mySRCdir)/atlas-mmkg.base -o $(rt) pre=$(pre) vec=NA \
+@skip gen_sy@(rt) : $(BINdir)/xextract $(mySRCdir)/atlas-mmkg.base
+@skip 	$(extC) -b $(mySRCdir)/atlas-mmkg.base -o $(rt) pre=$(pre) vec=NA \
+gen_sy@(rt) : $(BINdir)/xextract $(mySRCdir)/atlas-syrk-mmkg.base
+	$(extC) -b $(mySRCdir)/atlas-syrk-mmkg.base -o $(rt) pre=$(pre) vec=NA \
                 rout=@(rt) -def vl $(vlen) -def mu $(mu) -def nu $(nu) \
                 -def cpvl $(cpvlen) -def beta $(beta) -def alpha $(alpha) \
                 -def TRI 1
@@ -2811,9 +2813,10 @@ x@(rt) : $(mySRCdir)/@(rt).c $(parsedeps)
 @endwhile
 # vec=[no,kdim,mdim]
 @multidef tri  0      1
+@multidef bb mmkg syrk-mmkg
 @whiledef rt amm amsyrk
 gen_@(rt) : $(BINdir)/xextract
-	$(extC) -b $(mySRCdir)/atlas-mmkg.base -o $(rt) pre=$(pre) vec=$(vec) \
+	$(extC) -b $(mySRCdir)/atlas-@(bb).base -o $(rt) pre=$(pre) vec=$(vec) \
            rout=amm -def vl $(vlen) -def mu $(mu) -def nu $(nu) -def ku $(ku) \
            -def kp $(kp) -def bc $(bcast) -def kb $(KB) \
            -def pf $(pf) -def pfLS $(pfLS) -def TRI @(tri)
@@ -2823,6 +2826,7 @@ gen_@(rt)_fko : $(BINdir)/xextract
            -def kp $(kp) -def bc $(bcast) -def kb $(KB) \
            -def pf $(pf) -def pfLS $(pfLS) -def TRI @(tri)
    @undef tri
+   @undef bb
 @endwhile
 gen_amm_sse : $(BINdir)/xextract
 	$(extC) -def mu "${mu}" -def nu "${nu}" -def kmaj "${kmaj}" \

--- a/AtlasBase/Clint/atlas-syrk-mmkg.base
+++ b/AtlasBase/Clint/atlas-syrk-mmkg.base
@@ -1,0 +1,4597 @@
+@ROUT !
+   @define pre @@(@pre)@
+   @PRE S C
+      @define typ @float@
+      @define sz @4@
+   @PRE D Z
+      @define sz @8@
+      @define typ @double@
+   @PRE !
+#define ATL_VLEN @(vl)
+#if !defined(SREAL) && !defined(DREAL) && !defined(SCPLX) && !defined(DCPLX)
+   @PRE C `   #define SCPLX 1`
+   @PRE S `   #define SREAL 1`
+   @PRE D `   #define DREAL 1`
+   @PRE Z `   #define DCPLX 1`
+#endif
+@ifdef ! TRI
+   @iexp TRI 0
+@endifdef
+@SKIP TRI = 1 means lower triangular C (SYRK)
+@iif TRI = 1
+   @define ma @1@
+   @define na @1@
+   @iif mu ! nu
+      @iif mu > nu
+         @iexp ma @(nu) @(mu) / 
+         @iexp mma @(ma) @(nu) *
+         @iif mu ! mma
+           @abort "mu must be mupliple of nu"  
+         @endiif
+         @skip @print ************ma = @(ma)
+      @endiif
+      @iif nu > mu
+         @iexp na @(mu) @(nu) / 
+         @iexp nna @(na) @(mu) *
+         @iif nu ! nna
+           @abort "nu must be mupliple of mu"  
+         @endiif
+         @skip @print ************na = @(na)
+      @endiif
+      @define mEn @0@
+   @endiif
+   @iif mu = nu
+      @define mEn @1@
+   @endiif
+@endiif
+@skip ************************kernel gen**************************************
+@ROUT amm
+@beginskip
+Should be called with VEC=[NO,MDIM,KDIM], TYPE=[SREAL,DREAL] and 
+following defines:
+   mu : m (scalar) unrolling
+   nu : n (scalar) unrolling
+   ku : k (scalar) unrolling
+   vl : vector length to use
+The following can be optionally defined:
+   kb : compile-time constant K loop bound to use
+   kp : # of kits to peel, must be a multiple of vku!
+   bc : don't define or set to 1 to use ATL_vbcast, 0 to use vld/vsplat
+   pf : bit vec describing prefetch strategy
+   pfLS : line size to assume for prefetch (64 bytes by default)
+   bc : now used a bitvector, default 1, with following meanings:
+    BPOS: SET MEANING
+      0 : use bcast (else use splat) for B load (ignored for K-vec)
+      1 : use only 1 register for B loads (ignored if using splat)
+      2 : nnu=1 (else need N-loop)
+      3 : nmu=1 (else need M-loop)
+
+pf bit location meanings:
+   prefC always done as just next mu*nu block
+   pfA/B : can prefetch next mu/nu A/B within K-loop
+   nA/nB : can prefetch next block outside K-loop 
+   take pf integer bitvec bit/additive means:
+      0/1   : prefetch C before K-loop
+      1/2   : prefetch next block of A before K-loop
+      2/4   : prefetch next block of B before K-loop
+      3/8   : prefetch next mu*K iter of A inside K-loop
+      4/16  : prefetch next nu*K iter of B inside K-loop
+      5/32  : pref of C should use ATL_pfl1 instead of ATL_pfl2
+      6/64  : pref of next blk of A should use ATL_pfl1 not ATL_pfl2
+      7/128 : pref of next blk of B should use ATL_pfl1 not ATL_pfl2
+      8/256 : pref of C should use ATL_pflX instead of ATL_pflX
+      9/512 : pref of next blk of A should use ATL_pflX not ATL_pfl2
+     10/1024: pref of next blk of B should use ATL_pflX not ATL_pfl2
+     11/2048: K-loop pref of A use ATL_pfl1 not ATL_pfl2
+     12/4096: K-loop pref of B use ATL_pfl1 not ATL_pfl2
+     13/8192: K-loop pref of A use ATL_pflX not ATL_pfl2
+    14/16384: K-loop pref of B use ATL_pflX not ATL_pfl2
+
+   We'll put pf bitvec in rout name, and then the search will find that
+   we want to pref everything to L1 for small NB, only C &  block of A for
+   medium size, and no pref for large, for instance.
+
+During tuning, think about several regions for prefetch:
+1. pref pfnA&B to L1:  m*n + 2*k*(m+n) < L1
+   -> n^2 + 4n^2 < L2 ==> nb <= sqrt(L1/5)
+2. pref B to L1, A to L2: m*n + 2*k*n + m*k < L1
+   -> n^2 + 2n^2 + n^2 < L1 ==> nb <= sqrt(L1/4)
+3. pref A&B to L2 so long as all 5 blocks fit (L2 size not known)
+4. pref only one of nA/B to L2
+5. No prefetch of next blocks (maybe internal prefetch)
+@endskip
+@SKIP extract info from bc, then set it to bcast value
+@ifdef ! bc
+   @iexp bc 1
+@endifdef
+@skip if ((bc&1) == 0 && (bc&2) == 2) bc ^= 2
+@iif @iexp @(bc) 1 & 0 = @(bc) 2 & 2 = &
+   @iexp bc @(bc) 2 ^
+@endiif
+@iexp B1R @(bc) 2 & 0 !
+@iexp DONLOOP @(bc) 4 & 0 =
+@iexp DOMLOOP @(bc) 8 & 0 =
+@iexp bc @(bc) 1 &
+@print bc=@(bc) B1R=@(B1R) DO_N,M=@(DONLOOP),@(DONLOOP)
+@SKIP KVEC & UNVEC can't use splat, so define bcast!
+@VEC KDIM NO
+@ifdef bc
+   @undef bc
+@endifdef
+@iexp bc 0 1 +
+@VEC MDIM
+@ifdef ! bc
+   @iexp bc 0 1 +
+@endifdef
+@VEC !
+@ifdef ! pf
+   @define pf @1@
+@endifdef
+@ifdef ! pfLS
+   @define pfLS @64@
+@endifdef
+@iif pfLS = 0
+   @define pfLS @64@
+@endiif
+@iexp pfLS @(sz) @(pfLS) /
+@iexp kk @(pf) 32 &
+@iif kk ! 0
+   @define pfC @ATL_pfl1W@
+@endiif
+@iexp kk @(pf) 256 &
+@iif kk ! 0
+   @define pfC @ATL_pflXW@
+@endiif
+@ifdef ! pfC
+   @define pfC @ATL_pfl2W@
+@endifdef
+@iexp kk @(pf) 64 &
+@iif kk ! 0
+   @define pfA @ATL_pfl1R@
+@endiif
+@iexp kk @(pf) 512 &
+@iif kk ! 0
+   @define pfA @ATL_pflXR@
+@endiif
+@ifdef ! pfA
+   @define pfA @ATL_pfl2R@
+@endifdef
+@iexp kk @(pf) 128 &
+@iif kk ! 0
+   @define pfB @ATL_pfl1R@
+@endiif
+@iexp kk @(pf) 1024 &
+@iif kk ! 0
+   @define pfB @ATL_pflXR@
+@endiif
+@ifdef ! pfB
+   @define pfB @ATL_pfl2R@
+@endifdef
+@iexp kk @(pf) 8 &
+@iif kk ! 0
+   @define pfAk @ATL_pfl2R@
+   @iexp kk @(pf) 2048 &
+   @iif kk ! 0
+      @undef pfAk
+      @define pfAk @ATL_pfl1R@
+   @endiif
+   @iexp kk @(pf) 8192 &
+   @iif kk ! 0
+      @undef pfAk
+      @define pfAk @ATL_pflXR@
+   @endiif
+@endiif
+@iexp kk @(pf) 16 &
+@iif kk ! 0
+   @define pfBk @ATL_pfl2R@
+   @iexp kk @(pf) 4096 &
+   @iif kk ! 0
+      @undef pfBk
+      @define pfBk @ATL_pfl1R@
+   @endiif
+   @iexp kk @(pf) 16384 &
+   @iif kk ! 0
+      @undef pfBk
+      @define pfBk @ATL_pflXR@
+   @endiif
+@endiif
+@SKIP npfC = (pf&1) * ((mu*nu + pfLS -1) / pfLS)
+@iexp npfC 1 @(pf) & @(pfLS) @(nu) @(mu) * @(pfLS) + -1 + / *
+@iexp npfA @(pfLS) 1 @(pf) r 1 & @(mu) @(nu) * * /
+@iexp npfB @(pfLS) 2 @(pf) r 1 & @(mu) @(nu) * * /
+@iexp npf @(npfC) @(npfA) +
+@iif npfA ! 0
+   @iexp npfA @(npfA) @(npfC) +
+@endiif
+@iif npfB ! 0
+   @iexp npf @(npf) @(npfB) +
+   @iexp npfB @(npf) 0 +
+@endiif
+@skip bc = (bc != 0 || (vl < 2) || nu%vl != 0);
+@iexp bc 0 @(bc) ! 2 @(vl) < | @(vl) @(nu) % 0 ! |
+@iif TRI = 1
+   @VEC KDIM
+      @iif ku ! vl
+         @abort "ku (@(ku)) must equal vlen (@(vl))!"
+      @endiif
+   @VEC JJJJJ
+      @iif ku ! 1
+         @abort "ku must be 1, but it is @(ku)!"
+      @endiif
+   @VEC !
+@endiif
+#ifndef TYPE
+   #define TYPE @(typ)
+#endif
+#include "atlas_simd.h"
+@iexp pf @(pf) 31 &
+@iif pf ! 0
+#include "atlas_prefetch.h"
+@endiif
+@ifdef ! vl
+   @abort "vl must be defined!"
+@endifdef
+@ifdef ! mu
+   @abort "mu must be defined!"
+@endifdef
+@ifdef ! nu
+   @abort "nu must be defined!"
+@endifdef
+@ifdef ! ku
+   @abort "ku must be defined!"
+@endifdef
+@ifdef ! kb
+   @define kb @0@
+@endifdef
+@iif kb = 0
+   @addkeys KCON=no
+@endiif
+@iif kb ! 0
+   @addkeys KCON=yes
+@endiif
+@iexp vku @(ku) 0 +
+@iexp vmu @(mu) 0 +
+@iexp vnu @(nu) 0 +
+@VEC MDIM
+   @iexp vmu @(vl) @(mu) /
+   @iexp kk @(vmu) @(vl) *
+   @iif kk ! mu
+      @abort "MU=@(mu) illegal with VLEN=@(vl)!"
+   @endiif
+@VEC KDIM
+   @iexp vku @(vl) @(ku) /
+   @iif @iexp @(vku) @(vl) * @(ku) !
+      @abort "KU=@(ku) illegal with VLEN=@(vl)!"
+   @endiif
+@VEC NO
+   @iif vl ! 1
+      @abort "vl must be 1 for scalar code!"
+   @endiif
+@VEC !
+@ifdef ! kp
+   @VEC KDIM `@define kp @@(vl)@`
+   @VEC ! KDIM `@define kp @1@`
+@endifdef
+@VEC KDIM 
+   @iexp vkp @(vl) @(kp) /
+   @iexp kk @(vkp) @(vl) *
+   @iif kk != ku
+      @abort "KP (@(kp)) must be a multiple of ku*VLEN (@(ku)*@(vl))"
+   @endiif
+@VEC ! KDIM
+   @define vkp @@(kp)@
+@VEC !
+@define KB @K@
+@ifdef ! kp
+   @VEC KDIM
+      @define kp @@(vl)@
+   @VEC ! KDIM
+      @define kp @@(vku)@
+   @VEC !
+@endifdef
+@iif vkp < 1
+   @abort "K-peel (kp) must be >= 1!"
+@endiif
+@iexp kk @(ku) @(kp) /
+@iexp kk @(kk) @(ku) *
+@iif kp ! kk
+   @abort "K-peel (@(kp)) must be a multiple of KU=@(ku)!"
+@endiif
+@VEC KDIM
+@SKIP FOR KVEC, kb = CEIL(kb/vlen)*vlen
+@iif kb ! 0
+   @iexp kb @(vl) @(kb) @(vl) -1 + + / @(vl) *
+   @undef KB
+   @define KB @@(kb)@
+   @iif @iexp @(vku) @(kb) %
+      @abort "VKU=@(vku) must be multiple of @(kb)!"
+   @endiif
+@endiif
+@VEC !
+@iif kb > 0
+#define ATL_KBCONST 1
+#ifndef ATL_MM_KB
+   #ifdef KB
+      #define ATL_MM_KB KB
+   #else
+      #define ATL_MM_KB @(kb)
+   #endif
+#endif
+@endiif
+@iif kb = 0
+#ifndef ATL_MM_KB 
+   #ifdef KB
+      #if KB > 0
+         #define ATL_KBCONST 1
+         #define ATL_MM_KB KB
+      #else
+         #define ATL_KBCONST 0
+         #define ATL_MM_KB K
+      #endif
+   #else
+      #define ATL_KBCONST 0
+      #define ATL_MM_KB K
+   #endif
+#else
+   #if ATL_MM_KB > 0
+      #define ATL_KBCONST 1
+   #else
+      #undef ATL_MM_KB
+      #define ATL_MM_KB K
+      #define ATL_KBCONST 0
+   #endif
+#endif
+@endiif
+@VEC ! NO
+#ifdef BETA1
+   #define ATL_vbeta(p_, d_) \
+   { \
+      ATL_vld(rA0, p_); \
+      ATL_vadd(d_, d_, rA0); \
+      ATL_vst(p_, d_); \
+   }
+#elif defined(BETA0)
+   #define ATL_vbeta(p_, d_) ATL_vst(p_, d_)
+#else
+   #define ATL_vbeta(p_, d_) \
+   { \
+      ATL_vld(rA0, p_); \
+      ATL_vsub(d_, d_, rA0); \
+      ATL_vst(p_, d_); \
+   }
+#endif
+@VEC MDIM
+   @iif bc = 0
+      @BEGINPROC ldB spc d i_
+      @beginindent 1 @(spc)
+      @define j @@
+      @define kk @@
+@BEGINSKIP
+         1-D must be able to do 2 memops/MAC to get peak, and a 2x2 2-D block
+         must do a load for every MAC, so there will never be any "holes" to
+         do extra memory operations like prefetch or advanced load for these
+         cases.  1-D handles this with special code; to create a hole for 2x2
+         we therefore don't count the last B load as memory load.  We do:
+            IF (vmu != 2 || nu != 2 || i_ == nu-1)
+               mo++  // mo is count of memory ops done with last MAC
+         but this the same as
+            mo = mo + 1*(vmu != 2 || nu != 2 || i_ == nu-1)
+         which was obvious to you from the line below, of course.
+@ENDSKIP
+         @iexp mo 2 @(vmu) ! 2 @(nu) ! | @(i_) 1 @(nu) - = 1 * @(mo) +
+         @iexp j @(vl) @(i_) /
+         @iexp i_ @(vl) @(j) * @(i_) -
+   ATL_vsplat@(i_)(@(d), vB@(j));
+@SKIP    if ((i_+1)%vl == 0, add another vector to stack of vBs to load (lb)
+         @iexp kk @(vl) 1 @(i_) + %
+         @iif kk = 0
+@SKIP    Keep macro stack in old->new order by reversing if non-empty
+@SKIP    so we can add newest to bottom.
+            @whiledef lb
+               @define lb2 @@(lb)@
+            @endwhile
+            @define lb @@(j)@
+            @whiledef lb2
+               @define lb @@(lb2)@
+            @endwhile
+         @endiif
+         @undef j
+         @undef kk
+      @endindent
+      @ENDPROC
+   @endiif
+   @iif bc ! 0
+      @BEGINPROC ldB spc d i_
+      @beginindent 1 @(spc)
+         @iexp mo 2 @(vmu) ! 2 @(nu) ! | @(i_) 1 @(nu) - = 1 * @(mo) +
+         @iif ib < 0
+            @iif i_ ! 0
+   ATL_vbcast(@(d), pB+@(i_));
+            @endiif
+            @iif i_ = 0
+   ATL_vbcast(@(d), pB);
+            @endiif
+         @endiif
+         @iif ib > -1
+            @iif ib ! 0
+   ATL_vbcast(@(d), pB+@(ib));
+             @endiif
+            @iif ib = 0
+   ATL_vbcast(@(d), pB);
+             @endiif
+            @iexp ib @(ib) 1 +
+         @endiif
+      @endindent
+      @ENDPROC
+   @endiif
+@VEC KDIM
+@BEGINSKIP
+ARGS:
+   nv : vvrsum # to use
+   nr : actual number of registers remaining to be summed
+   ir : base register number (0 <= ir < mu*nu)
+ASSUMES: mu, nu, exreg
+@ENDSKIP
+   @BEGINPROC vvrsum nv nr ir
+      @define k @0@
+      @define kl @0@
+      @define i @0@
+      @define j @0@
+      @declare "   ATL_vvrsum@(nv)(" y n ");"
+         @iexp kl @(ir) @(nr) +
+         @iexp k @(ir)
+         @iwhile k < kl
+            @iexp j @(mu) @(k) /
+            @iexp i @(mu) @(k) %
+               rC@(i)_@(j)
+            @iexp k @(k) 1 +
+         @endiwhile
+         @iif nr < nv
+            @iexp kl @(ir) @(nv) +
+            @iwhile k < kl
+               @(exreg)
+            @iexp k @(k) 1 +
+         @endiwhile
+         @endiif
+      @enddeclare
+      @iexp j @(mu) @(ir) /
+      @iexp i @(mu) @(ir) %
+      @iexp kl @(j) @(mu) *
+      @iexp kl @(kl) @(i) +
+   ATL_vbeta(pC+@(kl), rC@(i)_@(j));
+      @undef i
+      @undef j
+      @undef k
+      @undef kl
+   @ENDPROC
+@VEC KDIM NO
+   @BEGINPROC ldB spc d i_
+   @beginindent 1 @(spc)
+      @iexp i_ @(vl) @(i_) *
+      @iexp mo 2 @(vmu) ! 2 @(nu) ! | @(i_) 1 @(nu) - = 1 * @(mo) +
+      @iif ib < 0
+         @iif i_ ! 0
+   ATL_vld(@(d), pB+@(i_));
+         @endiif
+         @iif i_ = 0
+   ATL_vld(@(d), pB);
+         @endiif
+      @endiif
+      @iif ib > -1 
+         @iif ib ! 0
+   ATL_vld(@(d), pB+@(ib));
+         @endiif
+         @iif ib = 0
+   ATL_vld(@(d), pB);
+         @endiif
+         @iexp ib @(ib) @(vl) +
+      @endiif
+   @endindent
+   @ENDPROC
+@VEC NO KDIM
+   @define ldB @ATL_vld@
+   @iexp bmul @(vl) 0 +
+@VEC MDIM
+   @define ldB @ATL_vbcast@
+   @iexp bmul 1 0 +
+@VEC NO
+   @BEGINPROC storeC spc
+   @define kk @dum@
+   @define i @dum@
+   @define j @dum@
+   @beginindent 1 @(spc)
+      @iexp kk 0 0 +
+      @iexp j 0 0 +
+      @iwhile j < @(nu)
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+   #ifdef BETA0
+      pC[@(kk)] = rC@(i)_@(j);
+   #elif defined(BETA1)
+      pC[@(kk)] += rC@(i)_@(j);
+   #else
+      pC[@(kk)] = rC@(i)_@(j) - pC[@(kk)];
+   #endif
+            @iexp kk @(kk) 1 +
+            @iexp i @(i) 1 +
+         @endiwhile
+         @iexp j @(j) 1 +
+      @endiwhile
+   @endindent
+   @undef kk
+   @undef j
+   @undef k
+   @ENDPROC
+@VEC MDIM
+   @BEGINPROC storeC spc
+   @define kk @dum@
+   @define i @dum@
+   @define j @dum@
+   @beginindent 1 @(spc)
+      @iexp kk 0 0 +
+      @iexp j 0 0 +
+      @iwhile j < @(nu)
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+   ATL_vbeta(pC+@(kk), rC@(i)_@(j));
+            @iexp kk @(kk) @(vl) +
+            @iexp i @(i) 1 +
+         @endiwhile
+         @iexp j @(j) 1 +
+      @endiwhile
+   @endindent
+   @undef kk
+   @undef j
+   @ENDPROC
+@VEC KDIM
+   @BEGINPROC storeC spc
+      @define nr @dum@
+      @define nf @dum@
+      @define k @dum@
+      @define ll @dum@
+      @define vl2 @dum@
+
+      @beginindent 1 @(spc)
+         @iexp nf @(vl) @(mu) @(nu) * / @(vl) *
+         @iexp nr @(nf) @(mu) @(nu) * -
+         @iexp k 0
+         @iwhile k < nf
+            @callproc vvrsum @(vl) @(vl) @(k)
+            @iexp k @(k) @(vl) +
+         @endiwhile
+         @iif nr = 1
+            @callproc vvrsum 1 1 @(k)
+         @endiif
+         @iif nr > 1
+            @iexp ll @(vl)
+            @iwhile nr > 0
+               @iexp vl2 2 @(ll) /
+            @print nr=@(nr) ll=@(ll) vl2=@(vl2)
+               @iif nr > vl2
+                  @callproc vvrsum @(ll) @(nr) @(k)
+                  @iexp nr 0
+               @endiif
+               @iif nr } vl2
+                  @callproc vvrsum @(vl2) @(vl2) @(k)
+                  @iexp nr @(vl2) @(nr) -
+                  @iexp k @(k) @(vl2) +
+               @endiif
+               @iexp ll @(vl2)
+            @endiwhile
+         @endiif
+      @endindent
+      @undef k
+      @undef nf
+      @undef nr
+      @undef ll
+      @undef vl2
+   @ENDPROC
+@VEC KDIM
+   @iexp incAk @(mu) @(vl) *
+   @iexp incBk @(nu) @(vl) *
+@VEC MDIM NO
+   @iexp incAk @(mu)
+   @iexp incBk @(nu)
+@VEC !
+@iexp TWOD 1 0 +
+@iif vmu = 1
+   @iexp TWOD 0 0 +
+@endiif
+@iif vnu = 1
+   @iexp TWOD 0 0 +
+@endiif
+@skip NOKLOOP = (kb == ku);
+@iexp NOKLOOP @(kb) @(ku) =
+@iif NOKLOOP = 0
+   @iexp ia -1 0 +
+   @iexp ib -1 0 +
+@endiif
+@iif NOKLOOP ! 0
+   @iexp ia 0 0 +
+   @iexp ib 0 0 +
+@endiif
+@ifdef lb
+   @abort "lb cannot be defined!"
+@endifdef
+@ifdef lb2
+   @abort "lb2 cannot be defined!"
+@endifdef
+
+#ifndef ATL_CSZT
+   #include <stddef.h>
+   #define ATL_CSZT const size_t
+#endif
+@skip Helper func for DoIter[0].  
+@skip IN: pfLS,npfA,npfB, npfC, ipb, ipa, mu, nu, IN_K; 
+@skip IN/OUT: mo, ipf
+@BEGINPROC DoPref
+   @define kk @dum@
+   @define jj @dum@
+   @SKIP commented out, now handled in ldB
+   @BEGINSKIP
+   @SKIP if (vmu == 2 && vnu == 2 && mo = 1) mo = 0
+   @iexp kk @(vmu) 2 = @(vnu) 2 = @(mo) 1 = & &
+   @iif kk ! 0
+      @iexp mo 0 0 +
+   @endiif
+   @ENDSKIP
+   @iif mo = 0
+      @iif ipf < npfC
+         @iexp kk @(ipf) @(pfLS) *
+               @(pfC)(pC+@(kk));
+         @iexp ipf @(ipf) 1 +
+         @iexp mo @(mo) 1 +
+      @endiif
+      @skip if (mo = 0 && ipf < npfA)
+      @iexp kk @(mo) 0 = @(npfA) @(ipf) < &
+      @iif kk ! 0
+         @iexp kk @(npfC) @(ipf) - @(pfLS) *
+               @(pfA)(pAn+@(kk));
+         @iexp ipf @(ipf) 1 +
+         @iif ipf = npfA
+               pAn += incAN;
+         @endiif
+         @iexp mo @(mo) 1 +
+      @endiif
+      @skip if (mo == 0 && ipf < npfB)
+      @iexp kk @(mo) 0 = @(npfB) @(ipf) < &
+      @iif kk ! 0
+         @iexp kk @(npfA) @(ipf) - @(pfLS) *
+               @(pfB)(pBn+@(kk));
+         @iexp ipf @(ipf) 1 +
+         @iif ipf = npfB
+               pBn += incBN;
+         @endiif
+         @iexp mo @(mo) 1 +
+      @endiif
+@SKIP Handle prefetch of next k loop traversal, if it exists
+      @iif mo = 0
+         @ifdef pfBk
+            @SKIP if (NOKLOOP == 0 && IN_K != 0)
+            @iexp kk 0 @(NOKLOOP) = 0 @(IN_K) ! &
+            @iif kk ! 0
+               @(pfBk)(pB+incBn);
+                  @undef pfBk
+               @iexp mo @(mo) 1 +
+            @endiif
+            @iexp jj @(kb) @(nu) *
+            @SKIP if (NOKLOOP != 0 && ipb%pfLS == 0 && ipb < incBn)
+            @iexp kk @(pfLS) @(ipb) % 0 = @(NOKLOOP) 0 ! & @(jj) @(ipb) < &
+            @iif kk ! 0
+               @iexp jj @(jj) @(ipb) +
+            @(pfBk)(pB+@(jj));
+               @iexp ipb @(ipb) @(pfLS) +
+               @iexp mo @(mo) 1 +
+            @iexp kk @(jj) @(ipb) <
+            @endiif
+         @endifdef
+      @endiif
+      @iif mo = 0
+         @ifdef pfAk
+            @SKIP if (NOKLOOP == 0 && IN_K != 0)
+            @iexp kk 0 @(NOKLOOP) = 0 @(IN_K) ! &
+            @iif kk ! 0
+               @(pfAk)(pA+incAm);
+                  @undef pfAk
+               @iexp mo @(mo) 1 +
+            @endiif
+            @iexp jj @(kb) @(mu) *
+            @SKIP if (NOKLOOP != 0 && ipa%pfLS == 0 && ipa < incAm)
+            @iexp kk @(pfLS) @(ipa) % 0 = @(NOKLOOP) 0 ! & @(jj) @(ipa) < &
+            @iif kk ! 0
+               @iexp jj @(jj) @(ipa) +
+            @(pfAk)(pA+@(jj));
+               @iexp ipa @(ipa) @(pfLS) +
+               @iexp mo @(mo) 1 +
+            @endiif
+         @endifdef
+      @endiif
+      @iif IN_K ! 0
+         @ifdef pfAk
+            @iif mo = 0
+            @(pfAk)(pA+incAm);
+               @undef pfAk
+               @iexp mo @(mo) 1 +
+            @endiif
+         @endifdef
+      @endiif
+   @endiif
+   @undef jj
+   @undef kk
+@ENDPROC
+@beginskip
+Perform initial iteration use vmul.  1-D scheduled to make it obvious
+the non-unit dimension can be directly loaded from memory, rather than
+really using registers.  This allows total number of registers to be:
+   MAX(MU,NU) + 1
+ASSUMES DEFINED: ldB, incBk, bmul, incAk, vmu, vnu, vl
+@endskip
+@BEGINPROC DoIter0_k
+@SKIP define internal vars, so they can popped off to leave caller unchanged
+   @define DN @0@
+   @define i @0@
+   @define j @0@
+   @define kk @0@
+@SKIP 1-D with NU=1
+   @iif vnu = 1
+      @iexp DN 1 0 +
+         @callproc ldB 9 rB0 0
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+         ATL_vld(rC@(i)_0, pA+@(ia));
+            @iexp ia @(ia) @(vl) +
+         ATL_vmul(rC@(i)_0, rC@(i)_0, rB0);
+            @iexp mo 0 0 +
+            @callproc DoPref
+            @iexp i @(i) 1 +
+         @endiwhile
+   @endiif
+@SKIP 1-D with VMU=1
+   @iif DN = 0
+      @iif vmu = 1
+         @iexp DN 1 0 +
+         ATL_vld(rA0, pA+@(ia));
+         @iexp ia @(ia) @(vl) +
+@skip         @iexp ia @(ia) @(incAk) +
+         @iexp j 0 0 +
+         @iwhile j < @(vnu)
+            @callproc ldB 6 rC0_@(j) @(j)
+         ATL_vmul(rC0_@(j), rC0_@(j), rA0);
+            @iexp mo 0 0 +
+            @callproc DoPref
+            @iexp j @(j) 1 +
+            @skip if (bc==0 && j%vl==0)
+            @iexp kk @(bc) 0 = @(vl) @(j) % 0 = &
+            @ifdef lb
+             ATL_vld(vB@(lb), pB+@(ib));
+                @undef lb
+                @iexp ib @(ib) @(vl) +
+            @endifdef
+         @endiwhile
+      @endiif
+   @endiif
+@SKIP 2-D case assumes all but last rB already loaded unless B1R is set
+   @iif DN = 0
+      @define jb @0@
+         ATL_vld(rA0, pA);
+      @iexp ia @(ia) @(vl) +
+      @iexp i 0 1 +
+      @iwhile i < @(vmu)
+         ATL_vld(rA@(i), pA+@(ia));
+         @iexp ia @(ia) @(vl) +
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif B1R = 0
+         @callproc ldB 6 rB@(jl) @(jl)
+      @endiif
+      @ifdef lb
+         ATL_vld(vB@(lb), pB+@(ib));  // A01
+         @undef lb
+         @iexp ib @(ib) @(vl) +
+      @endifdef
+      @iexp j 0 0 +
+      @iwhile j < @(vnu)
+         @iexp jb 0 @(B1R) = @(j) *
+         @iif B1R ! 0
+            @callproc ldB 9 rB0 @(j)
+         @endiif
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+         ATL_vmul(rC@(i)_@(j), rA@(i), rB@(jb));
+            @iexp mo 0 0 +
+            @iif j = jl
+            ATL_vld(rA@(i), pA+@(ia));
+               @iexp ia @(ia) @(vl) +
+               @iexp mo @(mo) 1 +
+            @endiif
+            @iif mo = 0
+               @ifdef lb
+            ATL_vld(vB@(lb), pB+@(ib));  // A02 i=@(i) j=@(j)
+                  @undef lb
+                  @iexp mo @(mo) 1 +
+                  @iexp ib @(ib) @(vl) +
+               @endifdef
+            @endiif
+            @skip if (i == il && j != jl && !B1R)
+            @iif @iexp @(i) @(il) = @(j) @(jl) ! & @(B1R) 0 = &
+               @callproc ldB 9 rB@(j) @(j)
+            @endiif
+            @callproc DoPref
+            @iexp i @(i) 1 +
+         @endiwhile
+         @iexp j @(j) 1 +
+      @endiwhile
+      @undef jb
+   @endiif
+@SKIP pop our defs so caller's macros of same name aren't changed
+   @undef DN
+   @undef i
+   @undef j
+   @undef kk
+@ENDPROC
+@SKIP Do normal iteration
+@SKIP ASSUMES DEFINED: ldB, incBk, bmul, incAk, vmu, vnu, vl, jpf
+@BEGINPROC DoIter_k
+@SKIP define internal vars, so they can popped off to leave caller unchanged
+   @define DN @0@
+   @define i @0@
+   @define j @0@
+   @define kk @0@
+@SKIP 1-D with NU=1
+   @iif vnu = 1
+      @iexp DN 1 0 +
+         @callproc ldB 9 rB0 0
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+            ATL_vld(rA0, pA+@(ia));
+            @iexp ia @(ia) @(vl) +
+            ATL_vmac(rC@(i)_0, rA0, rB0);
+            @iexp mo 0 0 +
+            @callproc DoPref
+            @iexp i @(i) 1 +
+         @endiwhile
+   @endiif
+@SKIP 1-D with MU=1
+   @iif DN = 0
+      @iif vmu = 1
+         @iexp DN 1 0 +
+            ATL_vld(rA0, pA+@(ia));
+            @iexp ia @(ia) @(vl) +
+         @iexp j 0 0 +
+         @iwhile j < @(vnu)
+            @callproc ldB 9 rB0 @(j)
+            ATL_vmac(rC0_@(j), rA0, rB0);
+            @iexp mo 0 0 +
+            @callproc DoPref
+            @iexp j @(j) 1 +
+            @skip if (bc==0 && j%vl==0)
+            @iexp kk @(bc) 0 = @(vl) @(j) % 0 = &
+            @iif kk ! 0
+               @iexp kk @(vl) @(j) / -1 +
+             ATL_vld(vB@(kk), pB+@(ib)); // 01
+               @iexp ib @(ib) @(vl) +
+            @endiif
+         @endiwhile
+      @endiif
+   @endiif
+@SKIP 2-D case assumes all but last rB already loaded unless B1R true
+   @iif DN = 0
+      @define jb @0@
+      @iexp j 0 0 +
+      @iwhile j < @(vnu)
+         @iexp jb 0 @(B1R) = @(j) *
+         @iif B1R ! 0
+            @callproc ldB 12 rB0 @(jl)
+         @endiif
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+            @iexp mo 0 0 +
+            ATL_vmac(rC@(i)_@(j), rA@(i), rB@(jb));
+            @skip if ((i|j) == 0 && !B1R)
+            @iif @iexp @(i) @(j) | 0 = @(B1R) 0 = &
+               @iexp kk @(jl) @(bmul) *
+               @callproc ldB 12 rB@(jl) @(jl)
+                  @ifdef lb
+               ATL_vld(vB@(lb), pB+@(ib)); // 02
+                     @undef lb
+                     @iexp ib @(ib) @(vl) +
+                     @iexp mo 1 0 +
+                  @endifdef
+            @endiif
+            @iif j = jl
+               ATL_vld(rA@(i), pA+@(ia));
+               @iexp ia @(ia) @(vl) +
+               @iexp mo 1 0 +
+            @endiif
+            @skip if (j != jl && i == il && !B1R
+            @iif @iexp @(j) @(jl) ! @(i) @(il) = & @(B1R) 0 = &
+               @callproc ldB 12 rB@(j) @(j)
+            @endiif
+            @iif mo = 0
+               @ifdef lb
+               ATL_vld(vB@(lb), pB+@(ib)); // 03
+                  @undef lb
+                  @iexp ib @(ib) @(vl) +
+                  @SKIP if (vmu !=2 && vnu != 2) mo++
+                  @iexp kk @(vmu) 2 ! @(vnu) 2 ! |
+                  @iif kk ! 0
+                     @iexp mo 1 0 +
+                  @endiif
+               @endifdef
+            @endiif
+            @callproc DoPref
+            @iexp i @(i) 1 +
+         @endiwhile
+         @iexp j @(j) 1 +
+      @endiwhile
+      @undef jb
+   @endiif
+@SKIP pop our defs so caller's macros of same name aren't changed
+   @undef DN
+   @undef i
+   @undef j
+   @undef kk
+@ENDPROC
+@BEGINPROC DoIter0
+@SKIP define internal vars, so they can popped off to leave caller unchanged
+   @define DN @0@
+   @define i @0@
+   @define j @0@
+   @define kk @0@
+@SKIP 1-D with NU=1
+   @iif vnu = 1
+      @iexp DN 1 0 +
+         @(ldB)(rB0, pB);
+         pB += @(incBk);
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+            @iexp kk @(i) @(vl) *
+         ATL_vld(rC@(i)_0, pA+@(kk));
+         ATL_vmul(rC@(i)_0, rC@(i)_0, rB0);
+            @iexp mo 0 0 +
+            @callproc DoPref
+            @iexp i @(i) 1 +
+         @endiwhile
+         pA += @(incAk);
+   @endiif
+@SKIP 1-D with VMU=1
+   @iif DN = 0
+      @iif vmu = 1
+         @iexp DN 1 0 +
+         ATL_vld(rA0, pA);
+         pA += @(incAk);
+         @iexp j 0 0 +
+         @iwhile j < @(vnu)
+            @callproc ldB 6 rC0_@(j) @(j)
+         ATL_vmul(rC0_@(j), rC0_@(j), rA0);
+            @iexp mo 0 0 +
+            @callproc DoPref
+            @iexp j @(j) 1 +
+            @skip if (bc==0 && j%vl==0)
+            @iexp kk @(bc) 0 = @(vl) @(j) % 0 = &
+            @iif kk ! 0
+               @iexp kk @(vl) @(j) / -1 +
+               @iexp jj @(kk) @(vl) *
+             ATL_vld(vB@(kk), pB+@(jj));
+            @endiif
+         @endiwhile
+         pB += @(incBk);
+      @endiif
+   @endiif
+@SKIP 2-D case assumes all but last rB already loaded unless B1R is true
+   @iif DN = 0
+      @define jb @0@
+         ATL_vld(rA0, pA);
+      @iexp i 0 1 +
+      @iwhile i < @(vmu)
+         @iexp kk @(i) @(vl) *
+         ATL_vld(rA@(i), pA+@(kk));
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif B1R = 0
+         @callproc ldB 6 rB@(jl) @(jl)
+      @endiif
+         pA += @(incAk);
+      @ifdef lb
+         @iexp jj @(vl) @(lb) *
+         ATL_vld(vB@(lb), pB+@(jj)); // di0_00
+         @undef lb
+      @endifdef
+      @iif B1R = 0
+         pB += @(incBk);
+      @endiif
+      @iexp j 0 0 +
+      @iwhile j < @(vnu)
+         @iif B1R ! 0
+            @callproc ldB 6 rB0 @(j)
+            @iif @iexp @(vnu) -1 + @(j) =
+               pB += @(incBk); // di0_02
+            @endiif
+         @endiif
+         @iexp jb 0 @(B1R) = @(j) *
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+         ATL_vmul(rC@(i)_@(j), rA@(i), rB@(jb));
+            @iexp mo 0 0 +
+            @iif j = jl
+               @iexp kk @(i) @(vl) *
+            ATL_vld(rA@(i), pA+@(kk));
+               @iexp mo @(mo) 1 +
+                  @iif i = il
+            pA += @(incAk);
+                  @endiif
+            @endiif
+            @iif mo = 0
+               @ifdef lb
+                  @iexp kk @(lb) @(vl) *
+               ATL_vld(vB@(lb), pB+@(kk)); // di0_01: lb=@(lb) jl=@(jl)
+                  @iexp kk @(kk) @(vl) +
+                  @iif kk = incBk
+               pB += @(incBk); // di0_02
+                  @endiif
+                  @undef lb
+                  @iexp mo @(mo) 1 +
+               @endifdef
+            @endiif
+            @iif B1R = 0
+               @iif i = il
+                  @iif j ! jl
+                     @iexp kk @(j) @(bmul) *
+            @callproc ldB 9 rB@(j) @(j)
+                  @endiif
+               @endiif
+            @endiif
+            @callproc DoPref
+            @iexp i @(i) 1 +
+         @endiwhile
+         @iexp j @(j) 1 +
+      @endiwhile
+      @undef jb
+   @endiif
+@SKIP pop our defs so caller's macros of same name aren't changed
+   @undef DN
+   @undef i
+   @undef j
+   @undef kk
+@ENDPROC
+@SKIP Do normal iteration
+@SKIP ASSUMES DEFINED: ldB, incBk, bmul, incAk, vmu, vnu, vl, jpf
+@BEGINPROC DoIter
+@SKIP define internal vars, so they can popped off to leave caller unchanged
+   @define DN @0@
+   @define i @0@
+   @define j @0@
+   @define kk @0@
+@SKIP 1-D with NU=1
+   @iif vnu = 1
+      @iexp DN 1 0 +
+            @(ldB)(rB0, pB);
+            pB += @(incBk);
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+            @iexp kk @(i) @(vl) *
+            ATL_vld(rA0, pA+@(kk));
+            ATL_vmac(rC@(i)_0, rA0, rB0);
+            @iexp mo 0 0 +
+            @callproc DoPref
+            @iexp i @(i) 1 +
+         @endiwhile
+            pA += @(incAk);
+   @endiif
+@SKIP 1-D with MU=1
+   @iif DN = 0
+      @iif vmu = 1
+         @iexp DN 1 0 +
+            ATL_vld(rA0, pA);
+            pA += @(incAk);
+         @iexp j 0 0 +
+         @iwhile j < @(vnu)
+            @callproc ldB 9 rB0 @(j)
+            ATL_vmac(rC0_@(j), rA0, rB0);
+            @iexp mo 0 0 +
+            @callproc DoPref
+            @iexp j @(j) 1 +
+            @skip if (bc==0 && j%vl==0)
+            @iexp kk @(bc) 0 = @(vl) @(j) % 0 = &
+            @iif kk ! 0
+               @iexp kk @(vl) @(j) / -1 +
+               @iexp jj @(kk) @(vl) *
+             ATL_vld(vB@(kk), pB+@(jj));
+            @endiif
+         @endiwhile
+            pB += @(incBk);
+      @endiif
+   @endiif
+@SKIP 2-D case assumes all but last rB already loaded
+   @iif DN = 0
+      @define jb @0@
+      @iexp j 0 0 +
+      @iwhile j < @(vnu)
+         @iexp jb 0 @(B1R) = @(j) *
+         @iif B1R ! 0
+            @callproc ldB 12 rB0 @(j)
+            @iif jl = j
+               pB += @(incBk);
+            @endiif
+         @endiif
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+            @iexp mo 0 0 +
+            ATL_vmac(rC@(i)_@(j), rA@(i), rB@(jb));
+            @skip if ((i|j|B1R) == 0)
+            @iif @iexp @(i) @(j) | @(B1R) | 0 =
+                  @iexp kk @(jl) @(bmul) *
+               @callproc ldB 12 rB@(jl) @(jl)
+                  @ifdef lb
+                     @iexp kk @(lb) @(vl) *
+               ATL_vld(vB@(lb), pB+@(kk));
+                     @undef lb
+                     @iexp mo 1 0 +
+                  @endifdef
+               pB += @(incBk);
+            @endiif
+            @iif j = jl
+               @iexp kk @(i) @(vl) *
+               ATL_vld(rA@(i), pA+@(kk));
+               @iexp mo 1 0 +
+               @iif i = il
+               pA += @(incAk);
+               @endiif
+            @endiif
+            @skip if (j != jl && i == il && !B1R)
+            @iif @iexp @(j) @(jl) ! @(i) @(il) = & @(B1R) 0 = &
+               @iexp kk @(j) @(bmul) *
+               @callproc ldB 12 rB@(j) @(j)
+            @endiif
+            @iif mo = 0
+               @ifdef lb
+                  @iexp kk @(lb) @(vl) *
+               ATL_vld(vB@(lb), pB+@(kk));
+                  @undef lb
+                  @iexp mo 1 0 +
+               @endifdef
+            @endiif
+            @callproc DoPref
+            @iexp i @(i) 1 +
+         @endiwhile
+         @iexp j @(j) 1 +
+      @endiwhile
+      @undef jb
+   @endiif
+@SKIP pop our defs so caller's macros of same name aren't changed
+   @undef DN
+   @undef i
+   @undef j
+   @undef kk
+@ENDPROC
+void ATL_USERMM
+(
+   ATL_CSZT nmus,
+   ATL_CSZT nnus,
+   ATL_CSZT K,
+   const @(typ) *pA, /* @(mu)*KB*nmus-length access-major array of A */
+   const @(typ) *pB, /* @(nu)*KB*nnus-length access-major array of B */
+   @(typ) *pC,   /* @(mu)*@(nu)*nnus*nmus-length access-major array of C */
+   const @(typ) *pAn, /* next block of A */
+   const @(typ) *pBn, /* next block of B */
+   const @(typ) *pCn  /* next block of C */
+)
+/*
+ * Performs a GEMM with M,N,K unrolling (& jam) of (@(mu),@(nu),@(ku)).
+@VEC KDIM ` * Vectorization of VLEN=@(vl) along K dim, vec unroll=(@(vmu),@(vnu),@(vku)).`
+@VEC MDIM ` * Vectorization of VLEN=@(vl) along M dim, vec unroll=(@(vmu),@(vnu),@(vku)).`
+@VEC NO   ` * Code is not vectorized (VLEN=@(vl)).`
+@iif kb = 0
+ * You may set compile-time constant K dim by defining ATL_MM_KB.
+@endiif
+ */
+{
+   @declare "   register ATL_VTYPE " y n ";"
+      @iif bc = 0
+         @iexp kk @(vl) @(vnu) /
+         @iexp j 0 0 +
+         @iwhile j < @(kk)
+            vB@(j)
+            @iexp j @(j) 1 +
+         @endiwhile
+      @endiif
+      @iif B1R ! 0
+         rB0
+      @endiif
+      @iexp j 0 0 +
+      @iwhile j < @(vnu)
+         @iif @iexp 0 @(TWOD) ! 0 @(B1R) = &
+            rB@(j)
+         @endiif
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+            rC@(i)_@(j)
+            @iexp i @(i) 1 +
+         @endiwhile
+         @iexp j @(j) 1 +
+      @endiwhile
+      @iif TWOD = 0
+         rA0 
+         @iif B1R = 0
+            rB0
+         @endiif
+      @endiif
+      @iif TWOD ! 0
+         @iexp i 0 0 +
+         @iwhile i < @(vmu)
+            rA@(i)
+            @iexp i @(i) 1 +
+         @endiwhile
+      @endiif
+      @SKIP if (mu*nu < vlen && mu != 1 && nu != 1
+      @iif @iexp @(vl) @(mu) @(nu) * < @(mu) 1 ! & @(nu) 1 ! &
+         rtmp
+         @define exreg @rtmp@
+      @endiif
+   @enddeclare
+   @iif @iexp @(vl) @(mu) @(nu) * > 
+      @define exreg @rC0_0@
+   @endiif
+   @ifdef ! exreg
+      @iif @iexp @(mu) 1 = @(nu) 1 = |
+         @define exreg @rB0@
+      @endiif
+   @endifdef
+   @declare "   const @(typ) " y n ";"
+    *pB0=pB *pA0=pA
+   @enddeclare
+   @iif npfA > 0
+   const int incAN = (ATL_MM_KB * @(mu)) / nnus;
+   @endiif
+   @iif npfB > 0
+   const int incBN = (ATL_MM_KB * @(nu)) / nmus;
+   @endiif
+@skip   const @(typ) *pfA;
+   int i, j, k;
+   #if ATL_KBCONST == 0
+      int incAm = @(mu)*K, incBn = @(nu)*K;
+   #else
+      #define incAm (@(mu)*ATL_MM_KB)
+      #define incBn (@(nu)*ATL_MM_KB)
+   #endif
+
+   @SKIP if (npfA > 0 & npfB > 0)
+   @iexp kk 0 @(npfA) > 0 @(npfB) > &
+   @iif kk ! 0
+   pAn = (pAn != pA) ? pAn : pC;
+   pBn = (pBn != pB) ? pBn : pC;
+   @endiif
+   @iif kk = 0
+      @iif npfA > 0
+         if (pAn == pA)
+            pAn = (pBn != pB) ? pBn : pCn;
+      @endiif
+      @iif npfB > 0
+         if (pBn == pB)
+            pBn = (pAn != pA) ? pAn : pCn;
+      @endiif
+   @endiif
+   @iexp mo 0 0 +
+   @iexp ipf 0 0 +
+   @iexp ipa 0 0 +
+   @iexp ipb 0 0 +
+   @iexp jl @(vnu) -1 +
+   @iexp il @(vmu) -1 +
+   @iif vnu > 2
+      @iexp jpf 0 1 +
+   @endiif
+   @iif vnu < 3
+      @iexp jpf 0 -1 +
+   @endiif
+   @iexp jpf 0 -1 +
+@iif @iexp @(DOMLOOP)
+   for (i=0; i < nmus; i++)
+   {
+@endiif
+@print NOK=@(NOKLOOP) ib=@(ib) ia=@(ia)
+   @iif bc = 0
+      @iexp j 0 0 +
+      @iwhile j < @(vnu)
+         @iexp kk @(vl) @(j) /
+      ATL_vld(vB@(kk), pB+@(j));
+         @iexp j @(j) @(vl) +
+      @endiwhile
+      @iif NOKLOOP ! 0
+         @iexp ib @(ib) @(nu) +
+      @endiif
+      @iif NOKLOOP = 0
+      pB += @(incBk);
+      @endiif
+   @endiif
+   @iif @iexp 1 @(vmu) > 0 @(B1R) = &
+      @iexp j 0 0 +
+      @iwhile j < @(jl)
+         @callproc ldB 3 rB@(j) @(j)
+         @ifdef lb
+            @iif ib < 0
+               @iexp kk @(vl) @(lb) *
+      ATL_vld(vB@(lb), pB+@(kk)); // h0
+            @endiif
+            @iif ib > -1 
+      ATL_vld(vB@(lb), pB+@(ib));  // h1
+               @iexp ib @(ib) @(vl) +
+            @endiif
+            @undef lb
+         @endifdef
+         @iexp j @(j) 1 +
+      @endiwhile
+   @endiif
+   @iif @iexp @(DONLOOP)
+      @iif TRI = 0
+      for (j=0; j < nnus; j++)
+      @endiif
+      @iif TRI = 1
+         @iif mEn = 1
+      for (j=0; j <= i; j++)
+         @endiif
+         @iif mEn ! 1
+            @iif ma > 1
+      for (j=0; j < @(ma)*(i+1); j++)
+            @endiif
+            @iif na > 1
+      for (j=0; j <= i/@(na); j++)
+            @endiif
+         @endiif
+      @endiif
+      {
+   @endiif
+         /* Peel K=0 iteration to avoid zero of rCxx and extra add  */
+   @iif NOKLOOP ! 0
+      @iexp IN_K 0 0 +
+         @CALLPROC DoIter0_k
+      @VEC KDIM `@iexp incK @(vl) 0 +`
+      @VEC ! KDIM `@iexp incK 1 0 +`
+      @iexp k 0 @(incK) +
+      @iwhile ipf < npf
+            /* Peel K=@(k) iteration for prefetch  */
+         @CALLPROC DoIter_k
+         @iexp k @(k) @(incK) +
+      @endiwhile
+      @iexp IN_K 1 0 +
+      @iwhile k < kb
+            /* K=@(k) iteration */
+         @CALLPROC DoIter_k
+         @iexp k @(k) @(incK) +
+      @endiwhile
+   @endiif
+   @iif NOKLOOP = 0
+      @iexp IN_K 0 0 +
+      @iexp npeel 1 0 +
+      @VEC KDIM `@iexp kmul @(vl)`
+      @VEC ! KDIM `@iexp kmul 1`
+      @CALLPROC DoIter0
+      @iwhile ipf < npf
+/*
+ *       Peel K=@(npeel) iter to allow prefetch of C or next blocks of A&B
+ */
+         @iexp kk @(kmul) @(npeel) *
+         if (K == @(kk))
+            goto KDONE;
+            @CALLPROC DoIter
+         @iexp npeel @(npeel) 1 +
+      @endiwhile
+      @SKIP peel until npeel%vku == 0
+      @iif @iexp @(vku) @(npeel) % 0 !
+         @iexp nep @(vku) @(npeel) % @(vku) -
+/*
+ *       Peeled @(npeel) iters, peel another @(nep) to make mul of vku=@(vku)
+ */
+         @iexp ii 0
+         @iwhile ii < nep
+         /* ku mulpeel @(ii) of @(nep) */
+         @iexp kk @(kmul) @(npeel) *
+         if (K == @(kk))
+            goto KDONE;
+            @CALLPROC DoIter
+            @iexp npeel @(npeel) 1 +
+            @iexp ii @(ii) 1 +
+         @endiwhile
+      @endiif
+         @iexp kk @(kmul) @(npeel) *
+         for (k=@(kk); k < ATL_MM_KB; k += @(ku))
+         {
+            @iexp IN_K 0 1 +
+            @iexp kk 0
+            @iwhile kk < @(vku)
+            @iif kk > 0
+
+            @endiif
+            @CALLPROC DoIter
+               @iexp kk @(kk) 1 +
+            @endiwhile
+         }
+      @iif npeel > 1
+KDONE:
+      @endiif
+   @endiif
+         @CALLPROC storeC 6
+         @VEC KDIM   `@iexp kk @(vl) @(mu) @(nu) * @(vl) + -1 + / @(vl) *`
+         @VEC ! KDIM `@iexp kk @(mu) @(nu) *`
+   @iif @iexp @(DOMLOOP) @(DONLOOP) |
+         pC += @(kk);
+      @iif NOKLOOP ! 0
+         pB += incBn;
+      @endiif
+      @iif ku ! kb
+         pA = pA0;
+      @endiif
+   @endiif
+   @iif @iexp @(DONLOOP)
+      }  /* end of loop over N */
+   @endiif
+   @iif @iexp @(DOMLOOP)
+      pB = pB0;
+      pA0 += incAm;
+      pA = pA0;
+   }  /* end of loop over M */
+   @endiif
+}
+@skip ************************ copy gen **************************************
+@ROUT blk2C C2blk
+#include <stddef.h>
+@ifdef ! cpvl
+   @iexp cpvl 1
+@endifdef
+@iif vl = 0
+   @iexp vl 1
+@endiif
+@iif cpvl > 1
+#define ATL_VLEN @(vl)
+#include "atlas_simd.h"
+@endiif
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__/100 >= 1999)
+   #define INLINE inline
+#endif
+@SKIP LEGAL: alpha=[1,-1,X], beta=[0,1,-1,X]
+@SKIP if (alpha==1) && (beta==0 || beta==1)) -> char same as #
+@ifdef ! rtnm
+   @define rtnm @ATL_USERCPMM@
+@endifdef
+@PRE S D
+@SKIP blksz = ((mu*nu+vlen-1)/vlen)*vlen
+@iexp bs @(vl) @(mu) @(nu) * @(vl) + -1 + / @(vl) *
+// HERE vl=@(vl), mu=@(mu), nu=@(nu) bs=@(bs)
+@SKIP this proc handles only one element
+@SKIP IN : alpha, beta, C, p 
+@BEGINPROC doElement r c k
+         @iif alpha = 1
+            @iif beta = 0
+@ROUT blk2C `            C@(c)[@(r)] = p[@(k)];`
+@ROUT C2blk `            p[@(k)] = C@(c)[@(r)];`
+            @endiif
+            @iif beta = 1
+@ROUT blk2C `            C@(c)[@(r)] += p[@(k)];`
+@ROUT C2blk `            p[@(k)] += C@(c)[@(r)];`
+            @endiif
+            @iif beta = -1
+@ROUT blk2C `            C@(c)[@(r)] = p[@(k)] - C@(c)[@(r)];`
+@ROUT C2blk `            p[@(k)] = C@(c)[@(r)] - p[@(k)];`
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `            C@(c)[@(r)] = beta*C@(c)[@(r)] + p[@(k)];`
+@ROUT C2blk `            p[@(k)] = beta*p[@(k)] + C@(c)[@(r)];`
+            @endiif
+         @endiif
+         @iif alpha = -1
+            @iif beta = 0
+@ROUT blk2C `            C@(c)[@(r)] = -p[@(k)];`
+@ROUT C2blk `            p[@(k)] = -C@(c)[@(r)];`
+            @endiif
+            @iif beta = 1
+@ROUT blk2C `            C@(c)[@(r)] -= p[@(k)];`
+@ROUT C2blk `            p[@(k)] -= C@(c)[@(r)];`
+            @endiif
+            @iif beta = -1
+@ROUT blk2C `            C@(c)[@(r)] = -C@(c)[@(r)] - p[@(k)];`
+@ROUT C2blk `            p[@(k)] = -C@(c)[@(r)] - p[@(k)];`
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `            C@(c)[@(r)] = beta*C@(c)[@(r)] - p[@(k)];`
+@ROUT C2blk `            p[@(k)] = beta*p[@(k)] - C@(c)[@(r)];`
+            @endiif
+         @endiif
+         @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
+            @iif beta = 0
+@ROUT blk2C `            C@(c)[@(r)] = alpha*p[@(k)];`
+@ROUT C2blk `            p[@(k)] = alpha*C@(c)[@(r)];`
+            @endiif
+            @iif beta = 1
+@ROUT blk2C `            C@(c)[@(r)] += alpha*p[@(k)];`
+@ROUT C2blk `            p[@(k)] += alpha*C@(c)[@(r)];`
+            @endiif
+            @iif beta = -1
+@ROUT blk2C `            C@(c)[@(r)] = alpha*p[@(k)] - C@(c)[@(r)];`
+@ROUT C2blk `            p[@(k)] = alpha*C@(c)[@(r)] - p[@(k)];`
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `            C@(c)[@(r)] = beta*C@(c)[@(r)] + alpha*p[@(k)];`
+@ROUT C2blk `            p[@(k)] = beta*p[@(k)] + alpha*C@(c)[@(r)];`
+            @endiif
+         @endiif
+@ENDPROC
+
+@SKIP IN: mu, nu, beta, alpha
+@BEGINPROC doDiBlock n_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define c @dum@
+   @define r @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+         @iexp k @(j) @(mu) * @(i) +
+@ROUT blk2C
+         @iexp r @(i)
+         @iexp c @(j)
+         @iif j { i
+@ROUT C2blk
+         @iif j > i
+            @iexp r @(j)
+            @iexp c @(i)
+         @endiif
+         @iif j { i
+            @iexp r @(i)
+            @iexp c @(j)
+         @endiif
+@ROUT blk2C C2blk
+      @callproc doElement @(r) @(c) @(k)  
+@ROUT blk2C 
+         @endiif
+@ROUT blk2C C2blk
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif n_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef i
+   @undef j
+   @undef c
+   @undef r
+@ENDPROC
+
+@SKIP this is for mu > nu diagonal subblocks
+@SKIP IN: mu, nu, beta, alpha
+@BEGINPROC doDiBlockmn m_ n_ ma_
+   @define i @dum@
+   @define j @dum@
+   @define jj @dum@
+   @define k @dum@
+   @define t @dum@
+   @define sc @dum@
+
+   switch (j%@(ma_))
+   {
+      @iexp sc 0
+      @iwhile sc < @(ma_)
+      case @(sc):
+         @iexp j 0
+         @iwhile j < @(n_)  
+            @iexp i 0
+            @iwhile i < @(m_) 
+               @iexp k @(j) @(mu) * @(i) +
+               @iexp t @(nu) @(sc) *
+               @iexp t @(t) @(j) +
+               @iif i < @(t) 
+@ROUT C2blk    
+               @iexp jj @(m_) -1 +    
+               @callproc doElement @(jj) @(j) @(k) 
+@ROUT C2blk blk2C
+               @endiif
+               @iif i } @(t)
+               @callproc doElement @(i) @(j) @(k)
+               @endiif
+               @iexp i @(i) 1 +
+            @endiwhile
+         C@(j) += @(m_);
+            @iexp j @(j) 1 +
+         @endiwhile
+         break;
+         @iexp sc @(sc) 1 +
+      @endiwhile
+   }
+   @undef i
+   @undef j
+   @undef jj
+   @undef k
+   @undef t
+   @undef sc
+@ENDPROC
+@SKIP this is for cleanup diagonal subblocks when mu!=nu 
+@SKIP IN: mu, nu, beta, alpha,
+@BEGINPROC doCuDiBlockmn m_ n_ ma_
+   @define i @dum@
+   @define j @dum@
+   @define jj @dum@
+   @define k @dum@
+   @define t @dum@
+   @define sc @dum@
+   @define m @dum@
+   
+      unsigned int rr;
+      switch (j%@(ma_))
+      {
+      @iexp m @(ma_) -1 +
+      @iexp sc 0
+      @iwhile sc < @(m)
+      case @(sc):
+         
+         @iexp j 0
+         @iwhile j < @(n_)  
+
+            @iexp i 0 
+            @iwhile i < @(m_) 
+               @iexp k @(j) @(mu) * @(i) +
+               @iexp t @(nu) @(sc) *
+               @iexp t @(t) @(j) +
+@ROUT C2blk    
+               @iif i < @(t) 
+               @iexp jj @(i) 1 +    
+            p[@(k)] = 0.0;
+               @endiif
+@ROUT C2blk blk2C
+               @iif i } @(t)
+                  @skip "upper limit"
+                  @iexp t @(sc) 1 +
+                  @iexp t @(t) @(nu) *
+                  @iif i < @(t)
+            @callproc doElement @(i) @(j) @(k)
+                  @endiif
+               @endiif
+               @iexp i @(i) 1 +
+            @endiwhile
+            @iexp j @(j) 1 +
+         @endiwhile
+            @skip "now from nu to mu "
+            @iexp jj @(sc) 1 +
+            @iexp jj @(jj) @(n_) *
+         for (rr=@(jj); rr < mr; rr++ )
+         {
+               @iexp jj 0
+               @iwhile jj < @(n_)
+                  @iexp t @(jj) @(m_) * 
+                  @callproc doElement rr @(jj) @(t)+rr
+                  @iexp jj @(jj) 1 +
+               @endiwhile
+         }
+         break;
+         @iexp sc @(sc) 1 +
+      @endiwhile
+      }
+   @undef i
+   @undef j
+   @undef jj
+   @undef k
+   @undef t
+   @undef sc
+   @undef m
+@ENDPROC
+@SKIP diagonal block when nu > mu and nu = na * mu
+@BEGINPROC doDirrBlockna n_ mul_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define c @dum@
+   @define r @dum@
+   @define m @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+         @iexp k @(j) @(mu) * @(i) +
+@ROUT blk2C
+         @iexp r @(i)
+         @iexp c @(j)
+         @iif j { i
+@ROUT C2blk
+         @iif j > i
+            @iexp r @(j)
+            @iexp c @(i)
+         @endiif
+         @iif j { i
+            @iexp r @(i)
+            @iexp c @(j)
+         @endiif
+@ROUT blk2C C2blk
+         @skip @iexp m @(n_) @(n_) *
+         @callproc doElement @(r) @(c) @(k)+rr*@(mul_) 
+@ROUT blk2C
+         @endiif
+@ROUT blk2C C2blk
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif n_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef i
+   @undef j
+   @undef c
+   @undef r
+   @undef m
+@ENDPROC
+@SKIP normal blocks 
+@BEGINPROC doBlock m_ n_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp k @(j) @(mu) * @(i) +
+         @callproc doElement @(i) @(j) @(k) 
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif m_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@SKIP full blocks with multiplication 
+@BEGINPROC donaBlock m_ n_ mn_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define m @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp k @(j) @(mu) * @(i) +
+         @callproc doElement @(i) @(j) @(k)+rr*@(mn_) 
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif m_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef m
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@iif cpvl = 1
+void @(rtnm)
+(
+   const size_t M,      /* number of rows in A */
+   const size_t N,      /* number of columns in A */
+   @ROUT blk2C
+   const @(typ) alpha,  /* scalar for b */
+   const @(typ) *b,     /* matrix stored in @(mu)x@(nu)-major order */
+   const @(typ) beta,   /* scalar for C */
+   @(typ) *C,           /* matrix to be copied to access-major format */
+   const size_t ldc     /* stride between row elements */
+   @ROUT C2blk
+   const @(typ) alpha,  /* scalar for C */
+   const @(typ) *C,     /* matrix to be copied to access-major format */
+   const size_t ldc,    /* stride between row elements */
+   const @(typ) beta,   /* scalar for b */
+   @(typ) *b            /* matrix stored in @(mu)x@(nu)-major order */
+   @ROUT C2blk blk2C
+)
+@endiif
+@iif cpvl > 1
+static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha, 
+                         const @(typ) *b, const SCALAR beta, 
+                         @(typ) *C, ATL_CSZT ldc)
+@endiif
+{
+   const unsigned int mf = M/@(mu), nf = N/@(nu);
+   const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
+@iif TRI = 1
+   @iif mEn = 1
+   unsigned int pansz = @(bs);
+   const size_t incC0 = (ldc+1)*@(nu);
+   @endiif
+   @iif mEn = 0
+      @skip "*** special case for mu = ma*nu"
+      @iif ma ! 1
+   unsigned int pansz = @(bs)*@(ma);
+   const unsigned int manf = (N/(@(nu)*@(ma)))*@(ma);
+   const unsigned int manr = nf - manf;
+   const size_t incC0 = ldc*@(nu);
+      @endiif 
+      @skip "*** special case for nu = na * mu"
+      @iif na ! 1
+   unsigned int pansz = @(bs);
+   const size_t incC0 = (ldc+1)*@(mu); 
+   const unsigned int mnf = N/@(mu);
+   const unsigned int mnr = N - (mnf*@(mu));
+   unsigned int rr; 
+      @endiif
+   @endiif
+@endiif
+@iif TRI = 0
+   const unsigned int pansz = (nr) ? (nf+1)*@(bs) : nf*@(bs); 
+   const size_t incC = ldc*@(nu) - m;
+@endiif
+   unsigned int i, j;
+@ROUT blk2C `   @declare "   @(typ) " n n ";"`
+@ROUT C2blk `   @declare "   const @(typ) " n n ";"`
+      *C0=C
+@iif na = 1
+      @define j @1@
+      @iwhile j < @(nu)
+         @iexp i @(j) -1 +
+         *C@(j)=C@(i)+ldc
+         @iexp j @(j) 1 +
+      @endiwhile
+   @enddeclare
+@endiif
+@iif na ! 1
+      @define j @1@
+      @iwhile j < @(mu)
+         @iexp i @(j) -1 +
+         *C@(j)=C@(i)+ldc
+         @iexp j @(j) 1 +
+      @endiwhile
+   @enddeclare
+@endiif
+@iif TRI = 1
+   @iif mEn = 1
+   for (j=0; j < nf; j++)
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+   size_t incC;
+   for (j=0; j < manf; j++)
+      @endiif
+      @iif na ! 1
+   for (j=0; j < mnf; j++)
+      @endiif
+   @endiif
+@endiif
+@iif TRI = 0
+   for (j=nf; j; j--, b += @(bs))
+@endiif
+   {
+@ROUT blk2C `      const @(typ) *p = b;`
+@ROUT C2blk `      @(typ) *p = b;`
+@iif TRI = 1
+   @iif mEn = 1
+      unsigned int psz = pansz+@(bs), incC = incC0 - (mf-j)*@(mu);
+
+      @callproc doDiBlock @(nu)
+      p += pansz;
+      for (i=j+1; i < mf; i++, p += psz, psz += @(bs))
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+      unsigned int psz = pansz + @(ma)*@(bs); 
+      incC = incC0 - (mf-(j+1)/@(ma))*@(mu);
+      @callproc doDiBlockmn @(mu) @(nu) @(ma)
+      p += pansz;
+      for (i=j/@(ma)+1; i < mf; i++, p += psz, psz += @(bs)*@(ma))
+      @endiif
+      @iif na ! 1
+      unsigned int psz = pansz, incC = incC0 - (mf-j)*@(mu);
+         rr = j % @(na);
+      @iexp mumu @(mu) @(mu) *
+      @callproc doDirrBlockna @(mu) @(mumu)
+      p += pansz;
+      for (i=j+1; i < mf; i++, p += psz )
+      @endiif
+   @endiif
+@endiif
+@iif TRI = 0
+      for (i=mf; i; i--, p += pansz)
+@endiif
+@iif na = 1
+      {
+         @callproc doBlock @(mu) @(nu)
+      }
+@endiif
+@iif na ! 1
+      {
+         @callproc donaBlock @(mu) @(mu) @(mumu)
+         psz += ((i%@(na))==0?@(bs):0);
+      }
+@endiif
+      switch(mr)
+      {
+   @iexp m 1
+   @iwhile m < @(mu)
+      case @(m):
+@iif na = 1
+      @callproc doBlock @(m) @(nu)
+@endiif
+@iif na ! 1
+      @callproc donaBlock @(m) @(mu) @(mumu)
+@endiif
+      @iexp m @(m) 1 +
+         break;
+   @endiwhile
+      default:;
+      }
+@iif na = 1
+   @iexp j 0
+   @iwhile j < @(nu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+@endiif
+@iif na ! 1
+   @iexp j 0
+   @iwhile j < @(mu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+@endiif
+@iif TRI = 1
+   @iif mEn = 1
+      pansz += @(bs);
+      b += pansz;
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+      b += ((j+1)% @(ma))==0 ? pansz+@(bs) : @(bs);
+      if ( (j+1) % @(ma) == 0)
+         pansz += @(ma)*@(bs);
+      @endiif
+      @iif na ! 1
+      pansz += ((j+1)%@(na)==0?@(bs):0);
+      b += pansz;
+      @endiif
+   @endiif
+@endiif
+   }
+@iif TRI = 1   
+      @SKIP "Remainder of manr = nf - manf " 
+   @iif mEn = 0
+      @iif ma ! 1
+   for (j=manf; j < nf; j++)
+   {
+@ROUT blk2C `      const @(typ) *p = b;`
+@ROUT C2blk `      @(typ) *p = b;`
+      unsigned int psz = pansz + @(ma)*@(bs), 
+                         incC = incC0 - (mf-(j+1)/@(ma))*@(mu);
+         @callproc doCuDiBlockmn @(mu) @(nu) @(ma)
+      p += pansz;
+   @iexp j 0
+   @iwhile j < @(nu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+      b += ((j+1)% @(ma))==0 ? pansz+@(bs) : @(bs);
+      if ( (j+1) % @(ma) == 0)
+         pansz += @(ma)*@(bs);
+   }
+         @endiif
+      @endiif
+@endiif
+
+@iif na = 1
+@iif nu > 1
+   switch(nr)
+   {
+@ROUT blk2C `      const @(typ) *p;`
+@ROUT C2blk `      @(typ) *p;`
+   @iexp n 1
+   @iwhile n < @(nu)
+   case @(n):
+      p = b;
+@iif TRI = 1
+   @iif mEn = 1
+         @callproc doDiBlock @(n)
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+         p += mr - nr; 
+         @iexp k 0
+         @iwhile k < @(n)
+            C@(k) += mr-nr;
+            @iexp k @(k) 1 +
+         @endiwhile
+         @skip "for nr cleanup, it works like mu=nu"
+         @callproc doDiBlock @(n)
+      @endiif
+   @endiif
+      break;
+@endiif 
+@iif TRI = 0
+      for (i=0; i < mf; i++, p += pansz)
+      {
+         @callproc doBlock @(mu) @(n)
+      }
+      switch(mr)
+      {
+   @iexp m 1
+   @iwhile m < @(mu)
+      case @(m):
+      @callproc doBlock @(m) @(n)
+      @iexp m @(m) 1 +
+         break;
+   @endiwhile
+      default:;
+      }
+      break;
+@endiif
+      @iexp n @(n) 1 +
+   @endiwhile
+   default:;
+   }
+@endiif
+@endiif
+@iif na ! 1
+@iif mu > 1
+   rr = mnf % @(na);
+   switch(mnr)
+   {
+@ROUT blk2C `      const @(typ) *p;`
+@ROUT C2blk `      @(typ) *p;`
+   @iexp n 1
+   @iwhile n < @(mu)
+   case @(n):
+      p = b;
+      @callproc doDirrBlockna @(n) @(mumu)
+         break;
+      @iexp n @(n) 1 +
+   @endiwhile
+   default:;
+   }
+@endiif
+@endiif
+}
+@iif TRI = 1
+@SKIP this proc handles only one element
+@SKIP IN : alpha, beta, C, b 
+@BEGINPROC doElementT r_ c_ k_
+   @iif alpha = 1
+      @iif beta = 0
+@ROUT blk2C `            C@(c_)[@(r_)] = b[@(k_)];`
+@ROUT C2blk `            b[@(k_)] = C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = 1
+@ROUT blk2C `            C@(c_)[@(r_)] += b[@(k_)];`
+@ROUT C2blk `            b[@(k_)] += C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = -1
+@ROUT blk2C `            C@(c_)[@(r_)] = b[@(k_)] - C@(c_)[@(r_)];`
+@ROUT C2blk `            b[@(k_)] = C@(c_)[@(r_)] - b[@(k_)];`
+      @endiif
+      @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `            C@(c_)[@(r_)] = beta*C@(c_)[@(r_)] + b[@(k_)];`
+@ROUT C2blk `            b[@(k_)] = beta*b[@(k_)] + C@(c_)[@(r_)];`
+      @endiif
+   @endiif
+   @iif alpha = -1
+      @iif beta = 0
+@ROUT blk2C `            C@(c_)[@(r_)] = -b[@(k_)];`
+@ROUT C2blk `            b[@(k_)] = -C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = 1
+@ROUT blk2C `            C@(c_)[@(r_)] -= b[@(k_)];`
+@ROUT C2blk `            b[@(k_)] -= C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = -1
+@ROUT blk2C `            C@(c_)[@(r_)] = -C@(c_)[@(r_)] - b[@(k_)];`
+@ROUT C2blk `            b[@(k_)] = -C@(c_)[@(r_)] - b[@(k_)];`
+      @endiif
+      @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `            C@(c_)[@(r_)] = beta*C@(c_)[@(r_)] - b[@(k_)];`
+@ROUT C2blk `            b[@(k_)] = beta*b[@(k_)] - C@(c_)[@(r_)];`
+      @endiif
+   @endiif
+   @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
+      @iif beta = 0
+@ROUT blk2C `            C@(c_)[@(r_)] = alpha*b[@(k_)];`
+@ROUT C2blk `            b[@(k_)] = alpha*C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = 1
+@ROUT blk2C `            C@(c_)[@(r_)] += alpha*b[@(k_)];`
+@ROUT C2blk `            b[@(k_)] += alpha*C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = -1
+@ROUT blk2C `            C@(c_)[@(r_)] = alpha*b[@(k_)] - C@(c_)[@(r_)];`
+@ROUT C2blk `            b[@(k_)] = alpha*C@(c_)[@(r_)] - b[@(k_)];`
+      @endiif
+      @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `            C@(c_)[@(r_)] = beta*C@(c_)[@(r_)] + alpha*b[@(k_)];`
+@ROUT C2blk `            b[@(k_)] = beta*b[@(k_)] + alpha*C@(c_)[@(r_)];`
+      @endiif
+   @endiif
+@ENDPROC
+@SKIP IN : alpha, beta, C, b 
+@BEGINPROC doElementTrr r_ c_ k_ m_
+   @iif alpha = 1
+      @iif beta = 0
+@ROUT blk2C `            C@(c_)[@(r_)] = b[rr*@(m_)+@(k_)];`
+@ROUT C2blk `            b[rr*@(m_)+@(k_)] = C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = 1
+@ROUT blk2C `            C@(c_)[@(r_)] += b[rr*@(m_)+@(k_)];`
+@ROUT C2blk `            b[rr*@(m_)+@(k_)] += C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = -1
+@ROUT blk2C `            C@(c_)[@(r_)] = b[rr*@(m_)+@(k_)] - C@(c_)[@(r_)];`
+@ROUT C2blk `            b[rr*@(m_)+@(k_)] = C@(c_)[@(r_)] - b[rr*@(m_)+@(k_)];`
+      @endiif
+      @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `            C@(c_)[@(r_)] = beta*C@(c_)[@(r_)] + b[rr*@(m_)+@(k_)];`
+@ROUT C2blk `            b[rr*@(m_)+@(k_)] = beta*b[rr*@(m_)+@(k_)] + C@(c_)[@(r_)];`
+      @endiif
+   @endiif
+   @iif alpha = -1
+      @iif beta = 0
+@ROUT blk2C `            C@(c_)[@(r_)] = -b[rr*@(m_)+@(k_)];`
+@ROUT C2blk `            b[rr*@(m_)+@(k_)] = -C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = 1
+@ROUT blk2C `            C@(c_)[@(r_)] -= b[rr*@(m_)+@(k_)];`
+@ROUT C2blk `            b[rr*@(m_)+@(k_)] -= C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = -1
+@ROUT blk2C `            C@(c_)[@(r_)] = -C@(c_)[@(r_)] - b[rr*@(m_)+@(k_)];`
+@ROUT C2blk `            b[rr+@(m_)+@(k_)] = -C@(c_)[@(r_)] - b[rr*@(m_)+@(k_)];`
+      @endiif
+      @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `            C@(c_)[@(r_)] = beta*C@(c_)[@(r_)] - b[rr*@(m_)+@(k_)];`
+@ROUT C2blk `            b[rr*@(m_)+@(k_)] = beta*b[rr*@(m)+@(k_)] - C@(c_)[@(r_)];`
+      @endiif
+   @endiif
+   @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
+      @iif beta = 0
+@ROUT blk2C `            C@(c_)[@(r_)] = alpha*b[rr*@(m_)+@(k_)];`
+@ROUT C2blk `            b[rr*@(m_)+@(k_)] = alpha*C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = 1
+@ROUT blk2C `            C@(c_)[@(r_)] += alpha*b[rr*@(m_)+@(k_)];`
+@ROUT C2blk `            b[rr*@(m_)+@(k_)] += alpha*C@(c_)[@(r_)];`
+      @endiif
+      @iif beta = -1
+@ROUT blk2C `            C@(c_)[@(r_)] = alpha*b[rr*@(m)+@(k_)] - C@(c_)[@(r_)];`
+@ROUT C2blk `            b[rr*@(m_)+@(k_)] = alpha*C@(c_)[@(r_)] - b[rr*@(m_)+@(k_)];`
+      @endiif
+      @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `            C@(c_)[@(r_)] = beta*C@(c_)[@(r_)] + alpha*b[rr*@(m_)+@(k_)];`
+@ROUT C2blk `            b[rr*@(m_)+@(k_)] = beta*b[rr*@(m_)+@(k_)] + alpha*C@(c_)[@(r_)];`
+      @endiif
+   @endiif
+@ENDPROC
+@SKIP handles square block 
+@BEGINPROC doBlockT m_ n_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp k @(i) @(mu) * @(j) +
+         @callproc doElementT @(i) @(j) @(k)  
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif m_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@SKIP handles square block 
+@BEGINPROC doBlockTna m_ n_ mu_ inc_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp k @(i) @(mu_) * @(j) +
+         @callproc doElementT @(i) @(j) @(k)  
+         @iexp i @(i) 1 +
+      @endiwhile
+            C@(j) += @(inc_);
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@SKIP handles partial block for na ! 1 
+@BEGINPROC doDiBlockTna m_ n_ mu_ nu_ inc_ sc_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define t @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp t @(nu_) @(sc_) *
+         @iexp t @(t) @(j) +
+         @iexp k @(i) @(mu_) * @(j) +
+@ROUT C2blk
+         @iif i > @(t)
+         p[@(k)] = 0.0;
+         @endiif
+@ROUT C2blk blk2C
+         @iif i { @(t)
+            @iexp t @(sc_) 1 +
+            @iexp t @(t) @(nu_) *
+            @iif i < @(t)
+         @callproc doElementT @(i) @(j) @(k)  
+            @endiif   
+         @endiif
+         @iexp i @(i) 1 +
+      @endiwhile
+            C@(j) += @(inc_);
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef t
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@BEGINPROC doBlockTrr m_ n_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp k @(i) @(mu) * @(j) +
+         @callproc doElementT @(i) @(j) rr*@(nu)+@(k)  
+         @iexp i @(i) 1 +
+      @endiwhile
+            C@(j) += @(m_);
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@skip handles diagonal block
+@BEGINPROC doDiBlockT n_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+         @iexp k @(i) @(mu) * @(j) +
+@ROUT blk2C
+         @iexp r @(i)
+         @iexp c @(j)
+         @iif j } i
+      @callproc doElementT @(r) @(c) @(k)
+         @endiif
+@ROUT C2blk
+         @iif j < i
+            @iexp r @(j)
+            @iexp c @(i)
+         @endiif
+         @iif j } i
+            @iexp r @(i)
+            @iexp c @(j)
+         @endiif
+      @callproc doElementT @(r) @(c) @(k)
+@ROUT blk2C C2blk
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif n_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@skip handles diagonal block
+@BEGINPROC doDiBlockTrr n_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+         @iexp k @(i) @(mu) * @(j) +
+@ROUT blk2C
+         @iexp r @(i)
+         @iexp c @(j)
+         @iif j } i
+      @callproc doElementT @(r) @(c) rr*@(nu)+@(k)
+         @endiif
+@ROUT C2blk
+         @iif j < i
+            @iexp r @(j)
+            @iexp c @(i)
+         @endiif
+         @iif j } i
+            @iexp r @(i)
+            @iexp c @(j)
+         @endiif
+      @callproc doElementT @(r) @(c) rr*@(nu)+@(k)
+@ROUT blk2C C2blk
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif n_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@skip  doCuDiBlockT @(mu) @(nu) @(ma)
+@SKIP IN: mu, nu, beta, alpha,
+@BEGINPROC doCuDiBlockT m_ n_ ma_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define sc @dum@
+   @define t @dum@
+   @iexp sc 0
+   @iwhile sc < @(ma_)
+   case @(sc):
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+         @iexp k @(i) @(m_) *
+         @iexp t @(sc) @(n_) *
+         @iexp k @(k) @(t) +
+         @iexp k @(k) @(j) +
+         @iif j } i
+            @callproc doElementT @(i) @(j) @(k)
+         @endiif
+         @iexp i @(i) 1 +
+      @endiwhile
+         C@(j) += @(n_);
+      @iexp j @(j) 1 +
+   @endiwhile
+      break;
+      @iexp sc @(sc) 1 +
+   @endiwhile
+   @undef t
+   @undef sc
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@ROUT C2blk `#if 0`
+#ifndef Mjoin
+   #define Mjoin(pre, nam) my_join(pre, nam)
+   #define my_join(pre, nam) pre ## nam
+#endif
+/*
+ * The block is assumed to store L, this function does a transpose while
+ * copying so that it is transferred with Upper portion of C
+ */
+void Mjoin(ATL_USERCPMM,_L2UT)
+(
+   const size_t M,      /* number of rows in A */
+   const size_t N,      /* number of columns in A */
+   @ROUT blk2C
+   const @(typ) alpha,  /* scalar for b */
+   const @(typ) *b,     /* matrix stored in @(mu)x@(nu)-major order */
+   const @(typ) beta,   /* scalar for C */
+   @(typ) *C,           /* matrix to be copied to access-major format */
+   const size_t ldc     /* stride between row elements */
+   @ROUT C2blk
+   const @(typ) alpha,  /* scalar for C */
+   const @(typ) *C,     /* matrix to be copied to access-major format */
+   const size_t ldc,    /* stride between row elements */
+   const @(typ) beta,   /* scalar for b */
+   @(typ) *b            /* matrix stored in @(mu)x@(nu)-major order */
+   @ROUT C2blk blk2C
+)
+{
+   const unsigned int mf = M/@(mu), nf = N/@(nu);
+   const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
+   unsigned int i, j;
+@iif na = 1      
+   const size_t incC0 = ldc*@(nu);
+@ROUT blk2C `   @declare "   @(typ) " n n ";"`
+@ROUT C2blk `   @declare "   const @(typ) " n n ";"`
+      *C0=C
+      @define j @1@
+      @iwhile j < @(nu)
+         @iexp i @(j) -1 +
+         *C@(j)=C@(i)+ldc
+         @iexp j @(j) 1 +
+      @endiwhile
+   @enddeclare
+@endiif
+@iif na ! 1      
+   const size_t incC0 = ldc*@(mu);
+@ROUT blk2C `   @declare "   @(typ) " n n ";"`
+@ROUT C2blk `   @declare "   const @(typ) " n n ";"`
+      *C0=C
+      @define j @1@
+      @iwhile j < @(mu)
+         @iexp i @(j) -1 +
+         *C@(j)=C@(i)+ldc
+         @iexp j @(j) 1 +
+      @endiwhile
+   @enddeclare
+@endiif
+@skip .... 
+@iif mEn = 0
+   @iif ma ! 1
+   unsigned int pansz = @(ma)*@(bs);
+@ROUT blk2C `   const @(typ) *p = b;` 
+@ROUT C2blk `   @(typ) *p = b;` 
+   int rr;
+   @endiif
+@endiif
+@iif na = 1
+   for (j=0; j < nf; j++)
+   {
+      unsigned int incC = incC0 - (j+1)*@(nu);
+      @iif mEn = 0
+         @iif ma ! 1
+      b = p;
+      rr = j % @(ma);
+         @endiif
+      @endiif
+      for (i=0; i < j; i++, b += @(bs))
+      {
+      @iif mEn = 1
+         @callproc doBlockT @(mu) @(nu)
+      @endiif
+      @iif mEn = 0
+         @iif ma ! 0
+         @callproc doBlockTrr @(nu) @(nu) 
+         @endiif
+      @endiif
+      }
+   @iif mEn = 1
+      @callproc doDiBlockT @(nu)
+   @iexp j 0
+   @iwhile j < @(nu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+      b += @(bs);
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+      switch(j%@(ma))
+      {
+      @callproc doCuDiBlockT @(mu) @(nu) @(ma)
+      }
+   @iexp j 0
+   @iwhile j < @(nu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+      p += ((j+1)%@(ma)==0? pansz: 0);
+      pansz += ((j+1)%@(ma)==0? @(ma)*@(bs):0);
+      @endiif
+   @endiif
+   }
+@endiif
+@iif na ! 1
+   for (j=0; j < mf; j++)
+   {
+      size_t incC = incC0 - (j/@(na)+1)*@(nu);
+      for (i=0; i < j/@(na); i++, b+=@(bs))
+      {
+         @callproc doBlockTna @(nu) @(mu) @(mu) @(nu)
+      }
+      switch(j%@(na))
+      {
+      @iexp n 0
+      @iwhile n < @(na)
+      case @(n):
+         @callproc doDiBlockTna @(nu) @(mu) @(mu) @(mu) @(nu) @(n)
+      break;
+         @iexp n @(n) 1 +
+      @endiwhile
+      }
+   @iexp j 0
+   @iwhile j < @(mu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+      b += @(bs);
+   }
+@endiif
+@iif nu > 1
+   @iif mEn = 1
+   switch(nr)
+   {
+   @iexp n 1
+   @iwhile n < @(nu)
+   case @(n):
+      for (i=0; i < mf; i++, b += @(bs))
+      {
+         @callproc doBlockT @(mu) @(n)
+      }
+      switch(mr)
+      {
+   @iexp m 1
+   @iwhile m < @(mu)
+      case @(m):
+      @skip Assumption for sryk  m = n" 
+      @callproc doDiBlockT @(m) 
+      @iexp m @(m) 1 +
+         break;
+   @endiwhile
+      default:;
+      }
+      break;
+      @iexp n @(n) 1 +
+   @endiwhile
+   default:;
+   }
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+      b = p;
+      rr = nf % @(ma);
+      switch(nr)
+      {
+         @iexp n 1
+         @iwhile n < @(nu)
+         case @(n) :
+            for (i=0; i < nf; i++, b+=@(bs))
+            {
+               @callproc doBlockTrr @(nu) @(n)
+            }
+               @callproc doDiBlockTrr @(n)
+         break;
+            @iexp n @(n) 1 +
+         @endiwhile
+      }
+      @endiif
+   @endiif
+@endiif
+@iif mu > 1
+   @iif na ! 1
+   switch (mr)
+   {
+      @iexp n 1
+      @iwhile n < @(mu)
+      case @(n):
+         for (i=0; i < nf; i++, b+=@(bs))
+         {
+         @callproc doBlockTna @(nu) @(n) @(mu) @(nu)
+         }
+         switch ( mf % @(na))
+         {
+            @iexp m 0 
+            @iwhile m < na  
+         case @(m):
+            @callproc doDiBlockTna @(nu) @(n) @(mu) @(mu) @(nu) @(m)
+            break;
+               @iexp m @(m) 1  +
+            @endiwhile
+         }
+      break;
+         @iexp n @(n) 1 +
+      @endiwhile
+   }
+   @endiif
+@endiif
+}
+@ROUT C2blk `#endif`
+@endiif
+@PRE C Z
+   @iexp betX 0 @(beta) ! 1 @(beta) ! & -1 @(beta) ! &
+   @iexp alpX 0 @(alpha) ! 1 @(alpha) ! & -1 @(alpha) ! &
+@SKIP blksz = ((mu*nu+vlen-1)/vlen)*vlen
+@iexp bs @(vl) @(mu) @(nu) * @(vl) + -1 + / @(vl) *
+// HERE vl=@(vl), mu=@(mu), nu=@(nu) bs=@(bs)
+@SKIP ***calc single element****
+@BEGINPROC doElement c_ ir_ ii_ k_
+         @iif alpha = 1
+            @iif beta = 0
+@ROUT blk2C 
+            C@(c_)[@(ir_)] = pr[@(k_)];
+            C@(c_)[@(ii_)] = pi[@(k_)];
+@ROUT C2blk 
+            pr[@(k_)] = C@(c_)[@(ir_)];
+            pi[@(k_)] = C@(c_)[@(ii_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            C@(c_)[@(ir_)] += pr[@(k_)];
+            C@(c_)[@(ii_)] += pi[@(k_)];
+@ROUT C2blk 
+            pr[@(k_)] += C@(c_)[@(ir_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            C@(c_)[@(ir_)] = pr[@(k_)] - C@(c_)[@(ir_)];
+            C@(c_)[@(ii_)] = pi[@(k_)] - C@(c_)[@(ii_)];
+@ROUT C2blk 
+            pr[@(k_)] = C@(c_)[@(ir_)] - pr[@(k_)];
+            pi[@(k_)] = C@(c_)[@(ii_)] - pi[@(k_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
+               register @(typ) rrv=pr[@(k_)], irv=pi[@(k_)];
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               C@(c_)[@(ir_)] = rrv;
+               C@(c_)[@(ii_)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=pr[@(k_)], ic=pi[@(k_)];
+               register @(typ) rrv=C@(c_)[@(ir_)], irv=C@(c_)[@(ii_)];
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               pr[@(k_)] = rrv;
+               pi[@(k_)] = ic;
+            }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+         @iif alpha = -1
+            @iif beta = 0
+@ROUT blk2C 
+            C@(c_)[@(ir_)] = -pr[@(k_)];
+            C@(c_)[@(ii_)] = -pi[@(k_)];
+@ROUT C2blk 
+            pr[@(k_)] = -C@(c_)[@(ir_)];
+            pi[@(k_)] = -C@(c_)[@(ii_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            C@(c_)[@(ir_)] -= pr[@(k_)];
+            C@(c_)[@(ii_)] -= pi[@(k_)];
+@ROUT C2blk 
+            pr[@(k_)] -= C@(c_)[@(ir_)];
+            pi[@(k_)] -= C@(c_)[@(ii_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            C@(c_)[@(ir_)] = -C@(c_)[@(ir_)] - pr[@(k_)];
+            C@(c_)[@(ii_)] = -C@(c_)[@(ii_)] - pi[@(k_)];
+@ROUT C2blk 
+            pr[@(k_)] = -C@(c_)[@(ir_)] - pr[@(k_)];
+            pi[@(k_)] = -C@(c_)[@(ii_)] - pi[@(k_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
+               register @(typ) rrv = -pr[@(k_)], irv = -pi[@(k_)];
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               C@(c_)[@(ir_)] = rrv;
+               C@(c_)[@(ii_)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=pr[@(k_)], ic=pi[@(k_)];
+               register @(typ) rrv = -C@(c_)[@(ir_)], irv = -C@(c_)[@(ii_)];
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               pr[@(k_)] = rrv;
+               pi[@(k_)] = ic;
+            }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+         @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
+            @iif beta = 0
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=pr[@(k_)], ic=pi[@(k_)];
+               register @(typ) rrv, irv;
+               rrv = rc * ra;
+               irv = ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               C@(c_)[@(ir_)] = rrv;
+               C@(c_)[@(ii_)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
+               register @(typ) rrv, irv;
+               rrv  = rc * ra;
+               irv  = ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               pr[@(k_)] = rrv;
+               pi[@(k_)] = irv;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=pr[@(k_)], ic=pi[@(k_)];
+               register @(typ) rrv=C@(c_)[@(ir_)], irv=C@(c_)[@(ii_)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               C@(c_)[@(ir_)] = rrv;
+               C@(c_)[@(ii_)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
+               register @(typ) rrv=pr[@(k_)], irv=pi[@(k_)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               pr[@(k_)] = rrv;
+               pi[@(k_)] = irv;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=pr[@(k_)], ic=pi[@(k_)];
+               register @(typ) rrv = -C@(c_)[@(ir_)], irv = -C@(c_)[@(ii_)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               C@(c_)[@(ir_)] = rrv;
+               C@(c_)[@(ii_)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
+               register @(typ) rrv = -pr[@(k_)], irv = -pi[@(k_)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               pr[@(k_)] = rrv;
+               pi[@(k_)] = irv;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            {
+               register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
+               register @(typ) rB=pr[@(k_)], iB=pi[@(k_)], r0, i0, r1, i1;
+               r0  = rb * rc;
+               r1  = ra * rB;
+               i0  = rb * ic;
+               i1  = ra * iB;
+               r0 -= ib * ic;
+               i1 += ib * rc;
+               r1 -= ia * iB;
+               i1 += ia * rB;
+               C@(c_)[@(ir_)] = r0 + r1;
+               C@(c_)[@(ii_)] = i0 + i1;
+            }
+@ROUT C2blk 
+            {
+               register @(typ) rB=C@(c_)[@(ir_)], iB=C@(c_)[@(ii_)];
+               register @(typ) rc=pr[@(k_)], ic=pi[@(k_)], r0, i0, r1, i1;
+               r0  = rb * rc;
+               r1  = ra * rB;
+               i0  = rb * ic;
+               i1  = ra * iB;
+               r0 -= ib * ic;
+               i1 += ib * rc;
+               r1 -= ia * iB;
+               i1 += ia * rB;
+               pr[@(k_)] = r0 + r1;
+               pi[@(k_)] = i0 + i1;
+            }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+@ENDPROC
+@SKIP IN: mu, nu, beta, alpha
+@BEGINPROC doDiBlock n_
+   @define i @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @define j @dum@
+   @define k @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+@ROUT C2blk 
+         @iif j > i
+            @iexp ir @(j) @(j) +
+            @define h @@(i)@
+         @endiif
+         @iif j { i
+            @iexp ir @(i) @(i) +
+            @define h @@(j)@
+         @endiif
+         @iexp ii @(ir) 1 +
+         @iexp k @(j) @(mu) * @(i) +
+@ROUT blk2C 
+         @iexp ir @(i) @(i) +
+         @iexp ii @(ir) 1 +
+         @iexp k @(j) @(mu) * @(i) +
+         @iif j { i
+@ROUT blk2C C2blk
+         @iif alpha = 1
+            @iif beta = 0
+@ROUT blk2C 
+            C@(j)[@(ir)] = pr[@(k)];  
+            C@(j)[@(ii)] = pi[@(k)];
+@ROUT C2blk 
+            pr[@(k)] = C@(h)[@(ir)];
+            pi[@(k)] = C@(h)[@(ii)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            C@(j)[@(ir)] += pr[@(k)];
+            C@(j)[@(ii)] += pi[@(k)];
+@ROUT C2blk 
+            pr[@(k)] += C@(h)[@(ir)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            C@(j)[@(ir)] = pr[@(k)] - C@(j)[@(ir)];
+            C@(j)[@(ii)] = pi[@(k)] - C@(j)[@(ii)];
+@ROUT C2blk 
+            pr[@(k)] = C@(h)[@(ir)] - pr[@(k)];
+            pi[@(k)] = C@(h)[@(ii)] - pi[@(k)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=C@(j)[@(ir)], ic=C@(j)[@(ii)];
+               register @(typ) rrv=pr[@(k)], irv=pi[@(k)];
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               C@(j)[@(ir)] = rrv;
+               C@(j)[@(ii)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=pr[@(k)], ic=pi[@(k)];
+               register @(typ) rrv=C@(h)[@(ir)], irv=C@(h)[@(ii)];
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               pr[@(k)] = rrv;
+               pi[@(k)] = ic;
+            }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+         @iif alpha = -1
+            @iif beta = 0
+@ROUT blk2C 
+            C@(j)[@(ir)] = -pr[@(k)];
+            C@(j)[@(ii)] = -pi[@(k)];
+@ROUT C2blk 
+            pr[@(k)] = -C@(h)[@(ir)];
+            pi[@(k)] = -C@(h)[@(ii)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            C@(j)[@(ir)] -= pr[@(k)];
+            C@(j)[@(ii)] -= pi[@(k)];
+@ROUT C2blk 
+            pr[@(k)] -= C@(h)[@(ir)];
+            pi[@(k)] -= C@(h)[@(ii)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            C@(j)[@(ir)] = -C@(j)[@(ir)] - pr[@(k)];
+            C@(j)[@(ii)] = -C@(j)[@(ii)] - pi[@(k)];
+@ROUT C2blk 
+            pr[@(k)] = -C@(h)[@(ir)] - pr[@(k)];
+            pi[@(k)] = -C@(h)[@(ii)] - pi[@(k)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=C@(j)[@(ir)], ic=C@(j)[@(ii)];
+               register @(typ) rrv = -pr[@(k)], irv = -pi[@(k)];
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               C@(j)[@(ir)] = rrv;
+               C@(j)[@(ii)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=pr[@(k)], ic=pi[@(k)];
+               register @(typ) rrv = -C@(h)[@(ir)], irv = -C@(h)[@(ii)];
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               pr[@(k)] = rrv;
+               pi[@(k)] = ic;
+            }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+         @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
+            @iif beta = 0
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=pr[@(k)], ic=pi[@(k)];
+               register @(typ) rrv, irv;
+               rrv = rc * ra;
+               irv = ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               C@(j)[@(ir)] = rrv;
+               C@(j)[@(ii)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=C@(h)[@(ir)], ic=C@(h)[@(ii)];
+               register @(typ) rrv, irv;
+               rrv  = rc * ra;
+               irv  = ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               pr[@(k)] = rrv;
+               pi[@(k)] = irv;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=pr[@(k)], ic=pi[@(k)];
+               register @(typ) rrv=C@(j)[@(ir)], irv=C@(j)[@(ii)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               C@(j)[@(ir)] = rrv;
+               C@(j)[@(ii)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=C@(h)[@(ir)], ic=C@(h)[@(ii)];
+               register @(typ) rrv=pr[@(k)], irv=pi[@(k)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               pr[@(k)] = rrv;
+               pi[@(k)] = irv;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=pr[@(k)], ic=pi[@(k)];
+               register @(typ) rrv = -C@(j)[@(ir)], irv = -C@(j)[@(ii)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               C@(j)[@(ir)] = rrv;
+               C@(j)[@(ii)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=C@(h)[@(ir)], ic=C@(h)[@(ii)];
+               const register @(typ) rrv = -pr[@(k)], irv = -pi[@(k)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               pr[@(k)] = rrv;
+               pi[@(k)] = irv;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            {
+               register @(typ) rc=C@(j)[@(ir)], ic=C@(j)[@(ii)];
+               register @(typ) rB=pr[@(k)], iB=pi[@(k)], r0, i0, r1, i1;
+               r0  = rb * rc;
+               r1  = ra * rB;
+               i0  = rb * ic;
+               i1  = ra * iB;
+               r0 -= ib * ic;
+               i1 += ib * rc;
+               r1 -= ia * iB;
+               i1 += ia * rB;
+               C@(j)[@(ir)] = r0 + r1;
+               C@(j)[@(ii)] = i0 + i1;
+            }
+@ROUT C2blk 
+            {
+               register @(typ) rB=C@(h)[@(ir)], iB=C@(h)[@(ii)];
+               register @(typ) rc=pr[@(k)], ic=pi[@(k)], r0, i0, r1, i1;
+               r0  = rb * rc;
+               r1  = ra * rB;
+               i0  = rb * ic;
+               i1  = ra * iB;
+               r0 -= ib * ic;
+               i1 += ib * rc;
+               r1 -= ia * iB;
+               i1 += ia * rB;
+               pr[@(k)] = r0 + r1;
+               pi[@(k)] = i0 + i1;
+            }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+@ROUT blk2C
+         @endiif
+@ROUT blk2C C2blk
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iexp i @(mu) @(mu) +
+      @iif n_ = mu
+            C@(j) += @(i);
+      @endiif
+@ROUT C2blk `      @undef h`
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef ii
+   @undef ir
+   @undef j
+   @undef i 
+@ENDPROC
+@BEGINPROC doBlock m_ n_
+   @define i @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @define j @dum@
+   @define k @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp ir @(i) @(i) +
+         @iexp ii @(ir) 1 +
+         @iexp k @(j) @(mu) * @(i) +
+         @callproc doElement @(j) @(ir) @(ii) @(k) 
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iexp i @(mu) @(mu) +
+      @iif m_ = mu
+            C@(j) += @(i);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef ii
+   @undef ir
+   @undef i
+   @undef j
+@ENDPROC
+@SKIP this is for mu = ma*nu diagonal subblocks
+@SKIP IN: mu, nu, beta, alpha
+@BEGINPROC doDiBlockmn m_ n_ ma_
+   @define i @dum@
+   @define j @dum@
+   @define jj @dum@
+   @define k @dum@
+   @define t @dum@
+   @define sc @dum@
+   @define ir @dum@
+   @define ii @dum@
+
+   switch (j%@(ma_))
+   {
+      @iexp sc 0
+      @iwhile sc < @(ma_)
+      case @(sc):
+         @iexp j 0
+         @iwhile j < @(n_)  
+            @iexp i 0
+            @iwhile i < @(m_) 
+               @iexp k @(j) @(mu) * @(i) +
+               @iexp t @(nu) @(sc) *
+               @iexp t @(t) @(j) +
+               @iif i < @(t) 
+@ROUT C2blk    
+                  @iexp jj @(m_) -1 +    
+                  @iexp ir @(jj) @(jj) + 
+                  @iexp ii @(ir) 1 + 
+                  @callproc doElement @(j) @(ir) @(ii) @(k) 
+@ROUT C2blk blk2C
+               @endiif
+               @iif i } @(t)
+                  @iexp ir @(i) @(i) + 
+                  @iexp ii @(ir) 1 + 
+                  @callproc doElement @(j) @(ir) @(ii) @(k)
+               @endiif
+               @iexp i @(i) 1 +
+            @endiwhile
+         @iexp ir @(m_) @(m_) +
+         @skip C@(j) += @(m_);
+         C@(j) += @(ir);
+            @iexp j @(j) 1 +
+         @endiwhile
+         break;
+         @iexp sc @(sc) 1 +
+      @endiwhile
+   }
+   @undef ir 
+   @undef ii 
+   @undef i
+   @undef j
+   @undef jj
+   @undef k
+   @undef t
+   @undef sc
+@ENDPROC
+@SKIP diagonal block when nu > mu and nu = na * mu
+@BEGINPROC doDirrBlockna n_ mul_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define c @dum@
+   @define r @dum@
+   @define m @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+         @iexp k @(j) @(mu) * @(i) +
+@ROUT blk2C
+         @iexp r @(i)
+         @iexp c @(j)
+         @iif j { i
+@ROUT C2blk
+         @iif j > i
+            @iexp r @(j)
+            @iexp c @(i)
+         @endiif
+         @iif j { i
+            @iexp r @(i)
+            @iexp c @(j)
+         @endiif
+@ROUT blk2C C2blk
+         @iexp ir @(r) @(r) + 
+         @iexp ii @(ir) 1 + 
+         @callproc doElement @(c) @(ir) @(ii) @(k)+rr*@(mul_) 
+@ROUT blk2C
+         @endiif
+@ROUT blk2C C2blk
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif n_ = mu
+            @iexp ir @(mu) @(mu) +
+            @skip C@(j) += @(mu);
+            C@(j) += @(ir);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef i
+   @undef j
+   @undef c
+   @undef r
+   @undef m
+   @undef ir
+   @undef ii
+@ENDPROC
+@SKIP full blocks with multiplication 
+@BEGINPROC donaBlock m_ n_ mn_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define m @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp k @(j) @(mu) * @(i) +
+         @iexp ir @(i) @(i) + 
+         @iexp ii @(ir) 1 + 
+         @callproc doElement @(j) @(ir) @(ii) @(k)+rr*@(mn_) 
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif m_ = mu
+         @iexp ir @(mu) @(mu) + 
+            C@(j) += @(ir);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef ii
+   @undef ir
+   @undef m
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@SKIP this is for cleanup diagonal subblocks when mu!=nu 
+@SKIP IN: mu, nu, beta, alpha,
+@BEGINPROC doCuDiBlockmn m_ n_ ma_
+   @define i @dum@
+   @define j @dum@
+   @define jj @dum@
+   @define k @dum@
+   @define t @dum@
+   @define sc @dum@
+   @define m @dum@
+   
+      unsigned int rr;
+      switch (j%@(ma_))
+      {
+      @iexp m @(ma_) -1 +
+      @iexp sc 0
+      @iwhile sc < @(m)
+      case @(sc):
+         
+         @iexp j 0
+         @iwhile j < @(n_)  
+
+            @iexp i 0 
+            @iwhile i < @(m_) 
+               @iexp k @(j) @(mu) * @(i) +
+               @iexp t @(nu) @(sc) *
+               @iexp t @(t) @(j) +
+@ROUT C2blk    
+               @iif i < @(t) 
+               @iexp jj @(i) 1 +    
+            pr[@(k)] = 0.0;
+            pi[@(k)] = 0.0;
+               @endiif
+@ROUT C2blk blk2C
+               @iif i } @(t)
+                  @skip "upper limit"
+                  @iexp t @(sc) 1 +
+                  @iexp t @(t) @(nu) *
+                  @iif i < @(t)
+                     @iexp ir @(i) @(i) + 
+                     @iexp ii @(ir) 1 + 
+            @callproc doElement @(j) @(ir) @(ii) @(k)
+                  @endiif
+               @endiif
+               @iexp i @(i) 1 +
+            @endiwhile
+            @iexp j @(j) 1 +
+         @endiwhile
+            @skip "now from nu to mu "
+            @iexp jj @(sc) 1 +
+            @iexp jj @(jj) @(n_) *
+         for (rr=@(jj); rr < mr; rr++ )
+         {
+               @iexp jj 0
+               @iwhile jj < @(n_)
+                  @iexp t @(jj) @(m_) * 
+                  @callproc doElement @(jj) (2*rr) (2*rr+1) @(t)+rr
+                  @iexp jj @(jj) 1 +
+               @endiwhile
+         }
+         break;
+         @iexp sc @(sc) 1 +
+      @endiwhile
+      }
+   @undef i
+   @undef j
+   @undef jj
+   @undef k
+   @undef t
+   @undef sc
+   @undef m
+@ENDPROC
+@ROUT blk2C C2blk
+@iif cpvl = 1
+void @(rtnm)
+(
+   const size_t M,      /* number of rows in A */
+   const size_t N,      /* number of columns in A */
+   const @(typ) *alpha, /* scalar for b */
+   @ROUT blk2C
+   const @(typ) *rC,    /* real block stored in @(mu)x@(nu)-major order */
+   const @(typ) *iC,    /* imag block stored in @(mu)x@(nu)-major order */
+   const @(typ) *beta,  /* scalar for C */
+   @(typ) *C,           /* matrix to be copied to access-major format */
+   const size_t ldc     /* stride between row elements */
+   @ROUT C2blk
+   const @(typ) *C,     /* matrix to be copied to access-major format */
+   const size_t ldc,    /* stride between row elements */
+   const @(typ) *beta,  /* scalar for C */
+   @(typ) *rC,          /* real block stored in @(mu)x@(nu)-major order */
+   @(typ) *iC           /* imag block stored in @(mu)x@(nu)-major order */
+   @ROUT C2blk blk2C
+)
+@endiif
+@iif cpvl > 1
+static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha, 
+                         const @(typ) *b, const SCALAR beta, 
+                         @(typ) *C, ATL_CSZT ldc)
+@endiif
+{
+   const unsigned int mf = M/@(mu), nf = N/@(nu);
+   const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
+@iif TRI = 1
+   @iif mEn = 1
+   unsigned int pansz = @(bs);
+   const size_t ldc2 = ldc+ldc, incC0 = (ldc2+2)*@(nu);
+   @endiif
+   @iif mEn = 0
+      @skip "*** case mu = ma*nu"
+      @iif ma ! 1
+   unsigned int pansz = @(bs)*@(ma);
+   const unsigned int manf = (N/(@(nu)*@(ma)))*@(ma);
+   const unsigned int manr = nf - manf;
+   const size_t ldc2 = ldc+ldc, incC0 = ldc2*@(nu);
+      @endiif 
+      @skip "*** special case for nu = na * mu"
+      @iif na ! 1
+   unsigned int pansz = @(bs);
+   const size_t ldc2 = ldc+ldc, incC0 = (ldc2+2)*@(nu);
+   const unsigned int mnf = N/@(mu);
+   const unsigned int mnr = N - (mnf*@(mu));
+   unsigned int rr; 
+      @endiif
+   @endiif
+@endiif
+@iif TRI = 0
+   const unsigned int pansz = (nr) ? (nf+1)*@(bs) : nf*@(bs); 
+   const size_t incC = (ldc*@(nu) - m)<<1, ldc2 = ldc+ldc;
+@endiif
+   unsigned int i, j;
+   @iif alpX ! 0
+   const register @(typ) ra=(*alpha), ia=alpha[1];
+   @endiif
+   @iif betX ! 0
+   const register @(typ) rb=(*beta), ib=beta[1];
+   @endiif
+@ROUT blk2C `   @declare "   @(typ) " n n ";"`
+@ROUT C2blk `   @declare "   const @(typ) " n n ";"`
+      *C0=C
+@iif na = 1
+      @define j @1@
+      @iwhile j < @(nu)
+         @iexp i @(j) -1 +
+         *C@(j)=C@(i)+ldc2
+         @iexp j @(j) 1 +
+      @endiwhile
+   @enddeclare
+@endiif
+@iif na ! 1
+      @define j @1@
+      @iwhile j < @(mu)
+         @iexp i @(j) -1 +
+         *C@(j)=C@(i)+ldc2
+         @iexp j @(j) 1 +
+      @endiwhile
+   @enddeclare
+@endiif
+@skip      @define j @1@
+@skip      @iwhile j < @(nu)
+@skip         @iexp i @(j) -1 +
+@skip         *C@(j)=C@(i)+ldc2
+@skip         @iexp j @(j) 1 +
+@skip      @endiwhile
+@skip   @enddeclare
+@iif TRI = 1
+   @iif mEn = 1
+   for (j=0; j < nf; j++)
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+   size_t incC;
+   for (j=0; j < manf; j++)
+      @endiif
+      @iif na ! 1
+   for (j=0; j < mnf; j++)
+      @endiif
+   @endiif
+@endiif
+@iif TRI = 0
+   for (j=nf; j; j--, rC += @(bs), iC += @(bs))
+@endiif
+   {
+@ROUT blk2C `      const @(typ) *pr = rC, *pi = iC;`
+@ROUT C2blk `      @(typ) *pr = rC, *pi = iC;`
+@iif TRI = 1
+   @iif mEn = 1
+      unsigned int psz = pansz+@(bs), incC = incC0 - (mf-j)*(@(mu)+@(mu));
+      @callproc doDiBlock @(nu)
+      pr += pansz; pi += pansz;
+      for (i=j+1; i < mf; i++, pr += psz, pi += psz, psz += @(bs))
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+      unsigned int psz = pansz + @(ma)*@(bs); 
+      incC = incC0 - (mf-(j+1)/@(ma))*(@(mu)+@(mu));
+      @callproc doDiBlockmn @(mu) @(nu) @(ma)
+      pr += pansz; pi += pansz;
+      for (i=j/@(ma)+1; i < mf; i++, pr += psz, pi += psz, psz += @(bs)*@(ma))
+      @endiif
+      @iif na ! 1
+      unsigned int psz = pansz, incC = incC0 - (mf-j)*@(mu);
+         rr = j % @(na);
+      @iexp mumu @(mu) @(mu) *
+      @callproc doDirrBlockna @(mu) @(mumu)
+      pr += pansz; pi += pansz;
+      for (i=j+1; i < mf; i++, pr += psz, pi += psz )
+      @endiif
+   @endiif
+@endiif
+@iif TRI = 0
+      for (i=mf; i; i--, pr += pansz, pi += pansz)
+@endiif
+@iif na = 1
+      {
+         @callproc doBlock @(mu) @(nu)
+      }
+@endiif
+@iif na ! 1
+      {
+         @callproc donaBlock @(mu) @(mu) @(mumu)
+         psz += ((i%@(na))==0?@(bs):0);
+      }
+@endiif
+      switch(mr)
+      {
+   @iexp m 1
+   @iwhile m < @(mu)
+      case @(m):
+@iif na = 1
+      @callproc doBlock @(m) @(nu)
+@endiif
+@iif na ! 1
+      @callproc donaBlock @(m) @(mu) @(mumu)
+@endiif
+      @iexp m @(m) 1 +
+         break;
+   @endiwhile
+      default:;
+      }
+@iif na = 1
+   @iexp j 0
+   @iwhile j < @(nu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+@endiif
+@iif na ! 1
+   @iexp j 0
+   @iwhile j < @(mu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+@endiif
+@iif TRI = 1
+   @iif mEn = 1
+      pansz += @(bs);
+      rC += pansz;
+      iC += pansz;
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+      rC += ((j+1)% @(ma))==0 ? pansz+@(bs) : @(bs);
+      iC += ((j+1)% @(ma))==0 ? pansz+@(bs) : @(bs);
+      if ( (j+1) % @(ma) == 0)
+         pansz += @(ma)*@(bs);
+      @endiif
+      @iif na ! 1
+      pansz += ((j+1)%@(na)==0?@(bs):0);
+      rC += pansz;
+      iC += pansz;
+      @endiif
+   @endiif
+@endiif
+   }
+@iif TRI = 1   
+      @SKIP "Remainder of manr = nf - manf " 
+   @iif mEn = 0
+      @iif ma ! 1
+   for (j=manf; j < nf; j++)
+   {
+@ROUT blk2C `      const @(typ) *pr = rC, *pi = iC;`
+@ROUT C2blk `      @(typ) *pr = rC, *pi = iC;`
+      unsigned int psz = pansz + @(ma)*@(bs), 
+                         incC = incC0 - ((mf-(j+1)/@(ma))<<1)*@(mu);
+         @callproc doCuDiBlockmn @(mu) @(nu) @(ma)
+      pr += pansz;
+      pi += pansz;
+   @iexp j 0
+   @iwhile j < @(nu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+      rC += ((j+1)% @(ma))==0 ? pansz+@(bs) : @(bs);
+      iC += ((j+1)% @(ma))==0 ? pansz+@(bs) : @(bs);
+      if ( (j+1) % @(ma) == 0)
+         pansz += @(ma)*@(bs);
+   }
+         @endiif
+      @endiif
+@endiif
+@iif na = 1
+@iif nu > 1
+   switch(nr)
+   {
+@ROUT blk2C `      const @(typ) *pr, *pi;`
+@ROUT C2blk `      @(typ) *pr, *pi;`
+   @iexp n 1
+   @iwhile n < @(nu)
+   case @(n):
+      pr = rC; pi = iC;
+@iif TRI = 1
+   @iif mEn = 1
+      @callproc doDiBlock @(n)
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+         pr += mr - nr; pi += mr - nr; 
+         @iexp k 0
+         @iwhile k < @(n)
+            @skip ---C@(k) += mr-nr;
+            C@(k) += ((mr-nr)<<1);
+            @iexp k @(k) 1 +
+         @endiwhile
+         @skip "for nr cleanup, it works like mu=nu"
+         @callproc doDiBlock @(n)
+      @endiif
+   @endiif
+      break;
+@endiif
+@iif TRI = 0
+      for (i=0; i < mf; i++, pr += pansz, pi += pansz)
+      {
+         @callproc doBlock @(mu) @(n)
+      }
+      switch(mr)
+      {
+   @iexp m 1
+   @iwhile m < @(mu)
+      case @(m):
+      @callproc doBlock @(m) @(n)
+      @iexp m @(m) 1 +
+         break;
+   @endiwhile
+      default:;
+      }
+      break;
+@endiif
+      @iexp n @(n) 1 +
+   @endiwhile
+   default:;
+   }
+@endiif
+@endiif
+@iif na ! 1
+@iif mu > 1
+   rr = mnf % @(na);
+   switch(mnr)
+   {
+@ROUT blk2C `      const @(typ) *pr, *pi;`
+@ROUT C2blk `      @(typ) *pr, *pi;`
+   @iexp n 1
+   @iwhile n < @(mu)
+   case @(n):
+      pr= rC;
+      pi =iC;
+      @callproc doDirrBlockna @(n) @(mumu)
+         break;
+      @iexp n @(n) 1 +
+   @endiwhile
+   default:;
+   }
+@endiif
+@endiif
+}
+@iif TRI = 1
+@SKIP handles single element of sub-block
+@BEGINPROC doElementT c_ ir_ ii_ k_ 
+         @iif alpha = 1
+            @iif beta = 0
+@ROUT blk2C 
+            C@(c_)[@(ir_)] = rC[@(k_)];
+            #ifdef Conj_
+               C@(c_)[@(ii_)] = -iC[@(k_)];
+            #else
+               C@(c_)[@(ii_)] = iC[@(k_)];
+            #endif
+@ROUT C2blk 
+            rC[@(k_)] = C@(c_)[@(ir_)];
+            #ifdef Conj_
+               iC[@(k_)] = -C@(c_)[@(ii_)];
+            #else
+               iC[@(k_)] = C@(c_)[@(ii_)];
+            #endif
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            C@(c_)[@(ir_)] += rC[@(k_)];
+            #ifdef Conj_
+               C@(c_)[@(ii_)] -= iC[@(k_)];
+            #else
+               C@(c_)[@(ii_)] += iC[@(k_)];
+            #endif
+@ROUT C2blk 
+            rC[@(k_)] += C@(c_)[@(ir_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            C@(c_)[@(ir_)] = rC[@(k_)] - C@(c_)[@(ir_)];
+            #ifdef Conj_
+               C@(c_)[@(ii_)] = -iC[@(k_)] - C@(c_)[@(ii_)];
+            #else
+               C@(c_)[@(ii_)] = iC[@(k_)] - C@(c_)[@(ii_)];
+            #endif
+@ROUT C2blk 
+            rC[@(k_)] = C@(c_)[@(ir_)] - rC[@(k_)];
+            #ifdef Conj_
+               iC[@(k_)] = C@(c_)[@(ii_)] + iC[@(k_)];
+            #else
+               iC[@(k_)] = C@(c_)[@(ii_)] - iC[@(k_)];
+            #endif
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
+               register @(typ) rrv=rC[@(k_)];
+               #ifdef Conj_
+                  register @(typ) irv = -iC[@(k_)];
+               #else
+                  register @(typ) irv =  iC[@(k_)];
+               #endif
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               C@(c_)[@(ir_)] = rrv;
+               C@(c_)[@(ii_)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=rC[@(k_)], ic=iC[@(k_)];
+               register @(typ) rrv=C@(c_)[@(ir_)];
+               #ifdef Conj_
+                  register @(typ) irv = -C@(c_)[@(ii_)];
+               #else
+                  register @(typ) irv =  C@(c_)[@(ii_)];
+               #endif
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               rC[@(k_)] = rrv;
+               iC[@(k_)] = ic;
+            }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+         @iif alpha = -1
+            @iif beta = 0
+@ROUT blk2C 
+            C@(c_)[@(ir_)] = -rC[@(k_)];
+            #ifdef Conj_
+               C@(c_)[@(ii_)] = iC[@(k_)];
+            #else
+               C@(c_)[@(ii_)] = -iC[@(k_)];
+            #endif
+@ROUT C2blk 
+            rC[@(k_)] = -C@(c_)[@(ir_)];
+            #ifdef Conj_
+               iC[@(k_)] = C@(c_)[@(ii_)];
+            #else
+               iC[@(k_)] = -C@(c_)[@(ii_)];
+            #endif
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            C@(c_)[@(ir_)] -= rC[@(k_)];
+            #ifdef Conj_
+               C@(c_)[@(ii_)] += iC[@(k_)];
+            #else
+               C@(c_)[@(ii_)] -= iC[@(k_)];
+            #endif
+@ROUT C2blk 
+            rC[@(k_)] -= C@(c_)[@(ir_)];
+            #ifdef Conj_
+               iC[@(k_)] += C@(c_)[@(ii_)];
+            #else
+               iC[@(k_)] -= C@(c_)[@(ii_)];
+            #endif
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            C@(c_)[@(ir_)] = -C@(c_)[@(ir_)] - rC[@(k_)];
+            #ifdef Conj_
+               C@(c_)[@(ii_)] = iC[@(k_)] - C@(c_)[@(ii_)];
+            #else
+               C@(c_)[@(ii_)] = -C@(c_)[@(ii_)] - iC[@(k_)];
+            #endif
+@ROUT C2blk 
+            rC[@(k_)] = -C@(c_)[@(ir_)] - rC[@(k_)];
+            #ifdef Conj_
+               iC[@(k_)] = C@(c_)[@(ii_)] - iC[@(k_)];
+            #else
+               iC[@(k_)] = -C@(c_)[@(ii_)] - iC[@(k_)];
+            #endif
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
+               register @(typ) rrv = -rC[@(k_)];
+               #ifdef Conj_
+                  register @(typ) irv = iC[@(k_)];
+               #else
+                  register @(typ) irv = -iC[@(k_)];
+               #endif
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               C@(c_)[@(ir_)] = rrv;
+               C@(c_)[@(ii_)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=rC[@(k_)], ic=iC[@(k_)];
+               register @(typ) rrv = -C@(c_)[@(ir_)];
+               #ifdef Conj_
+                  register @(typ) irv =  C@(c_)[@(ii_)];
+               #else
+                  register @(typ) irv = -C@(c_)[@(ii_)];
+               #endif
+               rrv += rc * rb;
+               irv += ic * rb;
+               rrv -= ic * ib;
+               irv += rc * ib;
+               rC[@(k_)] = rrv;
+               iC[@(k_)] = ic;
+            }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+         @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
+            @iif beta = 0
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=rC[@(k_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -iC[@(k_)];
+               #else
+                  const register @(typ) ic =  iC[@(k_)];
+               #endif
+               register @(typ) rrv, irv;
+               rrv = rc * ra;
+               irv = ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               C@(c_)[@(ir_)] = rrv;
+               C@(c_)[@(ii_)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=C@(c_)[@(ir_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -C@(c_)[@(ii_)];
+               #else
+                  const register @(typ) ic =  C@(c_)[@(ii_)];
+               #endif
+               register @(typ) rrv, irv;
+               rrv  = rc * ra;
+               irv  = ic * ra;
+               rrv -= ic * ia;
+               ir += rc * ia;
+               rC[@(k_)] = rrv;
+               iC[@(k_)] = irv;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=rC[@(k_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -iC[@(k_)];
+               #else
+                  const register @(typ) ic =  iC[@(k_)];
+               #endif
+               register @(typ) rrv=C@(c_)[@(ir_)], irv=C@(c_)[@(ii_)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               C@(c_)[@(ir_)] = rrv;
+               C@(c_)[@(ii_)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=C@(c_)[@(ir_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -C@(c_)[@(ii_)];
+               #else
+                  const register @(typ) ic =  C@(c_)[@(ii_)];
+               #endif
+               register @(typ) rrv=rC[@(k_)], irv=iC[@(k_)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               rC[@(k_)] = rrv;
+               iC[@(k_)] = irv;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=rC[@(k_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -iC[@(k_)];
+               #else
+                  const register @(typ) ic =  iC[@(k_)];
+               #endif
+               register @(typ) rrv = -C@(c_)[@(ir_)], irv = -C@(c_)[@(ii_)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               C@(c_)[@(ir_)] = rrv;
+               C@(c_)[@(ii_)] = irv;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=C@(c_)[@(ir_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -C@(c_)[@(ii_)];
+               #else
+                  const register @(typ) ic =  C@(c_)[@(ii_)];
+               #endif
+               register @(typ) rrv = -rC[@(k_)], irv = -iC[@(k_)];
+               rrv += rc * ra;
+               irv += ic * ra;
+               rrv -= ic * ia;
+               irv += rc * ia;
+               rC[@(k_)] = rrv;
+               iC[@(k_)] = irv;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            {
+               register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
+               register @(typ) rB=rC[@(k_)], r0, i0, r1, i1;
+               #ifdef Conj_
+                  register @(typ) iB = -iC[@(k_)];
+               #else
+                  register @(typ) iB =  iC[@(k_)];
+               #endif
+               r0  = rb * rc;
+               r1  = ra * rB;
+               i0  = rb * ic;
+               i1  = ra * iB;
+               r0 -= ib * ic;
+               i1 += ib * rc;
+               r1 -= ia * iB;
+               i1 += ia * rB;
+               C@(c_)[@(ir_)] = r0 + r1;
+               C@(c_)[@(ii_)] = i0 + i1;
+            }
+@ROUT C2blk 
+            {
+               register @(typ) rB=C@(c_)[@(ir_)];
+               #ifdef Conj_
+                  register @(typ) iB = -C@(c_)[@(ii_)];
+               #else
+                  register @(typ) iB =  C@(c_)[@(ii_)];
+               #endif
+               register @(typ) rc=rC[@(k_)], ic=iC[@(k_)], r0, i0, r1, i1;
+               r0  = rb * rc;
+               r1  = ra * rB;
+               i0  = rb * ic;
+               i1  = ra * iB;
+               r0 -= ib * ic;
+               i1 += ib * rc;
+               r1 -= ia * iB;
+               i1 += ia * rB;
+               rC[@(k_)] = r0 + r1;
+               iC[@(k_)] = i0 + i1;
+            }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+@ENDPROC
+@BEGINPROC doBlockT m_ n_
+   @define i @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @define j @dum@
+   @define k @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp ir @(i) @(i) +
+         @iexp ii @(ir) 1 +
+         @iexp k @(i) @(mu) * @(j) +
+            @callproc doElementT @(j) @(ir) @(ii) @(k) 
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iexp i @(mu) @(mu) +
+      @iif m_ = mu
+            C@(j) += @(i);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef ii
+   @undef ir
+   @undef j
+@ENDPROC
+@BEGINPROC doBlockTrr m_ n_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp ir @(i) @(i) +
+         @iexp ii @(ir) 1 +
+         @iexp k @(i) @(mu) * @(j) +
+         @callproc doElementT @(j) @(ir) @(ii) rr*@(nu)+@(k)  
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iexp i @(m_) @(m_) +
+            C@(j) += @(i);
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef ii
+   @undef ir
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@BEGINPROC doBlockTna m_ n_ mu_ inc_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp ir @(i) @(i) +
+         @iexp ii @(ir) 1 +
+         @iexp k @(i) @(mu_) * @(j) +
+         @callproc doElementT @(j) @(ir) @(ii) @(k)  
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iexp i @(inc_) @(inc_) +
+            C@(j) += @(i);
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef ii
+   @undef ir
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@BEGINPROC doDiBlockT n_
+   @define i @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @define j @dum@
+   @define k @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+@ROUT C2blk 
+         @iif j < i
+            @iexp ir @(j) @(j) +
+            @define h @@(i)@
+         @endiif
+         @iif j } i
+            @iexp ir @(i) @(i) +
+            @define h @@(j)@
+         @endiif
+         @iexp ii @(ir) 1 +
+         @iexp k @(i) @(mu) * @(j) +
+            @callproc doElementT @(h) @(ir) @(ii) @(k) 
+@ROUT blk2C 
+         @iexp ir @(i) @(i) +
+         @iexp ii @(ir) 1 +
+         @iexp k @(i) @(mu) * @(j) +
+         @iif j } i
+            @callproc doElementT @(j) @(ir) @(ii) @(k) 
+         @endiif
+@ROUT blk2C C2blk
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif n_ = mu
+         @iexp i @(mu) @(mu) +
+            C@(j) += @(i);
+      @endiif
+@ROUT C2blk `      @undef h`
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef ii
+   @undef ir
+   @undef j
+@ENDPROC
+@skip handles diagonal block
+@BEGINPROC doDiBlockTrr n_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+         @iexp k @(i) @(mu) * @(j) +
+@ROUT blk2C
+         @iexp r @(i)
+         @iexp c @(j)
+         @iif j } i
+         @iexp ir @(r) @(r) +
+         @iexp ii @(ir) 1 +
+      @callproc doElementT @(c) @(ir) @(ii) rr*@(nu)+@(k)
+         @endiif
+@ROUT C2blk
+         @iif j < i
+            @iexp r @(j)
+            @iexp c @(i)
+         @endiif
+         @iif j } i
+            @iexp r @(i)
+            @iexp c @(j)
+         @endiif
+         @iexp ir @(r) @(r) +
+         @iexp ii @(ir) 1 +
+      @callproc doElementT @(c) @(ir) @(ii) rr*@(nu)+@(k)
+@ROUT blk2C C2blk
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif n_ = mu
+            @iexp i @(mu) @(mu) +
+            C@(j) += @(i);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef ii
+   @undef ir
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@skip  doCuDiBlockT @(mu) @(nu) @(ma)
+@SKIP IN: mu, nu, beta, alpha,
+@BEGINPROC doCuDiBlockT m_ n_ ma_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define sc @dum@
+   @define t @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp sc 0
+   @iwhile sc < @(ma_)
+   case @(sc):
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+         @iexp k @(i) @(m_) *
+         @iexp t @(sc) @(n_) *
+         @iexp k @(k) @(t) +
+         @iexp k @(k) @(j) +
+         @iif j } i
+            @iexp ir @(i) @(i) +
+            @iexp ii @(ir) 1 +
+            @callproc doElementT @(j) @(ir) @(ii) @(k)
+         @endiif
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iexp i @(n_) @(n_) +
+         C@(j) += @(i);
+      @iexp j @(j) 1 +
+   @endiwhile
+      break;
+      @iexp sc @(sc) 1 +
+   @endiwhile
+   @undef ii
+   @undef ir
+   @undef i
+   @undef j
+   @undef k
+   @undef sc
+   @undef t
+@ENDPROC
+@SKIP handles partial block for na ! 1 
+@BEGINPROC doDiBlockTna m_ n_ mu_ nu_ inc_ sc_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define t @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp t @(nu_) @(sc_) *
+         @iexp t @(t) @(j) +
+         @iexp k @(i) @(mu_) * @(j) +
+@ROUT C2blk
+         @iif i > @(t)
+         pr[@(k)] = 0.0;
+         pi[@(k)] = 0.0;
+         @endiif
+@ROUT C2blk blk2C
+         @iif i { @(t)
+            @iexp t @(sc_) 1 +
+            @iexp t @(t) @(nu_) *
+            @iif i < @(t)
+               @iexp ir @(i) @(i) +
+               @iexp ii @(ir) 1 +
+         @callproc doElementT @(j) @(ir) @(ii) @(k)  
+            @endiif   
+         @endiif
+         @iexp i @(i) 1 +
+      @endiwhile
+         @iexp i @(inc_) @(inc_) +
+            C@(j) += @(i);
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef ii
+   @undef ir
+   @undef t
+   @undef k
+   @undef i
+   @undef j
+@ENDPROC
+@ROUT C2blk `#if 0`
+#ifndef Mjoin
+   #define Mjoin(pre, nam) my_join(pre, nam)
+   #define my_join(pre, nam) pre ## nam
+#endif
+/*
+ * The block is assumed to store L, this function does a transpose while
+ * copying so that it is transferred with Upper portion of C
+ */
+#ifdef Conj_
+void Mjoin(ATL_USERCPMM,_L2UH)
+#else
+void Mjoin(ATL_USERCPMM,_L2UT)
+#endif
+(
+   const size_t M,      /* number of rows in A */
+   const size_t N,      /* number of columns in A */
+   const @(typ) *alpha, /* scalar for b */
+   @ROUT blk2C
+   const @(typ) *rC,    /* real block stored in @(mu)x@(nu)-major order */
+   const @(typ) *iC,    /* imag block stored in @(mu)x@(nu)-major order */
+   const @(typ) *beta,  /* scalar for C */
+   @(typ) *C,           /* matrix to be copied to access-major format */
+   const size_t ldc     /* stride between row elements */
+   @ROUT C2blk
+   const @(typ) *C,     /* matrix to be copied to access-major format */
+   const size_t ldc,    /* stride between row elements */
+   const @(typ) *beta,  /* scalar for C */
+   @(typ) *rC,          /* real block stored in @(mu)x@(nu)-major order */
+   @(typ) *iC           /* imag block stored in @(mu)x@(nu)-major order */
+   @ROUT C2blk blk2C
+)
+{
+   const unsigned int mf = M/@(mu), nf = N/@(nu);
+   const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
+   unsigned int i, j;
+   @iif alpX ! 0
+   const register @(typ) ra=(*alpha), ia=alpha[1];
+   @endiif
+   @iif betX ! 0
+   const register @(typ) rb=(*beta), ib=beta[1];
+   @endiif
+@iif na = 1      
+   const size_t ldc2 = ldc+ldc, incC0 = ldc2*@(nu);
+@ROUT blk2C `   @declare "   @(typ) " n n ";"`
+@ROUT C2blk `   @declare "   const @(typ) " n n ";"`
+      *C0=C
+      @define j @1@
+      @iwhile j < @(nu)
+         @iexp i @(j) -1 +
+         *C@(j)=C@(i)+ldc2
+         @iexp j @(j) 1 +
+      @endiwhile
+   @enddeclare
+@endiif
+@iif na ! 1      
+   const size_t ldc2 = ldc+ldc, incC0 = ldc2*@(mu);
+@ROUT blk2C `   @declare "   @(typ) " n n ";"`
+@ROUT C2blk `   @declare "   const @(typ) " n n ";"`
+      *C0=C
+      @define j @1@
+      @iwhile j < @(mu)
+         @iexp i @(j) -1 +
+         *C@(j)=C@(i)+ldc2
+         @iexp j @(j) 1 +
+      @endiwhile
+   @enddeclare
+@endiif
+@iif mEn = 0
+   @iif ma ! 1
+   unsigned int pansz = @(ma)*@(bs);
+@ROUT blk2C `   const @(typ) *pr = rC, *pi = iC;` 
+@ROUT C2blk `   @(typ) *pr = rC, *pi = iC;` 
+   int rr;
+   @endiif
+@endiif
+@iif na = 1
+   for (j=0; j < nf; j++)
+   {
+      unsigned int incC = incC0 - ((j+1)<<1)*@(nu);
+      @iif mEn = 0
+         @iif ma ! 1
+      rC = pr; iC = pi;
+      rr = j % @(ma);
+         @endiif
+      @endiif
+      for (i=0; i < j; i++, rC += @(bs), iC += @(bs))
+      {
+      @iif mEn = 1
+         @callproc doBlockT @(mu) @(nu)
+      @endiif
+      @iif mEn = 0
+         @iif ma ! 0
+         @callproc doBlockTrr @(nu) @(nu) 
+         @endiif
+      @endiif
+      }
+   @iif mEn = 1
+      @callproc doDiBlockT @(nu)
+   @iexp j 0
+   @iwhile j < @(nu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+      rC += @(bs); iC += @(bs); 
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+      switch(j%@(ma))
+      {
+      @callproc doCuDiBlockT @(mu) @(nu) @(ma)
+      }
+   @iexp j 0
+   @iwhile j < @(nu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+      pr += ((j+1)%@(ma)==0? pansz: 0);
+      pi += ((j+1)%@(ma)==0? pansz: 0);
+      pansz += ((j+1)%@(ma)==0? @(ma)*@(bs):0);
+      @endiif
+   @endiif
+   }
+@endiif
+@iif na ! 1
+   for (j=0; j < mf; j++)
+   {
+      size_t incC = incC0 - ((j/@(na)+1)*@(nu))>>1;
+      for (i=0; i < j/@(na); i++, rC+=@(bs), iC+=@(bs))
+      {
+         @callproc doBlockTna @(nu) @(mu) @(mu) @(nu)
+      }
+      switch(j%@(na))
+      {
+      @iexp n 0
+      @iwhile n < @(na)
+      case @(n):
+         @callproc doDiBlockTna @(nu) @(mu) @(mu) @(mu) @(nu) @(n)
+      break;
+         @iexp n @(n) 1 +
+      @endiwhile
+      }
+   @iexp j 0
+   @iwhile j < @(mu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+      rC += @(bs); iC += @(bs);
+   }
+@endiif
+@iif nu > 1
+   @iif mEn = 1
+   switch(nr)
+   {
+   @iexp n 1
+   @iwhile n < @(nu)
+   case @(n):
+      for (i=0; i < mf; i++, rC += @(bs), iC += @(bs))
+      {
+         @callproc doBlockT @(mu) @(n)
+      }
+      switch(mr)
+      {
+   @iexp m 1
+   @iwhile m < @(mu)
+      case @(m):
+      @skip Assumption for sryk  m = n" 
+      @callproc doDiBlockT @(m) 
+      @iexp m @(m) 1 +
+         break;
+   @endiwhile
+      default:;
+      }
+      break;
+      @iexp n @(n) 1 +
+   @endiwhile
+   default:;
+   }
+   @endiif
+   @iif mEn = 0
+      @iif ma ! 1
+      rC = pr; iC = pi;
+      rr = nf % @(ma);
+      switch(nr)
+      {
+         @iexp n 1
+         @iwhile n < @(nu)
+         case @(n) :
+            for (i=0; i < nf; i++, rC+=@(bs), iC+=@(bs))
+            {
+               @callproc doBlockTrr @(nu) @(n)
+            }
+               @callproc doDiBlockTrr @(n)
+         break;
+            @iexp n @(n) 1 +
+         @endiwhile
+      }
+      @endiif
+   @endiif
+@endiif
+@iif mu > 1
+   @iif na ! 1
+   switch (mr)
+   {
+      @iexp n 1
+      @iwhile n < @(mu)
+      case @(n):
+         for (i=0; i < nf; i++, rC+=@(bs), iC+=@(bs))
+         {
+         @callproc doBlockTna @(nu) @(n) @(mu) @(nu)
+         }
+         switch ( mf % @(na))
+         {
+            @iexp m 0 
+            @iwhile m < na  
+         case @(m):
+            @callproc doDiBlockTna @(nu) @(n) @(mu) @(mu) @(nu) @(m)
+            break;
+               @iexp m @(m) 1  +
+            @endiwhile
+         }
+      break;
+         @iexp n @(n) 1 +
+      @endiwhile
+   }
+   @endiif
+@endiif
+}
+@ROUT C2blk `#endif`
+@endiif
+@ROUT blk2C_x87
+@BEGINPROC GetAOff i_ j_
+   @define of @1@
+@iif @iexp @(i_) 0 = @(j_) 0 = &
+   @define ao @(pA)@
+@endiif
+@iif @(j_) = 0
+   @define al @@(i_)*SZ(pA)@
+@endiif
+@iif @(j_) = 1
+   @iif (i_) = 0
+      @define al @(pA,lda)@
+   @endiif
+   @iif (i_) ! 0
+      @define al @@(i_)*SZ(pA,lda)@
+   @endiif
+@endiif
+@iif @(j_) = 2
+   @iif (i_) = 0
+      @define al @(pA,lda,2)@
+   @endiif
+   @iif (i_) ! 0
+      @define al @@(i_)*SZ(pA,lda,2)@
+   @endiif
+@endiif
+@iif @(j_) = 3
+   @iif (i_) = 0
+      @define al @(pA,lda3)@
+   @endiif
+   @iif (i_) ! 0
+      @define al @@(i_)*SZ(pA,lda3)@
+   @endiif
+@endiif
+@iif @(j_) = 4
+   @iif (i_) = 0
+      @define al @(pA,lda,4)@
+   @endiif
+   @iif (i_) ! 0
+      @define al @@(i_)*SZ(pA,lda,4)@
+   @endiif
+@endiif
+@ENDPROC
+#include "atlas_asm.h"
+/*
+ *                            rdi       rsi             xmm0            rdx
+ * void ATL_ATL_USERCPMM(size_t M, size_t N, const TYPE alpha, const TYPE *w,
+ *                                  xmm1       rcx         r8
+ *                       const TYPE beta, TYPE *A, size_t lda);
+ *                       
+ */
+#define M    %rdi
+#deifne N    %rsi
+#define pW   %rdx
+#define pA   %rcx
+#define lda  %rax  /* comes in r8 */
+#define lda3 %r8  
+#define Mr   %r9
+#define Nr   %r10
+#define II   %r11
+.text
+.global ATL_asmdecor(ATL_USERCPMM)
+ALIGN16
+ATL_asmdecor(ATL_USERCPMM):
+   mov M, Mr
+/*
+ * M = M / 12  -> (M/4) /3;
+ */
+   shr $2, M   /* M /= 4 */
+   mov M, %rax
+   movabsq $-6148914691236517205, M
+   mulq M
+   shrq M
+/*
+ * rax = 12*(M/12)
+ */
+   lea (M,M,2), %rax /* rax = 3*(M/12) */
+   shl $2, %rax      /* rax = 12*(M/12) */
+   sub %rax, Mr      /* Mr = M - (M/12)*12 */
+
+   shr $2, N  /* N /= 4 */
+   mov N, %rax
+   shl $2, %rax
+   sub %rax, Nr     /* Nr = N - (N/4)*4 */
+
+   mov %r8, lda
+   lea (%r8,%r8,2), lda3
+   #ifdef ALPHAX
+      movlpd %xmm0, -8(%rsp)
+      fldl -8(%esp)              /* ST={alpha} */
+      #ifdef BETAX
+         movlpd %xmm1, -8(%rsp)
+         fldl -8(%esp)           /* ST={beta,alpha} */
+         #define SCAN 2
+      #else
+         #define SCAN 1
+      #endif
+   #elif defined(BETAX)
+      #define SCAN 1
+      movlpd %xmm1, -8(%rsp)
+      fldl -8(%esp)              /* ST={beta} */
+   #else
+      #define SCAN 0
+   #endif
+   #if SCAN == 1
+      #define ST4 %st4
+      #define ST5 %st5
+      #define ST6 %st6
+   #elif SCAN == 2
+      #define ST4 %st5
+      #define ST5 %st6
+      #define ST6 %st7
+   #endif
+   cmp $0, N
+   je CLEAN_N
+   cmp $0, M
+   je CLEAN_N
+   LOOPN:
+      mov M, II
+      LOOPM:
+         fldl (pW)          /* ST={p[0],[bet],[alp]} */
+         #ifdef BETAX
+            fmul %st1, %st  /* ST={bet*p[0],[bet],[alp]} */
+         #elif defined(BETAN) || defined(BETAN1)
+            fchs
+         #endif
+         fldl 8(pW)         /* ST={p[1], bet*p[0],[bet],[alp]} */
+         #ifdef BETAX
+            fmul %st2, %st  /* ST={bet*p[1],bet*p[0],[bet],[alp]} */
+         #elif defined(BETAN) || defined(BETAN1)
+            fchs
+         #endif
+         fldl 16(pW)        /* ST={p[2], bet*p[1],bet*p[0],[bet],[alp]} */
+         #ifdef BETAX
+            fmul %st3, %st  /* ST={bet*p[2],bet*p[1],bet*p[0],[bet],[alp]} */
+         #elif defined(BETAN) || defined(BETAN1)
+            fchs
+         #endif
+         fldl (pA)  /* ST={A[0],{bet*p[2],bet*p[1],bet*p[0],[bet],[alp]} */
+         #ifdef ALPHAX
+            fmul ST4, %st
+         #elif defined(BETAN) || defined(BETAN1)
+            fchs
+         #endif
+         fldl 8(pA)
+         #ifdef ALPHAX
+            fmul ST5, %st
+         #elif defined(ALPHAN) || defined(ALPHAN1)
+            fchs
+         #endif
+         fldl 16(pA)
+         #ifdef ALPHAX
+            fmul ST6, %st /*{A[2],A[1],A[0],p[2],p[1],p[0],[bet],[alp] */
+         #elif defined(ALPHAN) || defined(ALPHAN1)
+            fchs
+         #endif
+         dec II
+      jne LOOPM
+      dec N
+   jne LOOPN
+

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -1128,6 +1128,11 @@ void SYR2K
    #define ipsyrk  Mjoin(PATL,ipherk)
    #define SYRK Mjoin(PATL,herk)
    #define herk_FLG 1
+   #define syrkBlkMN Mjoin(PATL,herkBlkMN)
+   #define syrkMuNumul_K  Mjoin(PATL,herkMuNumul_KLoop)
+   #define syrkMuEqNu_K  Mjoin(PATL,herkMuEqNu_KLoop)
+   #define syrk_MuNumul  Mjoin(PATL,herk_MuNumul)
+   #define syrk_MuEqNu  Mjoin(PATL,herk_MuEqNu)
 #else
    #define syrkBlk Mjoin(PATL,syrkBlk)
    #define syrk_K  Mjoin(PATL,syrk_KLoop)
@@ -1136,7 +1141,385 @@ void SYR2K
    #define ipsyrk  Mjoin(PATL,ipsyrk)
    #define SYRK Mjoin(PATL,syrk)
    #define herk_FLG 0
+   #define syrkBlkMN Mjoin(PATL,syrkBlkMN)
+   #define syrkMuNumul_K  Mjoin(PATL,syrkMuNumul_KLoop)
+   #define syrkMuEqNu_K  Mjoin(PATL,syrkMuEqNu_KLoop)
+   #define syrk_MuNumul  Mjoin(PATL,syrk_MuNumul)
+   #define syrk_MuEqNu  Mjoin(PATL,syrk_MuEqNu)
 #endif
+/*#define MEM_DEBUG 1*/
+#if 1
+/*
+ * NOTE: temporary functions, will be deleted after creating the view
+ */   
+/*
+ * temporary structure to pass the kernels. Later, we may use view to select 
+ * syrk kernels (similar kernels as gemm to use same copy rotuines)
+ */
+typedef struct sykerninfo sykerninfo_t; 
+struct sykerninfo
+{
+   ammkern_t amsyrk_b0, amsyrk_b1;
+   ammkern_t amsyrkK1_b0, amsyrkK1_b1; /*kernel for K-cleanup(compile-time)*/
+   #ifdef TCPLX
+      ammkern_t amsyrk_bn; 
+      ammkern_t amsyrkK1_bn;         
+   #endif
+};
+
+#if defined (DREAL) || defined (DCPLX)
+
+static ablk2cmat_t GetBlk2Syrk (int mu, int nu, const SCALAR beta, 
+                                const enum ATLAS_UPLO Uplo)
+{
+   ablk2cmat_t blk2sy;
+
+   if (Uplo == AtlasLower)
+   {
+/*
+ *    alpha is multiplied with copy of A, so we need to copy just the beta...
+ *    alpha is always one
+ */
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b1_24x4);
+         else if (SCALAR_IS_NONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bN_24x4);
+         else if (SCALAR_IS_ZERO(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b0_24x4);
+         else 
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bX_24x4);
+      }
+      else
+         blk2sy = NULL; 
+   }
+   else  /* C is Upper */
+   {
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b1_24x4_L2UT);
+         else if (SCALAR_IS_NONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bN_24x4_L2UT);
+         else if (SCALAR_IS_ZERO(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b0_24x4_L2UT);
+         else 
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bX_24x4_L2UT);
+      }
+      else
+         blk2sy = NULL;
+   }
+   return(blk2sy);
+}
+
+static ablk2cmat_t GetBlk2SyrkAB (int mu, int nu, const SCALAR alpha, 
+                                  const SCALAR beta, 
+                                  const enum ATLAS_UPLO Uplo)
+{
+   ablk2cmat_t blk2sy;
+
+   if (Uplo == AtlasLower)
+   {
+/*
+ *    alpha is multiplied with copy of A, so we need to copy just the beta...
+ *    alpha is always one
+ */
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNb1_24x4);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b1_24x4)
+                     : Mjoin(PATL,SyrkIntoC_aXb1_24x4);
+         }
+         else if (SCALAR_IS_NONE(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNbN_24x4);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bN_24x4)
+                     : Mjoin(PATL,SyrkIntoC_aXbN_24x4);
+         }
+         else if (SCALAR_IS_ZERO(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNb0_24x4);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b0_24x4)
+                     : Mjoin(PATL,SyrkIntoC_aXb0_24x4);
+         }
+         else 
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNbX_24x4);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bX_24x4)
+                     : Mjoin(PATL,SyrkIntoC_aXbX_24x4);
+         }
+      }
+      else
+         blk2sy = NULL; 
+   }
+   else  /* C is Upper */
+   {
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNb1_24x4_L2UT);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b1_24x4_L2UT)
+                     : Mjoin(PATL,SyrkIntoC_aXb1_24x4_L2UT);
+         }
+         else if (SCALAR_IS_NONE(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNbN_24x4_L2UT);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bN_24x4_L2UT)
+                     : Mjoin(PATL,SyrkIntoC_aXbN_24x4_L2UT);
+         }
+         else if (SCALAR_IS_ZERO(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNb0_24x4_L2UT);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b0_24x4_L2UT)
+                     : Mjoin(PATL,SyrkIntoC_aXb0_24x4_L2UT);
+         }
+         else 
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNbX_24x4_L2UT);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bX_24x4_L2UT)
+                     : Mjoin(PATL,SyrkIntoC_aXbX_24x4_L2UT);
+         }
+      }
+      else
+         blk2sy = NULL; 
+   }
+   return(blk2sy);
+}
+
+#else
+static ablk2cmat_t GetBlk2Syrk (int mu, int nu, const SCALAR beta, 
+                                const enum ATLAS_UPLO Uplo)
+{
+   ablk2cmat_t blk2sy;
+
+   if (Uplo == AtlasLower)
+   {
+/*
+ *    alpha is multiplied with copy of A, so we need to copy just the beta...
+ *    alpha is always one
+ */
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b1_24x4);
+         else if (SCALAR_IS_NONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bN_24x4);
+         else if (SCALAR_IS_ZERO(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b0_24x4);
+         else 
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bX_24x4);
+      }
+      else
+         blk2sy = NULL; 
+   }
+   else  /* C is Upper */
+   {
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b1_24x4_L2UT);
+         else if (SCALAR_IS_NONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bN_24x4_L2UT);
+         else if (SCALAR_IS_ZERO(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b0_24x4_L2UT);
+         else 
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bX_24x4_L2UT);
+      }
+      else
+         blk2sy = NULL; 
+   }
+   return(blk2sy);
+}
+
+static ablk2cmat_t GetBlk2SyrkAB (int mu, int nu, const SCALAR alpha, 
+                                  const SCALAR beta,  
+                                  const enum ATLAS_UPLO Uplo)
+{
+   ablk2cmat_t blk2sy;
+
+   if (Uplo == AtlasLower)
+   {
+/*
+ *    alpha is multiplied with copy of A, so we need to copy just the beta...
+ *    alpha is always one
+ */
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNb1_24x4);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b1_24x4)
+                     : Mjoin(PATL,SyrkIntoC_aXb1_24x4);
+         }
+         else if (SCALAR_IS_NONE(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNbN_24x4);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bN_24x4)
+                     : Mjoin(PATL,SyrkIntoC_aXbN_24x4);
+         }
+         else if (SCALAR_IS_ZERO(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNb0_24x4);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b0_24x4)
+                     : Mjoin(PATL,SyrkIntoC_aXb0_24x4);
+         }
+         else 
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNbX_24x4);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bX_24x4)
+                     : Mjoin(PATL,SyrkIntoC_aXbX_24x4);
+         }
+      }
+      else
+         blk2sy = NULL; 
+   }
+   else  /* C is Upper */
+   {
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNb1_24x4_L2UT);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b1_24x4_L2UT)
+                     : Mjoin(PATL,SyrkIntoC_aXb1_24x4_L2UT);
+         }
+         else if (SCALAR_IS_NONE(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNbN_24x4_L2UT);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bN_24x4_L2UT)
+                     : Mjoin(PATL,SyrkIntoC_aXbN_24x4_L2UT);
+         }
+         else if (SCALAR_IS_ZERO(beta))
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNb0_24x4_L2UT);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b0_24x4_L2UT)
+                     : Mjoin(PATL,SyrkIntoC_aXb0_24x4_L2UT);
+         }
+         else 
+         {
+            if (SCALAR_IS_NONE(alpha))
+               blk2sy = Mjoin(PATL,SyrkIntoC_aNbX_24x4_L2UT);
+            else
+               blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bX_24x4_L2UT)
+                     : Mjoin(PATL,SyrkIntoC_aXbX_24x4_L2UT);
+         }
+      }
+      else
+         blk2sy = NULL; 
+   }
+   return(blk2sy);
+}
+#endif
+
+#if defined (DREAL) || defined (DCPLX)
+static ammkern_t GetAmmSyrk_b0(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_b0);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+static ammkern_t GetAmmSyrk_b1(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_b1);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+static ammkern_t GetAmmSyrk_bn(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_bn);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+#elif defined (SREAL) || defined (SCPLX)
+static ammkern_t GetAmmSyrk_b0(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_b0);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+static ammkern_t GetAmmSyrk_b1(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_b1);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+static ammkern_t GetAmmSyrk_bn(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_bn);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+#endif
+#endif   /* end of test kernels, copies */
+
 void syrkBlk
 (
    ipinfo_t *ip,
@@ -1162,7 +1545,7 @@ void syrkBlk
    ATL_CUINT kb = (k != ip->nfkblks) ? ip->kb : ip->kb0;
    ATL_UINT nb, kbS, nnu;
    size_t nfblks = ip->nfnblks;
-   #ifdef TCPLX 
+   #ifdef TCPLX
       TYPE *rA, *rB;
    #endif
    if (d == nfblks + ip->npnblks - 1)
@@ -1289,18 +1672,6 @@ void syrkBlk
       #endif
       if (ip->alpA != ip->alpB)
          alp = (ip->alpA != ip->alpC) ? ip->alpA : ip->alpB;
-      @beginskip
-      if (flag&1)  /* Upper matrix */
-      {
-         #ifdef TCPLX
-            const TYPE zero[2] = {ATL_rzero, ATL_rzero};
-            blk2c(nb, nb, alp, rC, wC, zero, wU, nb);
-         #else
-            blk2c(nb, nb, alp, wC, ATL_rzero, wU, nb);
-         #endif
-      }
-      else if (C)
-      @endskip
       if (C)
       {
          C = IdxC_ip(ip, C, d, d);
@@ -1385,14 +1756,14 @@ void syrk_K  /* inner-product based syrk/herk loop over K loop */
    if (nfkblks)
    {
       TYPE *wAn=(wA)? wA+szA:NULL, *wBn=(wB) ? wB+szB : NULL;
-      syrkBlk(ip, flag|4, d, 0, A, sy2blk, NULL, beta, NULL, rS, wS, 
+      syrkBlk(ip, flag|4, d, 0, A, sy2blk, NULL, beta, NULL, rS, wS,
               wA, wAn, wB, wBn, rC, wC, wU);
       wA = wAn;
       wB = wBn;
    }
    else /* this is first & last block! */
    {
-      syrkBlk(ip, flag|4, d, 0, A, sy2blk, blk2c, beta, C, rS, wS, 
+      syrkBlk(ip, flag|4, d, 0, A, sy2blk, blk2c, beta, C, rS, wS,
               wA, wA, wB, wB, rC, wC, wU);
       return;
    }
@@ -1402,7 +1773,7 @@ void syrk_K  /* inner-product based syrk/herk loop over K loop */
    for (k=1; k < nfkblks; k++)
    {
       TYPE *wAn=(wA)? wA+szA:NULL, *wBn=(wB) ? wB+szB : NULL;
-      syrkBlk(ip, flag, d, k, A, sy2blk, NULL, beta, NULL, rS, wS, 
+      syrkBlk(ip, flag, d, k, A, sy2blk, NULL, beta, NULL, rS, wS,
               wA, wAn, wB, wBn, rC, wC, wU);
       wA = wAn;
       wB = wBn;
@@ -1410,9 +1781,735 @@ void syrk_K  /* inner-product based syrk/herk loop over K loop */
 /*
  * Last block actually writes to C
  */
-   syrkBlk(ip, flag, d, k, A, sy2blk, blk2c, beta, C, rS, wS, 
+   syrkBlk(ip, flag, d, k, A, sy2blk, blk2c, beta, C, rS, wS,
            wA, wA, wB, wB, rC, wC, wU);
 }
+
+int syrk_MuEqNu
+(
+   ipinfo_t *ip,
+   const enum ATLAS_UPLO  Uplo,
+   const enum ATLAS_TRANS TA,
+   ATL_iptr_t  N,
+   ATL_iptr_t K,
+   const SCALAR alpha,
+   const TYPE *A,
+   ATL_iptr_t lda,
+   const SCALAR beta,
+   TYPE *C,
+   ATL_iptr_t ldc
+)
+{
+   size_t sz, szA, szB, szC, szS, nnblks, extra;
+   void *vp=NULL;
+   TYPE *wA, *wB, *wC, *wS, *wCs, *rC, *rCs, *rS;
+   double timG;
+   int nb, nbS, flg, idx;
+   int ierr;
+   cm2am_t sy2blk;
+   ablk2cmat_t blk2sy, blk2c;
+   #ifdef Conj_
+      const enum ATLAS_TRANS TB=(TA==AtlasNoTrans)?AtlasConjTrans:AtlasNoTrans;
+   #else
+      const enum ATLAS_TRANS TB = (TA==AtlasNoTrans) ? AtlasTrans:AtlasNoTrans;
+   #endif
+   #if 0
+   printf("D=(%u,%u), B=(%u,%u,%u), b=(%u,%u,%u), nB=(%u,%u,%u)\n",
+          (unsigned int)N,(unsigned int)K, ip.mb, ip.nb, ip.kb,
+          ip.pmb, ip.pnb, ip.kb0, ip.nfmblks, ip.nfnblks, ip.nfkblks);
+   #endif
+/*
+ * Will eventually need syrk timed for all square blocks to select best case.
+ * For now, just pretend syrk time doesn't matter
+ */
+/*
+ * Need space for only one column-panel of At
+ */
+   szB = ip->nfnblks ? ip->szA : ip->pszA;
+   szB *= (ip->nfkblks+1);
+/*
+ * A needs entire matrix minus one row/col panel
+ */
+   szA = szB * (ip->nfnblks + ip->npnblks - 1);
+   nb = (ip->nfnblks) ? ip->nb : ip->pnb;
+   nbS = (nb+ATL_SYRKK_NU-1)/ATL_SYRKK_NU;
+   szC = ((nbS+1)*nbS)>>1;  /* only need lower tri blks, not full nnu*nnu */
+   nbS *= ATL_SYRKK_NU;
+   szC *= ((ATL_SYRKK_NU*ATL_SYRKK_NU+ATL_SYRKK_VLEN-1)/ATL_SYRKK_VLEN)
+          * ATL_SYRKK_VLEN;
+   extra = ip->exsz;
+   extra = Mmax(extra, (ATL_SYRKK_NU+ATL_SYRKK_NU)*ATL_SYRKK_NU);
+   szS = ((ip->kb + ATL_SYRKK_KU-1)/ATL_SYRKK_KU)*ATL_SYRKK_KU;
+   szS *= nbS;
+   sz = Mmax(ip->szC,szC);
+   sz = ATL_MulBySize(sz + szS + szA+szB + extra) + 5*ATL_Cachelen;
+   if (sz < ATL_MaxMalloc)
+      vp = malloc(sz);
+   if (!vp)
+      return(1);  /* keep recurring, can't malloc space! */
+   wA = ATL_AlignPtr(vp);
+   wB = wA + (szA SHIFT);
+   wB = ATL_AlignPtr(wB);
+   wS = wB + (szB SHIFT);
+   wS = ATL_AlignPtr(wS);
+   wC = wS + (szS SHIFT);
+   wC = ATL_AlignPtr(wC);
+   if (!szA)
+      wA = NULL;
+   wCs = wC;
+   #ifdef TCPLX
+      rC = wC + ip->szC;
+      rCs = wC + szC;
+      rS = wS + szS;
+   #else
+      rCs = rC = wC;
+      rS = wS;
+   #endif
+/*
+ * ============================================================================
+ * First, we compute diagonals of C, and in the process we will copy A/A^T
+ * for use in computing non-diaginal blocks using inner-product amm.
+ * ============================================================================
+ */
+   sy2blk = IS_COLMAJ(TA) ? Mjoin(PATL,a2blk_syrkT) : Mjoin(PATL,a2blk_syrkN);
+
+   if (Uplo == AtlasLower)
+   {
+      if (SCALAR_IS_ONE(beta))
+      {
+         if (SCALAR_IS_NONE(alpha))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNb1);
+         else
+            blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b1):Mjoin(PATL,SyrkIntoC_aXb1);
+      }
+      else if (SCALAR_IS_NONE(beta))
+      {
+         if (SCALAR_IS_NONE(alpha))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNbN);
+         else
+            blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bN):Mjoin(PATL,SyrkIntoC_aXbN);
+      }
+      else if (SCALAR_IS_ZERO(beta))
+      {
+         if (SCALAR_IS_NONE(alpha))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNb0);
+         else
+            blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b0):Mjoin(PATL,SyrkIntoC_aXb0);
+      }
+      else
+      {
+         if (SCALAR_IS_NONE(alpha))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNbX);
+         else
+            blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bX):Mjoin(PATL,SyrkIntoC_aXbX);
+      }
+   }
+   else
+   {
+      if (SCALAR_IS_ONE(beta))
+      {
+         if (SCALAR_IS_NONE(alpha))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNb1_L2UT);
+         else
+            blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b1_L2UT)
+                     :Mjoin(PATL,SyrkIntoC_aXb1_L2UT);
+      }
+      else if (SCALAR_IS_NONE(beta))
+      {
+         if (SCALAR_IS_NONE(alpha))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNbN_L2UT);
+         else
+            blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bN_L2UT)
+                     :Mjoin(PATL,SyrkIntoC_aXbN_L2UT);
+      }
+      else if (SCALAR_IS_ZERO(beta))
+      {
+         if (SCALAR_IS_NONE(alpha))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNb0_L2UT);
+         else
+            blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1b0_L2UT)
+                     :Mjoin(PATL,SyrkIntoC_aXb0_L2UT);
+      }
+      else
+      {
+         if (SCALAR_IS_NONE(alpha))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNbX_L2UT);
+         else
+            blk2sy = SCALAR_IS_ONE(alpha) ?
+                     Mjoin(PATL,SyrkIntoC_a1bX_L2UT)
+                     :Mjoin(PATL,SyrkIntoC_aXbX_L2UT);
+      }
+   }
+   nnblks = ip->nfnblks + ip->npnblks;
+   flg = (TA == AtlasNoTrans) ? 2 : 0;
+/*
+ * Upper doesn't need to copy first row panel of A or last col panel of At
+ * to GEMM storage.  If C only block, should call syrk_IP instead!
+ */
+   if (Uplo == AtlasUpper)
+   {
+      flg |= 1;
+      syrk_K(ip, flg, 0, A, sy2blk, blk2sy, beta, C, rS, wS, wB, NULL,
+             rCs, wC, wCs);
+      if (N > nb)
+      {
+         const size_t incC = nb*((ldc+1)SHIFT);
+         size_t i;
+/*
+ *       Compute all C blks within this rowpan of C, copy rest of At
+ */
+         blk2c = ip->blk2c;
+         Mjoin(PATL,iploopsNK)(ip, 0, 1, NULL, A, C, 11, wB, wA, rC, wC,
+                               beta, blk2c);
+/*
+ *       Loop over all col-pans of C, excepting first & last;
+ *       A already fully copied, B will be copied by syrk_Kloop call.
+ */
+         for (i=1; i < nnblks-1; i++)
+         {
+            syrk_K(ip, flg, i, A, sy2blk, blk2sy, beta, C, rS, wS, wB, NULL,
+                   rCs, wC, wCs);
+            wA += szB SHIFT;
+            Mjoin(PATL,iploopsNK)(ip, i, i+1, NULL, NULL, C+i*(nb SHIFT), 11,
+                                  wB, wA, rC, wC, beta, blk2c);
+         }
+/*
+ *       Last colpan is only 1 diag blk, so don't copy A or B for gemm
+ */
+         syrk_K(ip, flg, i, A, sy2blk, blk2sy, beta, C, rS, wS, NULL, NULL,
+                rCs, wC, wCs);
+      }
+   }
+/*
+ * Lower doesn't need to copy first row panel of A or last col panel of At
+ * to GEMM storage.  If C only block, should call syrk_IP instead!
+ */
+   else
+   {
+      const size_t incC = (ldc SHIFT) * nb;
+      size_t j;
+      TYPE *c;
+/*
+ *    Compute first diag block, copying At to wB for use by all of this colpan
+ *    of C's gemm computation
+ */
+      syrk_K(ip, flg, 0, A, sy2blk, blk2sy, beta, C, rS, wS, NULL, wB,
+             rCs, wC, wCs);
+      if (N > nb)
+      {
+/*
+ *       Compute all C blks within this colpan of C, copying rest of A
+ */
+         blk2c = ip->blk2c;
+         Mjoin(PATL,iploopsMK)(ip, 1, 0, A, NULL, C, 7, wA, wB, rC, wC,
+                               beta, blk2c);
+/*
+ *       Loop over all col-pans of C, excepting first & last;
+ *       A already fully copied, B will be copied by syrk_Kloop call.
+ */
+         c = C + incC;
+         for (j=1; j < nnblks-1; j++)
+         {
+            syrk_K(ip, flg, j, A, sy2blk, blk2sy, beta, C, rS, wS,
+                   NULL, wB, rCs, wC, wCs);
+            wA += szB SHIFT;
+            Mjoin(PATL,iploopsMK)(ip, j+1, j, NULL, NULL, c, 7, wA, wB, rC, wC,
+                                  beta, blk2c);
+            c += incC;
+         }
+/*
+ *       Last colpan is only 1 diag blk, so don't copy A or B for gemm
+ */
+         syrk_K(ip, flg, j, A, sy2blk, blk2sy, beta, C, rS, wS,
+                NULL, NULL, rCs, wC, wCs);
+      }
+   }
+   free(vp);
+   return(0);
+}
+
+void syrkBlkMN
+(
+   ipinfo_t *ip,
+   int flag,      /* bitvec: 0: set means C is upper, 1: set TA==AtlasNoTrans*/
+   size_t d,      /* which global diagonal blk of C is being computed */
+   size_t k,      /* which K block of A is being computed */
+   const TYPE *A, /* if non-NULL, base A ptr to copy */
+   const TYPE *B, /* if non-NULL, base A ptr to copy */
+   sykerninfo_t *amsy, /* to pass syrk kernel info*/
+   ablk2cmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
+   const SCALAR beta, /* only needed if blk2c non-NULL */
+   TYPE *C,       /* if blk2c && non-NULL, which C to write to */
+   TYPE *wA,      /* if non-NULL, ip-based A workspace */
+   TYPE *wAn,     /* next A wrkspc to be prefetched */
+   TYPE *wB,      /* if non-NULL ip-based At workspace */
+   TYPE *wBn,     /* next B wrkspc to be prefetched */
+   TYPE *rC,      /* real portion of wC (unused for real routines) */
+   TYPE *wC      /* if non-NULL: ptr to syrk-storage C wrkspc */
+)
+{
+   ATL_CUINT kb = (k != ip->nfkblks) ? ip->kb : ip->kb0;
+   ATL_UINT mb, nb, kbS, nnu, nmu;
+   size_t nfblks = ip->nfnblks;
+   #ifdef TCPLX
+      TYPE *rA, *rB;
+   #endif
+   #ifdef TCPLX
+      ammkern_t amsyrk_b0 = amsy->amsyrk_b0; 
+      ammkern_t amsyrk_b1 = amsy->amsyrk_b1; 
+      ammkern_t amsyrk_bn = amsy->amsyrk_bn; 
+   #else
+      ammkern_t amsyrk_b0 = amsy->amsyrk_b0; 
+      ammkern_t amsyrk_b1 = amsy->amsyrk_b1; 
+   #endif
+   if (d == nfblks + ip->npnblks - 1)
+   {
+      nb = ip->nF;
+      #ifdef TCPLX
+         if (d < nfblks)
+         {
+            rA = wA + ip->szA;
+            rB = wB + ip->szB;
+         }
+         else
+         {
+            rA = wA + ip->pszA;
+            rB = wB + ip->pszB;
+         }
+      #endif
+   }
+   else if (d < nfblks)
+   {
+      nb = ip->nb;
+      #ifdef TCPLX
+         rA = wA + ip->szA;
+         rB = wB + ip->szB;
+      #endif
+   }
+   else
+   {
+      nb = ip->pnb;
+      #ifdef TCPLX
+         rA = wA + ip->pszA;
+         rB = wB + ip->pszB;
+      #endif
+   }
+/*
+ * calc nmu and nnu. one must be multiple of other 
+ */
+   if (ip->mu > ip->nu)
+   {
+      nmu = (nb+ip->mu-1)/ip->mu;
+      nnu = nmu * (ip->mu/ip->nu); // NU must be multiple of MU
+   }
+   else
+   {
+      nnu = (nb+ip->nu-1)/ip->nu;
+      nmu = nnu * (ip->nu/ip->mu); // NU must be multiple of MU
+   }
+   kbS = ((kb+ip->ku-1)/ip->ku)*ip->ku; /* same as KB0 */
+/*
+ * copy A  
+ */
+   if (A)  /* want to copy input array */
+   {
+      A = IdxA_ip(ip, A, d, k);   
+      #ifdef TCPLX
+         ip->a2blk(kb, nb, ip->alpA, A, ip->lda, rA, wA);
+      #else
+         ip->a2blk(kb, nb, ip->alpA, A, ip->lda, wA);
+      #endif
+   }
+   if (B)
+   {
+      B = IdxB_ip(ip, B, k, d);   
+      #ifdef TCPLX
+         ip->b2blk(kb, nb, ip->alpB, B, ip->ldb, rB, wB);
+      #else
+         ip->b2blk(kb, nb, ip->alpB, B, ip->ldb, wB);
+      #endif
+   }
+   if (wC)  /* want to compute SYRK on this block into wC */
+   {
+      #ifdef TCPLX
+         if (flag&4)
+         {
+            amsyrk_b0(nmu, nnu, kbS, wA, wB, rC, rA, wB, wC);
+            amsyrk_b0(nmu, nnu, kbS, rA, wB, wC, rA, rB, rC);
+         }
+         else
+         {
+            amsyrk_bn(nmu, nnu, kbS, wA, wB, rC, rA, wB, wC);
+            amsyrk_b1(nmu, nnu, kbS, rA, wB, wC, rA, rB, rC);
+         }
+         amsyrk_bn(nmu, nnu, kbS, rA, rB, rC, wA, rB, wC);
+         amsyrk_b1(nmu, nnu, kbS, wA, rB, wC, wA, wB, wC);
+      #else
+         if (flag&4)
+            amsyrk_b0(nmu, nnu, kbS, wA, wB, wC, wA, wB, wC);
+         else
+            amsyrk_b1(nmu, nnu, kbS, wA, wB, wC, wA, wB, wC);
+      #endif
+   }
+   if (blk2c)
+   {
+      const size_t ldc=ip->ldc;
+      #ifdef TCPLX
+         const TYPE *alp = ip->alpC;
+      #else
+         TYPE alp = ip->alpC;
+      #endif
+      if (ip->alpA != ip->alpB)
+         alp = (ip->alpA != ip->alpC) ? ip->alpA : ip->alpB;
+      if (C)
+      {
+         C = IdxC_ip(ip, C, d, d);
+         #ifdef TCPLX
+            blk2c(nb, nb, alp, rC, wC, beta, C, ldc);
+            #ifdef Conj_  /* must zero complex part of diagonal! */
+               Mjoin(PATLU,zero)(nb, C+1, (ldc+1)SHIFT);
+            #endif
+         #else
+            blk2c(nb, nb, alp, wC, beta, C, ldc);
+         #endif
+      }
+   }
+}
+
+void syrkMuNumul_K  /* inner-product based syrk/herk loop over K loop */
+(
+   ipinfo_t *ip,
+   int flag,      /* bitvec: 0: set means C is upper, 1: set TA==AtlasNoTrans*/
+   size_t d,      /* which global diagonal blk of C is being computed */
+   const TYPE *A, /* if non-NULL, base A ptr to copy */
+   const TYPE *B, /* if non-NULL, base B ptr to copy */
+   sykerninfo_t *amsy,/* TEMPORAY: to pass syrk kernel info*/
+   ablk2cmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
+   const SCALAR beta, /* only needed if blk2c non-NULL */
+   TYPE *C,       /* if blk2c non-NULL, which C to write to, else ignored */
+   TYPE *wA,      /* if non-NULL, ip-based A workspace */
+   TYPE *wB,      /* if non-NULL ip-based At workspace */
+   TYPE *rC,      /* real portion of wC (unused in real routines) */
+   TYPE *wC       /* if non-NULL: ptr to syrk-storage C wrkspc */
+)
+{
+   const size_t nfkblks = ip->nfkblks;
+   size_t k;
+   ATL_UINT szA, szB;
+   if (d < ip->nfnblks) 
+   {
+      /*szA = szB = ip->szA;*/
+      szA = ip->szA;
+      szB = ip->szB;
+   }
+   else
+   {
+      szA = ip->pszA;
+      szB = ip->pszB;
+   }
+   #ifdef TCPLX
+      szA += szA;
+      szB += szB;
+   #endif
+/*
+ * For first K block, use beta=0 kernel to init wC
+ */
+   if (nfkblks)
+   {
+      TYPE *wAn=(wA)? wA+szA:NULL, *wBn=(wB) ? wB+szB : NULL;
+      syrkBlkMN(ip, flag|4, d, 0, A, B, amsy, NULL, beta, NULL, wA,wAn, wB,wBn,
+                 rC, wC);
+      wA = wAn;
+      wB = wBn;
+   }
+   else /* this is first & last block! */
+   {
+      syrkBlkMN(ip, flag|4, d, 0, A, B, amsy, blk2c, beta, C, wA, wA, wB, wB, 
+                rC, wC);
+      return;
+   }
+/*
+ * Handle all blocks except first (handled above) & last (handled below)
+ */
+   for (k=1; k < nfkblks; k++)
+   {
+      TYPE *wAn=(wA)? wA+szA:NULL, *wBn=(wB) ? wB+szB : NULL;
+      syrkBlkMN(ip, flag, d, k, A, B, amsy, NULL, beta, NULL, wA, wAn, wB, wBn,
+                rC, wC);
+      wA = wAn;
+      wB = wBn;
+   }
+/*
+ * Last block actually writes to C
+ */
+   syrkBlkMN(ip, flag, d, k, A, B, amsy, blk2c, beta, C, wA,wA, wB,wB, rC,wC);
+}
+
+int syrk_MuNumul
+(
+   ipinfo_t *ip,
+   const enum ATLAS_UPLO  Uplo,
+   const enum ATLAS_TRANS TA,
+   ATL_iptr_t  N,
+   ATL_iptr_t K,
+   const SCALAR alpha,
+   const TYPE *A,
+   ATL_iptr_t lda,
+   const SCALAR beta,
+   TYPE *C,
+   ATL_iptr_t ldc
+)
+{
+   size_t sz, szA, szB, szC, szS, nnblks, extra;
+   void *vp=NULL;
+   TYPE *wA, *wB, *wC, *wS, *wCs, *rC, *rCs, *rS;
+   double timG;
+   int nb, nbS, flg, idx;
+   int k, ierr;
+   ablk2cmat_t blk2sy, blk2c;
+   sykerninfo_t amsy;
+   #ifdef Conj_
+      const enum ATLAS_TRANS TB=(TA==AtlasNoTrans)?AtlasConjTrans:AtlasNoTrans;
+   #else
+      const enum ATLAS_TRANS TB = (TA==AtlasNoTrans) ? AtlasTrans:AtlasNoTrans;
+   #endif
+#ifdef MEM_DEBUG   
+   void *vA=NULL, *vB=NULL, *vC=NULL;
+#endif
+   nb = (ip->nfnblks) ? ip->nb : ip->pnb;
+   nnblks = ip->nfnblks + ip->npnblks;
+/*
+ * Main idea: 
+ * 1. with syrk+gemm of full blks, syrk can always reuse the workspace of gemm 
+ *    no need to allocate extra space for syrk
+ * 2. syrk only: need to allocate only considering the syrk 
+ */
+/*
+ * Need space for only one column-panel of At
+ */
+   szB = ip->nfnblks ? ip->szA : ip->pszA;
+   szB *= (ip->nfkblks+1); 
+/*
+ * space calc for single syrk block 
+ */
+   if (nnblks == 1)    /* single blk in n-dimension: syrk only*/ 
+   {
+      int smnu=(ip->mu > ip->nu)?ip->mu:ip->nu; /* max of mu, nu*/
+      nbS = (nb+smnu-1)/smnu;
+      szC = ((nbS+1)*nbS)>>1;
+      nbS *= smnu;
+/*
+ *    considering mu and nu as one is multiple of other, the size of subblock
+ *    is smnu*smnu (rounded with ku).
+ */
+      szC *= ((smnu*smnu+ip->ku-1)/ip->ku)*ip->ku;
+      szS =  ((ip->kb+ip->ku-1)/ip->ku)*ip->ku;
+      szA = nbS * szS * (ip->nfkblks + 1);
+      extra = (smnu+smnu)*smnu;  /* may not need */
+   }
+   else
+   {
+/*
+ *    A needs entire matrix minus one row/col panel
+ */
+      szA = szB * (ip->nfnblks + ip->npnblks - 1);
+      szC = ip->szC;
+      extra = ip->exsz;
+   }
+#ifdef MEM_DEBUG   
+/*
+ * DEBUG: to debug, I allocate memory individually.... so that I can use 
+ * valgrind to find out of memory access error
+ */
+   sz = ATL_MulBySize(szA) + 2*ATL_Cachelen;
+   if (sz < ATL_MaxMalloc)
+      vA = malloc(sz);
+   if (!vA)
+      return(1);  /* keep recurring, can't malloc space! */
+   wA = ATL_AlignPtr(vA);
+   
+   sz = ATL_MulBySize(szB) + 2*ATL_Cachelen;
+   if (sz < ATL_MaxMalloc)
+      vB = malloc(sz);
+   if (!vB)
+      return(1);  /* keep recurring, can't malloc space! */
+   wB = ATL_AlignPtr(vB);
+   
+   sz = ATL_MulBySize(szC + extra) + 2*ATL_Cachelen;  
+   if (sz < ATL_MaxMalloc)
+      vC = malloc(sz);
+   if (!vC)
+      return(1);  /* keep recurring, can't malloc space! */
+   wC = ATL_AlignPtr(vC);
+#else
+/*
+ * use it for timing to reduce mulitple malloc. 
+ */
+   sz = ATL_MulBySize(szC + szA+szB + extra) + 5*ATL_Cachelen;
+   if (sz < ATL_MaxMalloc)
+      vp = malloc(sz);
+   if (!vp)
+      return(1);  /* keep recurring, can't malloc space! */
+   wA = ATL_AlignPtr(vp);
+   wB = wA + (szA SHIFT);
+   wB = ATL_AlignPtr(wB);
+   wC = wB + (szB SHIFT);
+   wC = ATL_AlignPtr(wC);
+#endif
+   #ifdef TCPLX
+      rC = wC + szC;
+   #else
+      rC = wC;
+   #endif
+/*
+ * ============================================================================
+ * First, we compute diagonals of C, and in the process we will copy A/A^T
+ * for use in computing non-diaginal blocks using inner-product amm.
+ * ============================================================================
+ */
+   flg = (TA == AtlasNoTrans) ? 2 : 0;
+/*
+ * NOTE: I'm selecting copy routines based on the logic of ipmenInfo here. 
+ * We will need a view or need to update ipmenInfo to select copy routines and
+ * kernel from there.
+ */
+   if (N < K)
+      blk2sy = GetBlk2SyrkAB(ip->mu, ip->nu, alpha, beta, Uplo);
+   else
+      blk2sy = GetBlk2Syrk(ip->mu, ip->nu, beta, Uplo);
+   if(!blk2sy) return(2);
+   #ifdef TCPLX
+      amsy.amsyrk_b0 = GetAmmSyrk_b0(ip->mu, ip->nu, ip->ku);
+      amsy.amsyrk_b1 = GetAmmSyrk_b1(ip->mu, ip->nu, ip->ku);
+      amsy.amsyrk_bn = GetAmmSyrk_bn(ip->mu, ip->nu, ip->ku);
+      if(!amsy.amsyrk_b0 || !amsy.amsyrk_b1 || !amsy.amsyrk_bn) return(2);
+/*
+ *    FIXME: I am using runtime kernels here (keeping K1 cleanup kernel same). 
+ *    For compile-time kernels, the cleanup-kernel may be different. 
+ */
+      amsy.amsyrkK1_b0 = amsy.amsyrk_b0;
+      amsy.amsyrkK1_bn = amsy.amsyrk_bn;
+   #else
+      amsy.amsyrk_b0 = GetAmmSyrk_b0(ip->mu, ip->nu, ip->ku);
+      amsy.amsyrk_b1 = GetAmmSyrk_b1(ip->mu, ip->nu, ip->ku);
+      if(!amsy.amsyrk_b0 || !amsy.amsyrk_b1) return(2);
+/*
+ *    for K-cleanup 
+ */
+      amsy.amsyrkK1_b0 = amsy.amsyrk_b0;
+      amsy.amsyrkK1_b1 = amsy.amsyrk_b1;
+   #endif
+/*
+ * syrk-upper 
+ */
+   if (Uplo == AtlasUpper)
+   {
+      flg |= 1;
+/*
+ *    1st syrk: copies both formats, no reuse
+ */
+      syrkMuNumul_K(ip, flg, 0, A, A, &amsy, blk2sy, beta, C, wB, wA, rC, wC);
+      if (N > nb)
+      {
+         const size_t incC = nb*((ldc+1)SHIFT);
+         size_t i;
+/*
+ *       Compute all C blks within this rowpan of C, copies B (At), reuse A  
+ */
+         blk2c = ip->blk2c;
+         Mjoin(PATL,iploopsNK)(ip, 0, 1, NULL, A, C, 11, wB, wA, rC, wC,
+                               beta, blk2c);
+/*
+ *       Loop over all col-pans of C, excepting first & last;
+ *       A already fully copied, B will be copied by syrk_Kloop call.
+ */
+         for (i=1; i < nnblks-1; i++)
+         {
+/*
+ *          syrk copies A and reuses B copy 
+ */
+            syrkMuNumul_K(ip, flg, i, A, NULL, &amsy, blk2sy, beta, C, wB, wA,
+                          rC, wC);
+            wA += szB SHIFT;
+/*
+ *          gemm can reuse both the copies 
+ */
+            Mjoin(PATL,iploopsNK)(ip, i, i+1, NULL, NULL, C+i*(nb SHIFT), 11,
+                                  wB, wA, rC, wC, beta, blk2c);
+         }
+/*
+ *       Last colpan is only 1 diag blk
+ */
+         syrkMuNumul_K(ip, flg, i, A, NULL, &amsy, blk2sy, beta, C, wB, wA, 
+                       rC, wC);
+      }
+   }
+/*
+ * Lower doesn't need to copy first row panel of A or last col panel of At
+ * to GEMM storage.  If C only block, should call syrk_IP instead!
+ */
+   else
+   {
+      const size_t incC = (ldc SHIFT) * nb;
+      size_t j;
+      TYPE *c;
+/*
+ *    Compute first diag block, copies both 
+ */
+      syrkMuNumul_K(ip, flg, 0, A, A, &amsy, blk2sy, beta, C, wA, wB, rC, wC);
+      if (N > nb)
+      {
+/*
+ *       Compute all C blks within this colpan of C, copying rest of A, reuse B
+ */
+         blk2c = ip->blk2c;
+         Mjoin(PATL,iploopsMK)(ip, 1, 0, A, NULL, C, 7, wA, wB, rC, wC,
+                               beta, blk2c);
+/*
+ *       Loop over all col-pans of C, excepting first & last;
+ *       A already fully copied, B will be copied by syrk_Kloop call.
+ */
+         c = C + incC;
+         for (j=1; j < nnblks-1; j++)
+         {
+/*
+ *          syrk reuse A and copies B
+ */
+            syrkMuNumul_K(ip, flg, j, NULL, A, &amsy, blk2sy, beta, C, wA, wB,
+                          rC, wC);
+            wA += szB SHIFT;
+/*
+ *          gemm reuses both the copies 
+ */
+            Mjoin(PATL,iploopsMK)(ip, j+1, j, NULL, NULL, c, 7, wA, wB, rC, wC,
+                                  beta, blk2c);
+            c += incC;
+         }
+/*
+ *       Last colpan is only 1 diag blk, still reuses A
+ */
+         syrkMuNumul_K(ip, flg, j, NULL, A, &amsy, blk2sy, beta, C, wA, wB, 
+                       rC, wC);
+      }
+   }
+#ifdef MEM_DEBUG
+   free(vA);
+   free(vB);
+   free(vC);
+#else
+   free(vp);
+#endif
+   return(0);
+}
+
+
 
 int syrk_amm
 (
@@ -1437,17 +2534,17 @@ int syrk_amm
 )
 {
    size_t sz, szA, szB, szC, szS, nnblks, extra;
-   void *vp=NULL;
    TYPE *wA, *wB, *wC, *wS, *wCs, *rC, *rCs, *rS;
    double timG;
    int nb, nbS, flg, idx;
+   int i, k, ierr;
    #ifdef Conj_
       TYPE alpha[2]={ralpha, ATL_rzero}, beta[2]={rbeta, ATL_rzero};
       const enum ATLAS_TRANS TB=(TA==AtlasNoTrans)?AtlasConjTrans:AtlasNoTrans;
    #else
       const enum ATLAS_TRANS TB = (TA==AtlasNoTrans) ? AtlasTrans:AtlasNoTrans;
    #endif
-   ipinfo_t ip;
+   ipinfo_t ip, ipmen;
    cm2am_t sy2blk;
    ablk2cmat_t blk2sy, blk2c;
 
@@ -1611,235 +2708,34 @@ int syrk_amm
  * For now, just pretend syrk time doesn't matter
  */
 /*
- * Need space for only one column-panel of At
+ * NOTE: Majedul: I'm using ipmenInfo for new syrk 
  */
-   szB = ip.nfnblks ? ip.szA : ip.pszA;
-   szB *= (ip.nfkblks+1);
+   Mjoin(PATL,ipmenInfo)(&ipmen, TA, TB, N,N,K, lda, lda, ldc, alpha, beta);
 /*
- * A needs entire matrix minus one row/col panel
+ * to apply new syrk, mu must be multiple of nu or vice versa
  */
-   szA = szB * (ip.nfnblks + ip.npnblks - 1);
-   nb = (ip.nfnblks) ? ip.nb : ip.pnb;
-   nbS = (nb+ATL_SYRKK_NU-1)/ATL_SYRKK_NU;
-   szC = ((nbS+1)*nbS)>>1;  /* only need lower tri blks, not full nnu*nnu */
-   nbS *= ATL_SYRKK_NU;
-   szC *= ((ATL_SYRKK_NU*ATL_SYRKK_NU+ATL_SYRKK_VLEN-1)/ATL_SYRKK_VLEN)
-          * ATL_SYRKK_VLEN;
-   extra = ip.exsz;
-   extra = Mmax(extra, (ATL_SYRKK_NU+ATL_SYRKK_NU)*ATL_SYRKK_NU);
-   @beginskip
-   if (Uplo == AtlasUpper)
-      extra = Mmax(extra, ip.szC);
-   @endskip
-   szS = ((ip.kb + ATL_SYRKK_KU-1)/ATL_SYRKK_KU)*ATL_SYRKK_KU;
-   szS *= nbS;
-   sz = Mmax(ip.szC,szC);
-   sz = ATL_MulBySize(sz + szS + szA+szB + extra) + 5*ATL_Cachelen;
-   if (sz < ATL_MaxMalloc)
-      vp = malloc(sz);
-   if (!vp)
-      return(1);  /* keep recurring, can't malloc space! */
-   wA = ATL_AlignPtr(vp);
-   wB = wA + (szA SHIFT);
-   wB = ATL_AlignPtr(wB);
-   wS = wB + (szB SHIFT);
-   wS = ATL_AlignPtr(wS);
-   wC = wS + (szS SHIFT);
-   wC = ATL_AlignPtr(wC);
-   if (!szA)
-      wA = NULL;
-@skip   if (Uplo == AtlasLower)
-   wCs = wC;
-   @beginskip
+   k = 1;
+   if (ipmen.mu == ipmen.nu) /* want to use new syrk */
+      k = 0;
+   else if (ipmen.mu > ipmen.nu)
+   {
+      i = ipmen.mu / ipmen.nu;
+      i *= ipmen.nu;
+      if (i == ipmen.mu)
+         k = 0;
+   }
+   else  /* ipmen.nu > ipmen.mu */
+   {
+      i = ipmen.nu / ipmen.mu;
+      i *= ipmen.mu;
+      if (i == ipmen.nu)
+         k = 0;
+   }
+   if (!k)
+      ierr = syrk_MuNumul(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
    else
-   {
-      wCs = wC + (szC SHIFT);
-      wCs = ATL_AlignPtr(wCs);
-   }
-   @endskip
-   #ifdef TCPLX
-      rC = wC + ip.szC;
-      rCs = wC + szC;
-      rS = wS + szS;
-   #else
-      rCs = rC = wC;
-      rS = wS;
-   #endif
-/*
- * ============================================================================
- * First, we compute diagonals of C, and in the process we will copy A/A^T
- * for use in computing non-diaginal blocks using inner-product amm.
- * ============================================================================
- */
-   sy2blk = IS_COLMAJ(TA) ? Mjoin(PATL,a2blk_syrkT) : Mjoin(PATL,a2blk_syrkN);
-      
-   if (Uplo == AtlasLower)
-   {
-      if (SCALAR_IS_ONE(beta))
-      {
-         if (SCALAR_IS_NONE(alpha))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNb1);
-         else
-            blk2sy = SCALAR_IS_ONE(alpha) ?
-                     Mjoin(PATL,SyrkIntoC_a1b1):Mjoin(PATL,SyrkIntoC_aXb1);
-      }
-      else if (SCALAR_IS_NONE(beta))
-      {
-         if (SCALAR_IS_NONE(alpha))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNbN);
-         else
-            blk2sy = SCALAR_IS_ONE(alpha) ?
-                     Mjoin(PATL,SyrkIntoC_a1bN):Mjoin(PATL,SyrkIntoC_aXbN);
-      }
-      else if (SCALAR_IS_ZERO(beta))
-      {
-         if (SCALAR_IS_NONE(alpha))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNb0);
-         else
-            blk2sy = SCALAR_IS_ONE(alpha) ?
-                     Mjoin(PATL,SyrkIntoC_a1b0):Mjoin(PATL,SyrkIntoC_aXb0);
-      }
-      else
-      {
-         if (SCALAR_IS_NONE(alpha))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNbX);
-         else
-            blk2sy = SCALAR_IS_ONE(alpha) ?
-                     Mjoin(PATL,SyrkIntoC_a1bX):Mjoin(PATL,SyrkIntoC_aXbX);
-      }
-   }
-   else
-   {
-      if (SCALAR_IS_ONE(beta))
-      {
-         if (SCALAR_IS_NONE(alpha))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNb1_L2UT);
-         else
-            blk2sy = SCALAR_IS_ONE(alpha) ?
-                     Mjoin(PATL,SyrkIntoC_a1b1_L2UT)
-                     :Mjoin(PATL,SyrkIntoC_aXb1_L2UT);
-      }
-      else if (SCALAR_IS_NONE(beta))
-      {
-         if (SCALAR_IS_NONE(alpha))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNbN_L2UT);
-         else
-            blk2sy = SCALAR_IS_ONE(alpha) ?
-                     Mjoin(PATL,SyrkIntoC_a1bN_L2UT)
-                     :Mjoin(PATL,SyrkIntoC_aXbN_L2UT);
-      }
-      else if (SCALAR_IS_ZERO(beta))
-      {
-         if (SCALAR_IS_NONE(alpha))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNb0_L2UT);
-         else
-            blk2sy = SCALAR_IS_ONE(alpha) ?
-                     Mjoin(PATL,SyrkIntoC_a1b0_L2UT)
-                     :Mjoin(PATL,SyrkIntoC_aXb0_L2UT);
-      }
-      else
-      {
-         if (SCALAR_IS_NONE(alpha))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNbX_L2UT);
-         else
-            blk2sy = SCALAR_IS_ONE(alpha) ?
-                     Mjoin(PATL,SyrkIntoC_a1bX_L2UT)
-                     :Mjoin(PATL,SyrkIntoC_aXbX_L2UT);
-      }
-@beginskip
-      if (SCALAR_IS_NONE(alpha))
-         blk2sy = Mjoin(PATL,SyrkIntoC_aNb0);
-      else
-         blk2sy = SCALAR_IS_ONE(alpha) ?
-                  Mjoin(PATL,SyrkIntoC_a1b0):Mjoin(PATL,SyrkIntoC_aXb0);
-@endskip
-   }
-   nnblks = ip.nfnblks + ip.npnblks;
-   flg = (TA == AtlasNoTrans) ? 2 : 0;
-/*
- * Upper doesn't need to copy first row panel of A or last col panel of At
- * to GEMM storage.  If C only block, should call ipsyrk instead!
- */
-   if (Uplo == AtlasUpper)
-   {
-      flg |= 1;
-      syrk_K(&ip, flg, 0, A, sy2blk, blk2sy, beta, C, rS, wS, wB, NULL, 
-             rCs, wC, wCs);
-      if (N > nb)
-      {
-         const size_t incC = nb*((ldc+1)SHIFT);
-         size_t i;
-/*
- *       Compute all C blks within this rowpan of C, copy rest of At
- */
-         blk2c = ip.blk2c;
-         Mjoin(PATL,iploopsNK)(&ip, 0, 1, NULL, A, C, 11, wB, wA, rC, wC,
-                               beta, blk2c);
-/*
- *       Loop over all col-pans of C, excepting first & last;
- *       A already fully copied, B will be copied by syrk_Kloop call.
- */
-         for (i=1; i < nnblks-1; i++)
-         {
-            syrk_K(&ip, flg, i, A, sy2blk, blk2sy, beta, C, rS, wS, wB, NULL, 
-                   rCs, wC, wCs);
-            wA += szB SHIFT;
-            Mjoin(PATL,iploopsNK)(&ip, i, i+1, NULL, NULL, C+i*(nb SHIFT), 11, 
-                                  wB, wA, rC, wC, beta, blk2c);
-         }
-/*
- *       Last colpan is only 1 diag blk, so don't copy A or B for gemm
- */
-         syrk_K(&ip, flg, i, A, sy2blk, blk2sy, beta, C, rS, wS, NULL, NULL, 
-                rCs, wC, wCs);
-      }
-   }
-/*
- * Lower doesn't need to copy first row panel of A or last col panel of At
- * to GEMM storage.  If C only block, should call ipsyrk instead!
- */
-   else
-   {
-      const size_t incC = (ldc SHIFT) * nb;
-      size_t j;
-      TYPE *c;
-/*
- *    Compute first diag block, copying At to wB for use by all of this colpan
- *    of C's gemm computation
- */
-      syrk_K(&ip, flg, 0, A, sy2blk, blk2sy, beta, C, rS, wS, NULL, wB, 
-             rCs, wC, wCs);
-      if (N > nb)
-      {
-/*
- *       Compute all C blks within this colpan of C, copying rest of A
- */
-         blk2c = ip.blk2c;
-         Mjoin(PATL,iploopsMK)(&ip, 1, 0, A, NULL, C, 7, wA, wB, rC, wC, 
-                               beta, blk2c);
-/* 
- *       Loop over all col-pans of C, excepting first & last;
- *       A already fully copied, B will be copied by syrk_Kloop call.
- */
-         c = C + incC;
-         for (j=1; j < nnblks-1; j++)
-         {
-            syrk_K(&ip, flg, j, A, sy2blk, blk2sy, beta, C, rS, wS,
-                   NULL, wB, rCs, wC, wCs);
-            wA += szB SHIFT;
-            Mjoin(PATL,iploopsMK)(&ip, j+1, j, NULL, NULL, c, 7, wA, wB, rC, wC,
-                                  beta, blk2c);
-            c += incC;
-         }
-/*
- *       Last colpan is only 1 diag blk, so don't copy A or B for gemm
- */
-         syrk_K(&ip, flg, j, A, sy2blk, blk2sy, beta, C, rS, wS, 
-                NULL, NULL, rCs, wC, wCs);
-      }
-   }
-   free(vp);
-   return(0);
+      ierr = syrk_MuEqNu(&ip, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
+   return(ierr);
 }
 
 static void syrk_rec
@@ -1935,7 +2831,7 @@ void SYRK
    ATL_CSZT ldc
 )
 {
-#if 1
+#if 0
    #ifdef Conj_
       Mjoin(PATL,herk_APR)(Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
    #else
@@ -1956,11 +2852,207 @@ void SYRK
 #ifdef Conj_
    #define syrkBlk Mjoin(PATL,herkBlk_OP)
    #define opsyrk Mjoin(PATL,opherk)
+   #define syrkBlkMN Mjoin(PATL,herkBlkMN_OP)
+   #define opsyrk_MuNumul Mjoin(PATL,opherk_MuNumul)
+   #define opsyrk_MuEqNu Mjoin(PATL,opherk_MuEqNu)
 #else
    #define syrkBlk Mjoin(PATL,syrkBlk_OP)
    #define opsyrk Mjoin(PATL,opsyrk)
+   #define syrkBlkMN Mjoin(PATL,syrkBlkMN_OP)
+   #define opsyrk_MuNumul Mjoin(PATL,opsyrk_MuNumul)
+   #define opsyrk_MuEqNu Mjoin(PATL,opsyrk_MuEqNu)
+#endif
+/**********************begin of temporary codes******************************/
+#if 1
+/*
+ * NOTE: I have selected the kernels by hand below only for testing...
+ * HERE, I kept only one specific kernel as an example 
+ * We will need a view to select syrk kernels and copy routines later 
+ */
+typedef struct syOPkerninfo syOPkerninfo_t; 
+struct syOPkerninfo
+{
+   ammkern_t amsyrk_b0, amsyrk_b1;
+   ammkern_t amsyrkK1_b0, amsyrkK1_b1;/*kernel for K-cleanup (compile-time)*/
+   #ifdef TCPLX
+      ammkern_t amsyrk_bn; 
+      ammkern_t amsyrkK1_bn;         
+   #endif
+};
+
+#if defined (DREAL) || defined (DCPLX)
+static ablk2cmat_t GetBlk2Syrk (int mu, int nu, const SCALAR beta, 
+                         const enum ATLAS_UPLO Uplo)
+{
+   ablk2cmat_t blk2sy;
+
+   if (Uplo == AtlasLower)
+   {
+/*
+ *    alpha is multiplied with copy of A, so we need to copy just the beta...
+ *    alpha is always one for these cases 
+ */
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b1_24x4);
+         else if (SCALAR_IS_NONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bN_24x4);
+         else if (SCALAR_IS_ZERO(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b0_24x4);
+         else 
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bX_24x4);
+      }
+      else
+         blk2sy = NULL; 
+
+   }
+   else  /* C is Upper */
+   {
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b1_24x4_L2UT);
+         else if (SCALAR_IS_NONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bN_24x4_L2UT);
+         else if (SCALAR_IS_ZERO(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b0_24x4_L2UT);
+         else 
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bX_24x4_L2UT);
+      }
+      else
+         blk2sy = NULL;
+   }
+   return(blk2sy);
+}
+
+#else
+
+static ablk2cmat_t GetBlk2Syrk (int mu, int nu, const SCALAR beta, 
+                         const enum ATLAS_UPLO Uplo)
+{
+   ablk2cmat_t blk2sy;
+
+   if (Uplo == AtlasLower)
+   {
+/*
+ *    alpha is multiplied with copy of A, so we need to copy just the beta...
+ *    alpha is always one
+ */
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b1_24x4);
+         else if (SCALAR_IS_NONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bN_24x4);
+         else if (SCALAR_IS_ZERO(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b0_24x4);
+         else 
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bX_24x4);
+      }
+      else
+         blk2sy = NULL; 
+   }
+   else  /* C is Upper */
+   {
+      if (mu == 24 && nu == 4)
+      {
+         if (SCALAR_IS_ONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b1_24x4_L2UT);
+         else if (SCALAR_IS_NONE(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bN_24x4_L2UT);
+         else if (SCALAR_IS_ZERO(beta))
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1b0_24x4_L2UT);
+         else 
+            blk2sy = Mjoin(PATL,SyrkIntoC_a1bX_24x4_L2UT);
+      }
+      else
+         blk2sy = NULL; 
+   }
+   return(blk2sy);
+}
 #endif
 
+#if defined (DCPLX)
+static ammkern_t GetAmmSyrk_b0(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_b0);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+static ammkern_t GetAmmSyrk_b1(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_b1);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+static ammkern_t GetAmmSyrk_bn(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_bn);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+
+#elif defined (DREAL) 
+static ammkern_t GetAmmSyrk(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_b0);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+#elif defined (SCPLX)
+static ammkern_t GetAmmSyrk_b0(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_b0);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+static ammkern_t GetAmmSyrk_b1(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_b1);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+static ammkern_t GetAmmSyrk_bn(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_bn);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+#elif defined (SREAL)
+static ammkern_t GetAmmSyrk(int mu, int nu, int ku)
+{
+   ammkern_t amsyrk; 
+   if (mu == 24 && nu == 4 && ku == 1)
+      amsyrk = Mjoin(PATL,amsyrkM24x4x1_b0);
+   else
+      amsyrk = NULL;
+   return amsyrk;
+}
+#endif
+#endif 
+/**********************End of temporary codes*********************************/
 /*
  * Indexes both A and C from base ptrs according to d (diagonal blk)
  */
@@ -2164,25 +3256,17 @@ void syrkBlk
       }
    }
 }
-
-int opsyrk
+int opsyrk_MuEqNu
 (
+   opinfo_t *op,
    const enum ATLAS_UPLO  Uplo,
    const enum ATLAS_TRANS TA,
    ATL_CSZT  N,
    ATL_CSZT K,
-   #ifdef Conj_
-   const TYPE ralpha,
-   #else
    const SCALAR alpha,
-   #endif
    const TYPE *A,
    ATL_CSZT lda,
-   #ifdef Conj_
-   const TYPE rbeta,
-   #else
    const SCALAR beta,
-   #endif
    TYPE *C,
    ATL_CSZT ldc
 )
@@ -2191,31 +3275,12 @@ int opsyrk
    void *vp;
    TYPE *wA, *wB, *wC, *wS, *wU, *rC, *rCs, *rS;
    int nb, nbS, flg, idx, extra;
-   #ifdef Conj_
-      TYPE alpha[2]={ralpha, ATL_rzero}, beta[2]={rbeta, ATL_rzero};
-      const enum ATLAS_TRANS TB=(TA==AtlasNoTrans)?AtlasConjTrans:AtlasNoTrans;
-   #else
-      const enum ATLAS_TRANS TB = (TA==AtlasNoTrans) ? AtlasTrans:AtlasNoTrans;
-   #endif
-   opinfo_t op;
    cm2am_t sy2blk;
    ablk2cmat_t blk2sy, blk2c;
 
-   return(1);  /* need debugging from Majedul */
-@skip   Mjoin(PATL,GetSyrkOP)(&op, 1, TA, TB, N, K, lda, ldc, alpha, beta);
-@skip   Mjoin(PATL,ipmenInfo)(&ip, idx, TA, TB, N, N, K, lda, lda, ldc, alpha, beta);
-   #ifdef Conj_
-      if (Mjoin(PATL,opsyrkInfo)(&op, 1, TA, N, K, lda, ldc, alpha, beta))
-   #else
-      if (Mjoin(PATL,opsyrkInfo)(&op, 0, TA, N, K, lda, ldc, alpha, beta))
-   #endif
-         return(2);
-   fprintf(stderr, "D=(%u,%u), B=(%u,%u,%u), pB=(%u,%u,%u)\n",
-           (unsigned int)N, (unsigned int)K, op.mb, op.nb, op.KB, 
-           op.pmb, op.pnb, op.kb);
-   nnblks = op.nfnblks + op.npnblks;
+   nnblks = op->nfnblks + op->npnblks;
    sy2blk = IS_COLMAJ(TA) ? Mjoin(PATL,a2blk_syrkT) : Mjoin(PATL,a2blk_syrkN);
-      
+
    if (Uplo == AtlasLower)
    {
       szU = 0;
@@ -2320,7 +3385,7 @@ int opsyrk
       #else
          szS = nbS * K;
       #endif
-      szU = Mmax(op.szC, szU);
+      szU = Mmax(op->szC, szU);  /* Majedul: don't need anymore */
       sz = ATL_MulBySize(szU + szC + szS + extra) + 3*ATL_Cachelen;
       vp = malloc(sz);
       if (!vp)
@@ -2338,7 +3403,7 @@ int opsyrk
          rS = wS;
       #endif
       flg |= (Uplo == AtlasUpper) ? 1 : 0;
-      syrkBlk(&op, flg, 0, A, sy2blk, blk2sy, C, rS, wS, 
+      syrkBlk(op, flg, 0, A, sy2blk, blk2sy, C, rS, wS,
               NULL, NULL, NULL, NULL, rC, wC, wU);
       free(vp);
       return(0);
@@ -2347,7 +3412,7 @@ int opsyrk
  * If we reach here, we have at rank-K SYRK update requiring both SYRK & GEMM
  * Since nnblks > 1, nfnblks > 1 as well.
  */
-   nbS = (op.nb+ATL_SYRKK_NU-1)/ATL_SYRKK_NU;
+   nbS = (op->nb+ATL_SYRKK_NU-1)/ATL_SYRKK_NU;
    szC = ((nbS+1)*nbS)>>1;  /* only need lower tri blks, not full nnu*nnu */
    nbS *= ATL_SYRKK_NU;
    szC *= ((ATL_SYRKK_NU*ATL_SYRKK_NU+ATL_SYRKK_VLEN-1)/ATL_SYRKK_VLEN)
@@ -2358,10 +3423,15 @@ int opsyrk
    #else
       szS = nbS * K;
    #endif
-   szU = Mmax(op.szC, szU);
-   szAblk = op.szA;
+   szU = Mmax(op->szC, szU);  /* Majedul: no need anymore */
+   szAblk = op->szA;
    szA = szAblk * (nnblks-1);
-   sz = ATL_MulBySize(szA+szAblk + szS + szC + szU + extra) + 5*ATL_Cachelen;
+   /*
+    * FIXED: wC is used both for syrk and gemm. 
+    * We need to allocate Mmax(szC, op->szC) for wC
+    */
+   sz = Mmax(szC, op->szC);
+   sz = ATL_MulBySize(szA+szAblk + szS + sz + szU + extra) + 5*ATL_Cachelen;
    vp = malloc(sz);
    if (!vp)
       return(1);
@@ -2375,7 +3445,7 @@ int opsyrk
    wU = wC + (szC SHIFT);
    wU = ATL_AlignPtr(wU);
    #ifdef TCPLX
-      rC = wC + op.szC;
+      rC = wC + op->szC;
       rCs = wC + szC;
       rS = wS + szS;
    #else
@@ -2390,26 +3460,26 @@ int opsyrk
  *    Do first diagonal block, don't copy A blk to GEMM storage since it is
  *    used only for this diagonal (SYRK)
  */
-      syrkBlk(&op, flg, 0, A, sy2blk, blk2sy, C, rS, wS, NULL, NULL, wB, wB, 
+      syrkBlk(op, flg, 0, A, sy2blk, blk2sy, C, rS, wS, NULL, NULL, wB, wB,
               rCs, wC, wU);
 /*
- *    Do rank-K update on ge blks beneath diag, copying entire A at same time
+ *    Do rank-K update on ge blks beneath diag, cop->ing entire A at same time
  */
-      Mjoin(PATL,oploopsM)(&op, 1, 0, A, NULL, C, 1, wA, wB, rC, wC);
+      Mjoin(PATL,oploopsM)(op, 1, 0, A, NULL, C, 1, wA, wB, rC, wC);
 /*
  *    For remaining column panels of C, syrkBlk copies B, reusues wA
  */
       for (j=1; j < nnblks-1; j++)
       {
-         syrkBlk(&op, flg, j, A, sy2blk, blk2sy, C, rS, wS, NULL, NULL, wB, wB, 
+         syrkBlk(op, flg, j, A, sy2blk, blk2sy, C, rS, wS, NULL, NULL, wB, wB,
                  rCs, wC, wU);
          wA += (szAblk SHIFT);
-         Mjoin(PATL,oploopsM)(&op, j+1, j, NULL, NULL, C, 1, wA, wB, rC, wC);
+         Mjoin(PATL,oploopsM)(op, j+1, j, NULL, NULL, C, 1, wA, wB, rC, wC);
       }
 /*
  *    Last col panel is only one diagonal
  */
-      syrkBlk(&op, flg, j, A, sy2blk, blk2sy, C, rS, wS, NULL, NULL, NULL, NULL,
+      syrkBlk(op, flg, j, A, sy2blk, blk2sy, C, rS, wS, NULL, NULL, NULL, NULL,
               rCs, wC, wU);
    }
    else
@@ -2420,30 +3490,440 @@ int opsyrk
  *    used only for this diagonal (SYRK)
  */
       flg |= 1;
-      syrkBlk(&op, flg, 0, A, sy2blk, blk2sy, C, rS, wS, wB, wB, NULL, NULL, 
+      syrkBlk(op, flg, 0, A, sy2blk, blk2sy, C, rS, wS, wB, wB, NULL, NULL,
               rCs, wC, wU);
 /*
  *    Do rank-K update on ge blks beneath diag, copying entire A^T at same time
  */
-      Mjoin(PATL,oploopsN)(&op, 0, 1, NULL, A, C, 2, wB, wA, rC, wC);
+      Mjoin(PATL,oploopsN)(op, 0, 1, NULL, A, C, 2, wB, wA, rC, wC);
 /*
  *    For remaining column panels of C, syrkBlk copies A, reuses A^T
  */
       for (i=1; i < nnblks-1; i++)
       {
-         syrkBlk(&op, flg, i, A, sy2blk, blk2sy, C, rS, wS, wB, wB, NULL, NULL,
+         syrkBlk(op, flg, i, A, sy2blk, blk2sy, C, rS, wS, wB, wB, NULL, NULL,
                  rCs, wC, wU);
          wA += (szAblk SHIFT);
-         Mjoin(PATL,oploopsN)(&op, i, i+1, NULL, NULL, C, 2, wB, wA, rC, wC);
+         Mjoin(PATL,oploopsN)(op, i, i+1, NULL, NULL, C, 2, wB, wA, rC, wC);
       }
 /*
  *    Last col panel is only one diagonal
  */
-      syrkBlk(&op, flg, i, A, sy2blk, blk2sy, C, rS, wS, NULL, NULL, NULL, NULL,
+      syrkBlk(op, flg, i, A, sy2blk, blk2sy, C, rS, wS, NULL, NULL, NULL, NULL,
               rCs, wC, wU);
    }
    free(vp);
    return(0);
+}
+
+void syrkBlkMN
+(
+   opinfo_t *op,
+   int flag,      /* bitvec: 0: set means C is upper, 1: set TA==AtlasNoTrans */
+   size_t d,      /* which global diagonal blk of C is being computed */
+   const TYPE *A, /* if non-NULL, base A ptr to copy in wA */
+   const TYPE *B, /* if non-NULL, base A ptr to copy in wB */
+   syOPkerninfo_t *amsy, /* temporary structure to pass syrk kernels */
+   ablk2cmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
+   TYPE *C,       /* if blk2c non-NULL, which C to write to, else ignored */
+   TYPE *wA,      /* if non-NULL, op-based A workspace */
+   TYPE *wAn,     /* next A wrkspc to be prefetched */
+   TYPE *wB,      /* if non-NULL op-based At workspace */
+   TYPE *wBn,     /* next B wrkspc to be prefetched */
+   TYPE *rC,      /* real ptr (unused for real routs) */
+   TYPE *wC      /* if non-NULL: ptr to syrk-storage C wrkspc */
+)
+{
+   ATL_CSZT lda = op->lda, nfblks = op->nfnblks;
+   ATL_CSZT ldb = op->ldb;
+   ATL_CUINT KB = op->KB, kb = op->kb;
+   ATL_UINT nb, kbS, nnu, nmu;
+#ifdef TCPLX
+   ATL_UINT szC, szA;
+   TYPE *rA, *rB;
+   TYPE *iA=wA, *iB=wB; /* may not need ... wA, wB can be used !!!*/
+#endif
+   const SCALAR beta=op->beta;
+   TYPE *wS;       
+#ifdef TCPLX
+   ammkern_t amsyrk_b0 = amsy->amsyrk_b0; 
+   ammkern_t amsyrk_b1 = amsy->amsyrk_b1; 
+   ammkern_t amsyrk_bn = amsy->amsyrk_bn; 
+#else
+   ammkern_t amsyrk = amsy->amsyrk_b0; 
+#endif
+   /*assert(op->mb==op->nb);*/
+   if (d == nfblks + op->npnblks - 1) /* last syrk only block*/ 
+   {
+      nb = op->nF;
+      nb = (nb) ? nb : op->nb;
+      #ifdef TCPLX
+         if (d < nfblks)
+         {
+            rA = wA + op->szA;
+            rB = wB + op->szB;
+         }
+         else
+         {
+            rA = wA + op->pszA;
+            rB = wB + op->pszB;
+         }
+      #endif
+   }
+   else if (d < nfblks) 
+   {
+      nb = op->nb;
+      #ifdef TCPLX
+         rA = wA + op->szA;
+         rB = wB + op->szB;
+      #endif
+   }
+   else  
+   {
+      nb = op->pnb;
+      #ifdef TCPLX
+         rA = wA + op->pszA;
+         rB = wB + op->pszB;
+      #endif
+   }
+/*
+ * calc nmu and nnu. one must be multiple of other 
+ */
+   if (op->mu > op->nu)
+   {
+      nmu = (nb+op->mu-1)/op->mu;
+      nnu = nmu * (op->mu/op->nu); // NU must be multiple of MU
+   }
+   else
+   {
+      nnu = (nb+op->nu-1)/op->nu;
+      nmu = nnu * (op->nu/op->mu); // NU must be multiple of MU
+   }
+/*
+ * we can use KB since we are using same kernel as gemm
+ */
+   kbS = op->KB;
+
+   if (A)  /* want to copy input array in wA */
+   {
+/*
+ *    Move A ptr to d'th block
+ */
+      if (d)
+      {
+         size_t n = Mmin(d, nfblks);
+         A += n*op->incAm;
+         n = d - n;  /* # of partial blocks remaining in d */
+         A += n*op->pincAm;
+      }
+      #ifdef TCPLX
+         op->a2blk(kb, nb, op->alpA, A, lda, rA, wA);
+      #else
+         op->a2blk(kb, nb, op->alpA, A, lda, wA);
+      #endif
+   }
+   if (B) /* want to copy input array in wB */
+   {
+      if (d)
+      {
+         size_t n = Mmin(d, nfblks);
+         B += n*op->incBn;
+         n = d - n;  /* # of partial blocks remaining in d */
+         B += n*op->pincBn;
+      }
+      
+      #ifdef TCPLX
+         op->b2blk(kb, nb, op->alpB, B, ldb, rB, wB);
+      #else
+         op->b2blk(kb, nb, op->alpB, B, ldb, wB);
+      #endif
+   }
+   if (wC)  /* want to compute SYRK on this block into wC */
+   {
+/*
+ *    NOTE: no need to specially handle herk/conj, since we are using gemm's
+ *    copy routines and similar kernels
+ */
+      #ifdef TCPLX
+         amsyrk_b0(nmu, nnu, kbS, wA, wB, rC, rA, wB, wC);
+         amsyrk_b0(nmu, nnu, kbS, rA, wB, wC, rA, rB, rC);
+         amsyrk_bn(nmu, nnu, kbS, rA, rB, rC, wA, rB, wC);
+         amsyrk_b1(nmu, nnu, kbS, wA, rB, wC, wA, wB, wC);
+      #else
+         amsyrk(nmu, nnu, kbS, wA, wB, wC, wA, wB, wC);
+      #endif
+   }
+   if (blk2c)
+   {
+      const size_t ldc=op->ldc;
+      int k;
+      #ifdef TCPLX
+         const TYPE *alp = (op->alpA == op->ONE) ? op->alpB : op->alpA;
+      #else
+         TYPE alp = (op->alpA == ATL_rone) ? op->alpB : op->alpA;
+      #endif
+      C += d*op->nb*((ldc+1)SHIFT);
+      if (flag&1)  /* Upper matrix */
+      {
+         #ifdef TCPLX
+            blk2c(nb, nb, alp, rC, wC, beta, C, ldc);
+            #ifdef Conj_  /* must zero complex part of diagonal! */
+               Mjoin(PATLU,zero)(nb, C+1, (ldc+1)SHIFT);
+            #endif
+         #else
+            blk2c(nb, nb, alp, wC, beta, C, ldc);
+         #endif
+      }
+      else
+      {
+         #ifdef TCPLX
+            blk2c(nb, nb, alp, rC, wC, beta, C, ldc);
+            #ifdef Conj_  /* must zero complex part of diagonal! */
+               Mjoin(PATLU,zero)(nb, C+1, (ldc+1)SHIFT);
+            #endif
+         #else
+            blk2c(nb, nb, alp, wC, beta, C, ldc);
+         #endif
+      }
+   }
+}
+
+int opsyrk_MuNumul
+(
+   opinfo_t *op,
+   const enum ATLAS_UPLO  Uplo,
+   const enum ATLAS_TRANS TA,
+   ATL_CSZT  N,
+   ATL_CSZT K,
+   const SCALAR alpha,
+   const TYPE *A,
+   ATL_CSZT lda,
+   const SCALAR beta,
+   TYPE *C,
+   ATL_CSZT ldc
+)
+{
+   size_t sz, szA, szC, szU, szS, nnblks, szAblk;
+   void *vp;
+   TYPE *wA, *wB, *wC, *wS, *wU, *rC, *rCs, *rS;
+   int nb, nbS, flg, idx, extra;
+   cm2am_t sy2blk;
+   ablk2cmat_t blk2sy, blk2c;
+   syOPkerninfo_t amsy;
+   int smnu;
+
+   nnblks = op->nfnblks + op->npnblks;
+   smnu = Mmax(op->mu, op->nu);           /* max unrolling */ 
+   blk2sy = GetBlk2Syrk (op->mu, op->nu, beta, Uplo);
+   if(!blk2sy) return(2);
+/*
+ * selecting kernel: hard-coded temporary... will select from view later
+ */
+   #ifdef TCPLX
+      amsy.amsyrk_b0 = GetAmmSyrk_b0(op->mu, op->nu, op->ku);
+      amsy.amsyrk_b1 = GetAmmSyrk_b1(op->mu, op->nu, op->ku);
+      amsy.amsyrk_bn = GetAmmSyrk_bn(op->mu, op->nu, op->ku);
+      if(!amsy.amsyrk_b0 || !amsy.amsyrk_b1 || !amsy.amsyrk_bn) return(2);
+   #else
+      amsy.amsyrk_b0 = GetAmmSyrk(op->mu, op->nu, op->ku);
+      if(!amsy.amsyrk_b0) return(2);
+   #endif
+
+   flg = (TA == AtlasNoTrans) ? 2 : 0;
+   if (TA == AtlasUpper)
+      flg |= 1;
+   if (nnblks == 1)  /* we've got a 1 block of SYRK only! */
+   {
+      extra = (smnu+smnu)*smnu;  
+      nbS = (N+smnu-1)/smnu;
+      szC = ((nbS+1)*nbS)>>1;
+      nbS *= smnu;
+      szC *= ((smnu*smnu+op->ku-1)/op->ku)*op->ku;
+      szS = nbS * op->KB;         /* KB is already rounded with ku */
+      szA = szAblk = szS;  
+      sz = ATL_MulBySize(szA+szAblk+szC+extra) + 3*ATL_Cachelen;
+      vp = malloc(sz);
+      if (!vp)
+         return(1);
+      wA = ATL_AlignPtr(vp);
+      wB = wA + (szA SHIFT);
+      wB = ATL_AlignPtr(wB);
+      wC = wB + (szAblk SHIFT);
+      wC = ATL_AlignPtr(wC);
+      #ifdef TCPLX
+         rC = wC + szC;
+      #else
+         rC = wC;
+      #endif
+      flg |= (Uplo == AtlasUpper) ? 1 : 0;
+      syrkBlkMN(op, flg, 0, A, A, &amsy, blk2sy, C, wA, wA, wB, wB, rC, wC);
+      free(vp);
+      return(0);
+   }
+/*
+ * If we reach here, we have at rank-K SYRK update requiring both SYRK & GEMM
+ * Since nnblks > 1, nfnblks > 1 as well.
+ */
+/*   
+ * syrk needs less space than gemm, so we can reuse same wC space 
+ */
+   szC = op->szC;
+   szAblk = op->szA;
+   szA = szAblk * (nnblks-1);  
+   extra = op->exsz;           /* why needed?? */
+   sz = ATL_MulBySize(szA + szAblk + szC + extra) + 3*ATL_Cachelen;
+
+   vp = malloc(sz);
+   if (!vp)
+      return(1);
+   wA = ATL_AlignPtr(vp);
+   wB = wA + (szA SHIFT);
+   wB = ATL_AlignPtr(wB);
+   wC = wB + (szAblk SHIFT);
+   wC = ATL_AlignPtr(wC);
+   #ifdef TCPLX
+      rC = wC + op->szC;
+   #else
+      rC = wC;
+   #endif
+   if (Uplo == AtlasLower)
+   {
+      size_t j;
+/*
+ *    SYRK uses same copy routines as GEMM. copy of B can be reused in GEMM 
+ *    of the column panels 
+ */
+      syrkBlkMN(op, flg, 0, A, A, &amsy, blk2sy, C, wA, wA, wB, wB, rC, wC);
+/*
+ *    Do rank-K update on ge blks beneath diag, copying entire A at same time
+ */
+      Mjoin(PATL,oploopsM)(op, 1, 0, A, NULL, C, 1, wA, wB, rC, wC);
+/*
+ *    For remaining column panels of C, syrkBlk copies B, re-uses wA
+ */
+      for (j=1; j < nnblks-1; j++)
+      {
+/*
+ *       ****** big idea: 
+ *       1. Resue A from previous wA calculated in oploopsM last time.
+ *          After the first call of oploopsM the whole wA is populated
+ *       2. compute wB which can be reused in subsequent oploopsM  
+ */        
+         syrkBlkMN(op, flg, j, NULL, A, &amsy, blk2sy, C, wA,wA, wB,wB, rC, wC);
+         wA += (szAblk SHIFT);
+         Mjoin(PATL,oploopsM)(op, j+1, j, NULL, NULL, C, 1, wA, wB, rC, wC);
+      }
+/*
+ *    Last col panel is only one diagonal
+ */
+      syrkBlkMN(op, flg, j, NULL, A, &amsy, blk2sy, C, wA, wA, wB, wB, rC, wC);
+   }
+   else
+   {
+      size_t i;
+/*
+ *    GEMM will reuse A*T, Syrk can reuse B later... wB is wA
+ */
+      flg |= 1;
+      syrkBlkMN(op, flg, 0, A, A, &amsy, blk2sy, C, wB, wB, wA, wA, rC, wC);
+/*
+ *    Do rank-K update on ge blks beneath diag, copying entire A^T at same time
+ */
+      Mjoin(PATL,oploopsN)(op, 0, 1, NULL, A, C, 2, wB, wA, rC, wC);
+/*
+ *    For remaining column panels of C, syrkBlk copies A, reuses A^T
+ */
+      for (i=1; i < nnblks-1; i++)
+      {
+         syrkBlkMN(op, flg, i, A, NULL, &amsy, blk2sy, C, wB,wB, wA,wA, rC, wC);
+         wA += (szAblk SHIFT);
+         Mjoin(PATL,oploopsN)(op, i, i+1, NULL, NULL, C, 2, wB, wA, rC, wC);
+      }
+/*
+ *    Last col panel is only one diagonal
+ */
+      syrkBlkMN(op, flg, i, A, NULL, &amsy, blk2sy, C, wB, wB, wA, wA, rC, wC);
+   }
+   free(vp);
+   return(0);
+}
+
+int opsyrk
+(
+   const enum ATLAS_UPLO  Uplo,
+   const enum ATLAS_TRANS TA,
+   ATL_CSZT  N,
+   ATL_CSZT K,
+   #ifdef Conj_
+   const TYPE ralpha,
+   #else
+   const SCALAR alpha,
+   #endif
+   const TYPE *A,
+   ATL_CSZT lda,
+   #ifdef Conj_
+   const TYPE rbeta,
+   #else
+   const SCALAR beta,
+   #endif
+   TYPE *C,
+   ATL_CSZT ldc
+)
+{
+   int i, ismul;
+   int ierr;
+   #ifdef Conj_
+      TYPE alpha[2]={ralpha, ATL_rzero}, beta[2]={rbeta, ATL_rzero};
+      const enum ATLAS_TRANS TB=(TA==AtlasNoTrans)?AtlasConjTrans:AtlasNoTrans;
+   #else
+      const enum ATLAS_TRANS TB = (TA==AtlasNoTrans) ? AtlasTrans:AtlasNoTrans;
+   #endif
+   opinfo_t op;
+@skip   Mjoin(PATL,GetSyrkOP)(&op, 1, TA, TB, N, K, lda, ldc, alpha, beta);
+@skip   Mjoin(PATL,ipmenInfo)(&ip, idx, TA, TB, N, N, K, lda, lda, ldc, alpha, beta);
+/*
+ * find opsyrkinfo 
+ */
+   #ifdef Conj_
+      if (Mjoin(PATL,opsyrkInfo)(&op, 1, TA, N, K, lda, ldc, alpha, beta))
+   #else
+      if (Mjoin(PATL,opsyrkInfo)(&op, 0, TA, N, K, lda, ldc, alpha, beta))
+   #endif
+         return(2);
+   #if 0 
+   fprintf(stderr, "D=(%u,%u), B=(%u,%u,%u), pB=(%u,%u,%u)\n",
+           (unsigned int)N, (unsigned int)K, op.mb, op.nb, op.KB,
+           op.pmb, op.pnb, op.kb);
+   #endif
+/*
+ * if mu is multiple of nu or nu is multiple of mu, apply syrk using same 
+ * mu, nu as gemm
+ */
+   ismul = 0;
+   if (op.mu == op.nu)
+      ismul = 1;
+   else if (op.mu > op.nu)
+   {
+      i = (op.mu / op.nu); 
+      i = i * op.nu; 
+      if (i == op.mu) /* mu multiple of nu */
+         ismul = 1;
+   }
+   else /* nu > mu */
+   {
+      i = (op.nu / op.mu);
+      i = i * op.mu;
+      if (i == op.nu) /* nu multiple of mu */
+         ismul = 1;
+   }
+/*
+ * apply new syrk if mu & nu are multiple of each other, old one otherwise
+ */
+   if (ismul)
+      ierr = opsyrk_MuNumul(&op, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
+   else
+      ierr = opsyrk_MuEqNu(&op, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc); 
+   return(ierr);
 }
 @ROUT ATL_ipsyrk
 @extract -b @(topd)/cw.inc lang=C -def cwdate 2015 

--- a/AtlasBase/make.base
+++ b/AtlasBase/make.base
@@ -1747,6 +1747,8 @@ fko_atlas-mmkg.base : $(basd)/fko_atlas-mmkg.base
 	cp $(basd)/fko_atlas-mmkg.base .
 atlas-mmkg.base : $(basd)/atlas-mmkg.base
 	cp $(basd)/atlas-mmkg.base .
+atlas-syrk-mmkg.base : $(basd)/atlas-syrk-mmkg.base
+	cp $(basd)/atlas-syrk-mmkg.base .
 atlas-mmg.base : $(basd)/atlas-mmg.base
 	cp $(basd)/atlas-mmg.base .
 trsm-nano.base : $(basdSTU)/trsm-nano.base


### PR DESCRIPTION
Please note that
1. this update won't work right away since the view of syrk is missing here. Selection of syrk kernels and copy routines are hard-coded. To test the implementation, I manually generated them (using atlas-syrk-mmkg.base which is also added here), added them in KERNEL (and also updated the header files in include). 
2. Added a syrk generator (atlas-syrk-mmkg.base) which can generate kernels and copy routines for all our supported cases (mu=nu, mu=i*nu, nu=i*mu).
3. Added a bugfix for old opsyrk     