### PR TITLE
Trmmdev - bug fixed

### DIFF
--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -14346,10 +14346,13 @@ static int AdjustForTRMM(char pre, int flag, ATL_mmnode_t *mp, ATL_mmnode_t *gd)
 /*
  *    removing all '-x assembler-with-cpp' from cflags
  */
-      s = mp->cflags;
       ln = strlen(srmflg);
-      while(s=strstr(s,srmflg))
-         memmove(s,s+ln,1+strlen(s+ln));
+      s = mp->cflags;
+      if (s)
+      {
+         while(s=strstr(s,srmflg))
+            memmove(s,s+ln,1+strlen(s+ln));
+      }
    }
    mp->flag &= ~((1<<MMF_KUISKB)|(1<<MMF_KCLN));
    mp->flag |= 1<<MMF_KRUNTIME;

--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -14346,10 +14346,10 @@ static int AdjustForTRMM(char pre, int flag, ATL_mmnode_t *mp, ATL_mmnode_t *gd)
 /*
  *    removing all '-x assembler-with-cpp' from cflags
  */
-      ln = strlen(srmflg);
       s = mp->cflags;
       if (s)
       {
+         ln = strlen(srmflg);
          while(s=strstr(s,srmflg))
             memmove(s,s+ln,1+strlen(s+ln));
       }

--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -14337,10 +14337,19 @@ static int AdjustForTRMM(char pre, int flag, ATL_mmnode_t *mp, ATL_mmnode_t *gd)
  */
    if (mp->ID)
    {
+      int ln;
+      char *s, *srmflg="-x assembler-with-cpp";
       mp->ID = 0;
       if (mp->rout)
          free(mp->rout);
       mp->rout = DupString("ATL_tmp.c");
+/*
+ *    removing all '-x assembler-with-cpp' from cflags
+ */
+      s = mp->cflags;
+      ln = strlen(srmflg);
+      while(s=strstr(s,srmflg))
+         memmove(s,s+ln,1+strlen(s+ln));
    }
    mp->flag &= ~((1<<MMF_KUISKB)|(1<<MMF_KCLN));
    mp->flag |= 1<<MMF_KRUNTIME;
@@ -39800,6 +39809,8 @@ double Mjoin(PATL,ipsyrkInfo)
          i = (nbL-nb > nb-nbS) ? i+1 : i;
          nbS = ((N+ATL_SYRKK_NU-1)/ATL_SYRKK_NU)*ATL_SYRKK_NU;
       }
+      if (nbS >= N)
+         return(-1.0);
       tpf = (float*)(ATL_VIEW_syrk+ATL_VWsyrk_IDXMUL(i));
       timS = (*tpf*nbS)*nbS*K;
       #ifdef DEBUG


### PR DESCRIPTION
1. removed '-x assembler-with-cpp' from cflags
2. added checking for ipsyrk (already added on rcwdev)