### PR TITLE
URSYRK implementation

### DIFF
--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -973,8 +973,8 @@ int Mjoin(PATL,@(rt)her2k)
    @undef rtsy
    @undef rthk
 @endwhile
-@SKIP prototypes for sq/um syrk
-@whiledef rt sq um
+@SKIP prototypes for sq/ur syrk
+@whiledef rt sq ur
 int Mjoin(PATL,@(rt)syrk)
    (ipinfo_t *ip, const enum ATLAS_UPLO, const enum ATLAS_TRANS, ATL_CSZT, 
     ATL_CSZT, const SCALAR, const TYPE*, ATL_CSZT, const SCALAR, TYPE*,
@@ -37913,6 +37913,9 @@ void prepSyrkAmm(char pre, ATL_mmnode_t *kb)
       cu = tp;
    }
    assert((cs->flag&(1<<MMF_COMPLEX))&&(cu->flag&(1<<MMF_COMPLEX)));
+/*
+ * NOTE: MMF_RIGHT used for umsyrk before, used for ursyrk now
+ */
    ru->flag |= 1<<MMF_RIGHT;
    cu->flag |= 1<<MMF_RIGHT;
 }
@@ -37946,6 +37949,12 @@ ATL_cpnode_t *GetKernCopies(char pre, char *outd, ATL_mmnode_t *kb)
       switch(mp->blask)
       {
       case ATL_KSYRK:  /* SYRK needs C copies for all alpha,beta */
+/*
+ *       don't need to be generated copies for ursyrk anymore
+ *       so, skip if ursyrk
+ */
+         if (FLAG_IS_SET(mp->flag, MMF_RIGHT)) 
+            continue; 
          cpflag |= (1<<CPF_SYRK) | (1<<CPF_CBLK);
          cp = GetCopyNodeFromMM(cpflag, mp, NULL);
 /*
@@ -37966,11 +37975,13 @@ ATL_cpnode_t *GetKernCopies(char pre, char *outd, ATL_mmnode_t *kb)
                   fn[5] = 's';
                   fn[6] = 'q';
                }
+            #if 0
                else
                {
                   fn[5] = 'u';
                   fn[6] = 'm';
                }
+            #endif
                fn[18] = bn[ia];
                fn[20] = bn[ib];
                p->genstr = GetCopyGenStr(p);
@@ -38001,9 +38012,15 @@ void GenSyrkPerfH(char pre, char *outd, ATL_mmnode_t *sq, ATL_mmnode_t *um)
    if (um)
    {
       double syMF=*um->mflop, mmMF=um->mflop[1];
+   #if 0
       fprintf(fp, "   #define ATL_umsyrkMF %e\n", syMF);
       fprintf(fp, "   #define ATL_umgemmMF %e\n", mmMF);
       fprintf(fp, "   #define ATL_umratio %f\n", syMF/mmMF);
+   #else
+      fprintf(fp, "   #define ATL_ursyrkMF %e\n", syMF);
+      fprintf(fp, "   #define ATL_urgemmMF %e\n", mmMF);
+      fprintf(fp, "   #define ATL_urratio %f\n", syMF/mmMF);
+   #endif
    }
    CloseGenHeader(fp);
 }
@@ -38016,9 +38033,15 @@ void GenSyrkH(char pre, char *outd, ATL_mmnode_t *mb, unsigned int bv)
    FILE *fp;
    const int RCSAME=bv&1, UM=bv&2;
    const int ntr = (pre == 'd' || pre == 's') ? 2 : 4;
+#if 0
    const char *sh = (UM) ? "um" : "sq";
    const char *SH = (UM) ? "UM" : "SQ";
    const char *ums = (UM) ? "UM":"";
+#else
+   const char *sh = (UM) ? "ur" : "sq";
+   const char *SH = (UM) ? "UR" : "SQ";
+   const char *ums = (UM) ? "UR":"";
+#endif
    int ial, ibe, itr, flg;
    const char be[3] = {'0', '1', 'n'};
    char bes[4] = {'1', 'N', 'X', '0'};
@@ -38035,15 +38058,15 @@ void GenSyrkH(char pre, char *outd, ATL_mmnode_t *mb, unsigned int bv)
    {
       if (UM)
       {
-         fp = OpenMMGenHeader(outd, 0, pre, NULL, "amm", "umsyrk", NULL);
+         fp = OpenMMGenHeader(outd, 0, pre, NULL, "amm", "ursyrk", NULL);
          fprintf(fp, "   #include atlas_%camm_sqsyrk.h", pre);
          @whiledef nm VLEN KVEC MU NU
-         fprintf(fp, "#define ATL_UMSYRKK_@(nm) ATL_SQSYRKK_@(nm)\n");
+         fprintf(fp, "#define ATL_URSYRKK_@(nm) ATL_SQSYRKK_@(nm)\n");
          @endwhile
-         fprintf(fp, "#define ATL_%cumsyrkK_b0 ATL_%csqsyrkK_b0\n", pre, pre);
-         fprintf(fp, "#define ATL_%cumsyrkK_b1 ATL_%csqsyrkK_b1\n", pre, pre);
-         fprintf(fp, "#define ATL_%cumsyrkK_bn ATL_%csqsyrkK_bn\n", pre, pre);
-         fprintf(fp, "#define ATL_%ca2blk_umsyrkN ATL_%ca2blk_sqsyrkN\n", 
+         fprintf(fp, "#define ATL_%cursyrkK_b0 ATL_%csqsyrkK_b0\n", pre, pre);
+         fprintf(fp, "#define ATL_%cursyrkK_b1 ATL_%csqsyrkK_b1\n", pre, pre);
+         fprintf(fp, "#define ATL_%cursyrkK_bn ATL_%csqsyrkK_bn\n", pre, pre);
+         fprintf(fp, "#define ATL_%ca2blk_ursyrkN ATL_%ca2blk_sqsyrkN\n", 
                  pre, pre);
 /*
  *       redefine C cpy routs: ATL_<pre>[sq,um]SyrkIntoC_a<alp>_b<bet>
@@ -38056,12 +38079,12 @@ void GenSyrkH(char pre, char *outd, ATL_mmnode_t *mb, unsigned int bv)
                for (is=0; is < 2; is++)
                {
                   fprintf(fp, "#ifdef Conj_\n");
-                  fprintf(fp, "   #define ATL_%cumHerkIntoC_a%cb%c%s "
+                  fprintf(fp, "   #define ATL_%curHerkIntoC_a%cb%c%s "
                           "ATL_%csqHerkIntoC_a%cb%c%s\n", 
                            pre, bes[ial], bes[ibe], sfx[is],
                            pre, bes[ial], bes[ibe], hfx[is]);
                   fprintf(fp, "#endif\n");
-                  fprintf(fp, "#define ATL_%cumSyrkIntoC_a%cb%c%s "
+                  fprintf(fp, "#define ATL_%curSyrkIntoC_a%cb%c%s "
                           "ATL_%csqSyrkIntoC_a%cb%c%s",
                           pre, bes[ial], bes[ibe], sfx[is],
                           pre, bes[ial], bes[ibe], sfx[is] 
@@ -38073,7 +38096,7 @@ void GenSyrkH(char pre, char *outd, ATL_mmnode_t *mb, unsigned int bv)
       }
       return;
    }
-   fp = OpenMMGenHeader(outd, 0, pre, NULL, "amm", UM?"umsyrk":"sqsyrk", NULL);
+   fp = OpenMMGenHeader(outd, 0, pre, NULL, "amm", UM?"ursyrk":"sqsyrk", NULL);
    fprintf(fp, "#define ATL_%sSYRKK_VLEN %d\n", SH, mb->vlen);
    fprintf(fp, "#define ATL_%sSYRKK_KVEC %d\n", SH,
            FLAG_IS_SET(mb->flag, MMF_KVEC) ? mb->vlen:0);
@@ -38149,36 +38172,75 @@ void GenSyrkH(char pre, char *outd, ATL_mmnode_t *mb, unsigned int bv)
 /*
  * Prototype all C cpy routs: ATL_<pre>[sq,um]SyrkIntoC_a<alp>_b<bet>
  */
-   for (ial=0; ial < 3; ial++)
+   if (!UM)
    {
-      for (ibe=0; ibe < 4; ibe++)
+      for (ial=0; ial < 3; ial++)
       {
-         int is;
-         for (is=0; is < 2; is++)
+         for (ibe=0; ibe < 4; ibe++)
          {
-            fprintf(fp, "#ifdef Conj_\n");
-            fprintf(fp, "#define ATL_%c%sSyrkIntoC_a%cb%c%s "
-                    "ATL_%c%sHerkIntoC_a%cb%c%s\n", 
-                     pre, sh, bes[ial], bes[ibe], sfx[is],
-                     pre, sh, bes[ial], bes[ibe], hfx[is]);
-            fprintf(fp, "#endif\n");
-            fprintf(fp, "void ATL_%c%sSyrkIntoC_a%cb%c%s\n", pre, sh, bes[ial],
-                    bes[ibe], sfx[is]);
-            if (pre == 's' || pre == 'd')
-               fprintf(fp, "   (ATL_CSZT,ATL_CSZT,const SCALAR,const TYPE*,const SCALAR, TYPE *,ATL_CSZT);\n");
-            else
-               fprintf(fp, "   (ATL_CSZT,ATL_CSZT,const SCALAR,const TYPE*,"
-                       "const TYPE*,const SCALAR, TYPE *,ATL_CSZT);\n");
+            int is;
+            for (is=0; is < 2; is++)
+            {
+               fprintf(fp, "#ifdef Conj_\n");
+               fprintf(fp, "#define ATL_%c%sSyrkIntoC_a%cb%c%s "
+                       "ATL_%c%sHerkIntoC_a%cb%c%s\n", 
+                        pre, sh, bes[ial], bes[ibe], sfx[is],
+                        pre, sh, bes[ial], bes[ibe], hfx[is]);
+               fprintf(fp, "#endif\n");
+               fprintf(fp, "void ATL_%c%sSyrkIntoC_a%cb%c%s\n", pre, sh, bes[ial],
+                       bes[ibe], sfx[is]);
+               if (pre == 's' || pre == 'd')
+                  fprintf(fp, "   (ATL_CSZT,ATL_CSZT,const SCALAR,const TYPE*,const SCALAR, TYPE *,ATL_CSZT);\n");
+               else
+                  fprintf(fp, "   (ATL_CSZT,ATL_CSZT,const SCALAR,const TYPE*,"
+                          "const TYPE*,const SCALAR, TYPE *,ATL_CSZT);\n");
 
-            fprintf(fp, "#ifndef ATL_%cSyrkIntoC_a%cb%c%s\n   #define "
-            "ATL_%cSyrkIntoC_a%cb%c%s ATL_%c%sSyrkIntoC_a%cb%c%s\n#endif\n",  
-               pre, bes[ial], bes[ibe], sfx[is],
-               pre, bes[ial], bes[ibe], sfx[is],
-               pre, sh, bes[ial], bes[ibe], sfx[is]);
+               fprintf(fp, "#ifndef ATL_%cSyrkIntoC_a%cb%c%s\n   #define "
+               "ATL_%cSyrkIntoC_a%cb%c%s ATL_%c%sSyrkIntoC_a%cb%c%s\n#endif\n",  
+                  pre, bes[ial], bes[ibe], sfx[is],
+                  pre, bes[ial], bes[ibe], sfx[is],
+                  pre, sh, bes[ial], bes[ibe], sfx[is]);
+            }
          }
       }
    }
-   
+   else /* for URSYRK */
+   {
+      for (ial=0; ial < 3; ial++)
+      {
+         for (ibe=0; ibe < 4; ibe++)
+         {
+            int is;
+            for (is=0; is < 2; is++)
+            {
+               fprintf(fp, "#ifdef Conj_\n");
+               fprintf(fp, "#define ATL_%camL2skLNB_a%cb%c%s "
+                    "ATL_%camL2hkLNB_a%cb%c%s\n",
+                     pre, bes[ial], bes[ibe], sfx[is],
+                     pre, bes[ial], bes[ibe], hfx[is]);
+               fprintf(fp, "#endif\n");
+               fprintf(fp, "void ATL_%camL2skLNB_a%cb%c%s\n", pre, bes[ial],
+                    bes[ibe], sfx[is]);
+               if (pre == 's' || pre == 'd')
+                  fprintf(fp, "   (ATL_CSZT,ATL_CUINT,ATL_CUINT,ATL_CUINT,const SCALAR,const TYPE*,const SCALAR, TYPE *,ATL_CSZT);\n");
+               else
+                  fprintf(fp, "   (ATL_CSZT,ATL_CUINT,ATL_CUINT,ATL_CUINT,const SCALAR,const TYPE*,"
+                       "const TYPE*,const SCALAR, TYPE *,ATL_CSZT);\n");
+
+               fprintf(fp, "#ifndef ATL_%c%sSyrkIntoC_a%cb%c%s\n   #define "
+            "ATL_%c%sSyrkIntoC_a%cb%c%s ATL_%camL2skLNB_a%cb%c%s\n#endif\n",
+               pre, sh, bes[ial], bes[ibe], sfx[is],
+               pre, sh, bes[ial], bes[ibe], sfx[is],
+               pre,  bes[ial], bes[ibe], sfx[is]);
+               fprintf(fp, "#ifndef ATL_%cSyrkIntoC_a%cb%c%s\n   #define "
+            "ATL_%cSyrkIntoC_a%cb%c%s ATL_%c%sSyrkIntoC_a%cb%c%s\n#endif\n",
+               pre, bes[ial], bes[ibe], sfx[is],
+               pre, bes[ial], bes[ibe], sfx[is],
+               pre,  sh, bes[ial], bes[ibe], sfx[is]);
+            }
+         }
+      }
+   }
    CloseGenHeader(fp);
 }
 
@@ -38935,8 +38997,10 @@ ATL_mmnode_t *GenAllSyrkH(char pre, char *outd, ATL_mmnode_t **BKB)
    assert(!FLAG_IS_SET(rp->flag, MMF_RIGHT)&&!FLAG_IS_SET(cp->flag, MMF_RIGHT));
    assert((rp->mu == rp->nu) && (cp->nu == cp->mu));
    assert(rp->blask == ATL_KSYRK);
+#if 0 /* no need for the restriction anymore */
    assert(!(rU->mu % rU->nu) || !(rU->nu % rU->mu));
    assert(!(cU->mu % cU->nu) || !(cU->nu % cU->mu));
+#endif
    bv = MMKernsPerfSame(rp, cp);
    GenSyrkH(pre, outd, rp, bv);
    GenSyrkH(cpr, outd, cp, bv);
@@ -40360,7 +40424,7 @@ void Mjoin(PATL,@(vwf)Info)
 #include "atlas_amm.h"
 #include Mstr(Mjoin(ATLAS_UPR,amm_kern.h))
 #include Mstr(Mjoin(ATLAS_PRE,amm_sqsyrk.h))
-#include Mstr(Mjoin(ATLAS_PRE,amm_umsyrk.h))
+#include Mstr(Mjoin(ATLAS_PRE,amm_ursyrk.h))
 #include Mstr(Mjoin(ATLAS_PRE,ipmen_view.h))
 #include Mstr(Mjoin(ATLAS_PRE,syrk_view.h))
 #include Mstr(COPY/Mjoin(ATLAS_PRE,FromANg_a1.h))

--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -528,12 +528,12 @@ ID=55 MU=7 NU=7 KU=4 AUTH='R. Clint Whaley' ROUT='ATL_kmm7x7xVLv16_vsx.S' \
                            const TYPE*, TYPE*, const size_t);
    typedef void (*ablk2cmat_t)(const size_t, const size_t, const SCALAR,
                                const TYPE*, const SCALAR, TYPE *, const size_t);
-   typedef void (*ablk2tcmat_t)(const size_t, ATL_CUINT, ATL_CUINT, ATL_CUINT,
-                               const SCALAR, TYPE *, const SCALAR, TYPE *, 
-                               const size_t);
    typedef void (*cmat2ablk_t)(const size_t, const size_t, const SCALAR,
                                const TYPE*, const size_t, const SCALAR,TYPE*);
    typedef void (*ammswp_t)(ATL_CINT, TYPE*,ATL_CSZT,TYPE*);
+   typedef void (*ablk2tcmat_t)(const ATL_iptr_t, ATL_CUINT, ATL_CUINT,
+                               ATL_CUINT, const SCALAR, const TYPE *, 
+                               const SCALAR, TYPE *, const ATL_iptr_t);
 #else
    typedef void (*cm2am_t)(const size_t, const size_t, const SCALAR,
                            const TYPE*, const size_t, TYPE*, TYPE*);
@@ -544,16 +544,18 @@ ID=55 MU=7 NU=7 KU=4 AUTH='R. Clint Whaley' ROUT='ATL_kmm7x7xVLv16_vsx.S' \
    typedef void (*ablk2cmat_t)(const size_t, const size_t, const SCALAR,
                                const TYPE*, const TYPE*, const SCALAR, 
                                TYPE *, const size_t);
-   typedef void (*ablk2tcmat_t)(const size_t, ATL_CUINT, ATL_CUINT, ATL_CUINT,
-                               const SCALAR, TYPE *, TYPE *, const SCALAR, 
-                               TYPE *, const size_t);
    typedef void (*cmat2ablk_t)(const size_t, const size_t, const SCALAR,
                                const TYPE*, const size_t, const SCALAR,
                                TYPE*,TYPE*);
    typedef void (*ammswp_t)(ATL_CINT, TYPE*,ATL_CSZT,TYPE*,TYPE*);
+   typedef void (*ablk2tcmat_t)(const ATL_iptr_t, ATL_CUINT, ATL_CUINT, 
+                               ATL_CUINT, const SCALAR, const TYPE *, 
+                               const TYPE *, const SCALAR, TYPE *, 
+                               const ATL_iptr_t);
 #endif
 typedef void (*ammkern_t)(ATL_CSZT,ATL_CSZT,ATL_CSZT,const TYPE*,const TYPE*,
                           TYPE*, const TYPE*, const TYPE*, const TYPE*);
+
 #define ushort unsigned short
 #define uint unsigned int
 #define uchar unsigned char

--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -669,7 +669,8 @@ struct opinfo
    uint pszA, szA;          /* size of real portion of part & full blks of A */
    uint pszB, szB;          /* size of real portion of part & full blks of B */
    ushort exsz;             /* extra bytes to alloc past end */
-   ushort idx;              /* kern array index */
+   ushort idx;              /* index in view of this amm case */
+   ushort idxK;             /* index in atlas_?amm_kern.h */
    ushort mF, nF;           /* size of final part of mat before copy */
    ushort mb, pmb, nb, pnb; /* full & partial blk factors for M & N */
    ushort kb;               /* K from original problem */
@@ -39295,6 +39296,7 @@ void Mjoin(PATL,opinfo) /* pop opinfo_t using atlas_opgen_view K-3 idx */
    out->szC = sz;
    out->exsz = (mu*nu)<<1;
    out->idx = iv;
+   out->idxK = imm;
    out->kb = K;
    out->KB = kb;
    out->lda = lda;
@@ -39851,6 +39853,7 @@ int Mjoin(PATL,opsyrkInfo) /* pop opinfo_t using atlas_opgen_view K-3 idx */
    out->szC = sz;
    out->exsz = (mu*nu)<<1;
    out->idx = iv;
+   out->idxK = imm;
    out->kb = K;
    out->KB = kb;
 @ROUT ATL_opsyr2kInfo

--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -37952,8 +37952,8 @@ ATL_cpnode_t *GetKernCopies(char pre, char *outd, ATL_mmnode_t *kb)
       {
       case ATL_KSYRK:  /* SYRK needs C copies for all alpha,beta */
 /*
- *       don't need to be generated copies for ursyrk anymore
- *       so, skip if ursyrk
+ *       no need to generate copies for ursyrk anymore
+ *       so, skip if ursyrk, MMF_RIGHT is used for ursyrk now
  */
          if (FLAG_IS_SET(mp->flag, MMF_RIGHT)) 
             continue; 
@@ -37977,13 +37977,6 @@ ATL_cpnode_t *GetKernCopies(char pre, char *outd, ATL_mmnode_t *kb)
                   fn[5] = 's';
                   fn[6] = 'q';
                }
-            #if 0
-               else
-               {
-                  fn[5] = 'u';
-                  fn[6] = 'm';
-               }
-            #endif
                fn[18] = bn[ia];
                fn[20] = bn[ib];
                p->genstr = GetCopyGenStr(p);
@@ -38005,24 +37998,18 @@ ATL_cpnode_t *GetKernCopies(char pre, char *outd, ATL_mmnode_t *kb)
    return(cb);
 }
 
-void GenSyrkPerfH(char pre, char *outd, ATL_mmnode_t *sq, ATL_mmnode_t *um)
+void GenSyrkPerfH(char pre, char *outd, ATL_mmnode_t *sq, ATL_mmnode_t *ur)
 {
    FILE *fp;
    
    fp = OpenMMGenHeader(outd, 0, pre, NULL, "amm", "syrkPerf", NULL);
    fprintf(fp, "   #define ATL_sqsyrkMF %e\n", sq->mflop[0]);
-   if (um)
+   if (ur)
    {
-      double syMF=*um->mflop, mmMF=um->mflop[1];
-   #if 0
-      fprintf(fp, "   #define ATL_umsyrkMF %e\n", syMF);
-      fprintf(fp, "   #define ATL_umgemmMF %e\n", mmMF);
-      fprintf(fp, "   #define ATL_umratio %f\n", syMF/mmMF);
-   #else
+      double syMF=*ur->mflop, mmMF=ur->mflop[1];
       fprintf(fp, "   #define ATL_ursyrkMF %e\n", syMF);
       fprintf(fp, "   #define ATL_urgemmMF %e\n", mmMF);
       fprintf(fp, "   #define ATL_urratio %f\n", syMF/mmMF);
-   #endif
    }
    CloseGenHeader(fp);
 }
@@ -38033,17 +38020,11 @@ void GenSyrkH(char pre, char *outd, ATL_mmnode_t *mb, unsigned int bv)
 {
    ATL_cpnode_t *cb;
    FILE *fp;
-   const int RCSAME=bv&1, UM=bv&2;
+   const int RCSAME=bv&1, UR=bv&2;
    const int ntr = (pre == 'd' || pre == 's') ? 2 : 4;
-#if 0
-   const char *sh = (UM) ? "um" : "sq";
-   const char *SH = (UM) ? "UM" : "SQ";
-   const char *ums = (UM) ? "UM":"";
-#else
-   const char *sh = (UM) ? "ur" : "sq";
-   const char *SH = (UM) ? "UR" : "SQ";
-   const char *ums = (UM) ? "UR":"";
-#endif
+   const char *sh = (UR) ? "ur" : "sq";
+   const char *SH = (UR) ? "UR" : "SQ";
+   const char *ums = (UR) ? "UR":"";
    int ial, ibe, itr, flg;
    const char be[3] = {'0', '1', 'n'};
    char bes[4] = {'1', 'N', 'X', '0'};
@@ -38058,7 +38039,7 @@ void GenSyrkH(char pre, char *outd, ATL_mmnode_t *mb, unsigned int bv)
  */
    if (!mb)
    {
-      if (UM)
+      if (UR)
       {
          fp = OpenMMGenHeader(outd, 0, pre, NULL, "amm", "ursyrk", NULL);
          fprintf(fp, "   #include atlas_%camm_sqsyrk.h", pre);
@@ -38098,11 +38079,11 @@ void GenSyrkH(char pre, char *outd, ATL_mmnode_t *mb, unsigned int bv)
       }
       return;
    }
-   fp = OpenMMGenHeader(outd, 0, pre, NULL, "amm", UM?"ursyrk":"sqsyrk", NULL);
+   fp = OpenMMGenHeader(outd, 0, pre, NULL, "amm", UR?"ursyrk":"sqsyrk", NULL);
    fprintf(fp, "#define ATL_%sSYRKK_VLEN %d\n", SH, mb->vlen);
    fprintf(fp, "#define ATL_%sSYRKK_KVEC %d\n", SH,
            FLAG_IS_SET(mb->flag, MMF_KVEC) ? mb->vlen:0);
-   if (UM)
+   if (UR)
       fprintf(fp, "#define ATL_%sSYRKK_MU %d\n", SH, mb->mu);
    fprintf(fp, "#define ATL_%sSYRKK_NU %d\n", SH, mb->nu);
    fprintf(fp, "#define ATL_%sSYRKK_KU %d\n", SH, mb->ku);
@@ -38113,7 +38094,7 @@ void GenSyrkH(char pre, char *outd, ATL_mmnode_t *mb, unsigned int bv)
            "ATL_%sSYRKK_@(mn)\n#endif\n", SH);
    @endwhile
    fprintf(fp, "#ifndef ATL_SYRKK_MU\n  #define ATL_SYRKK_MU "
-           "ATL_%sSYRKK_%s\n#endif\n", SH, UM?"MU":"NU");
+           "ATL_%sSYRKK_%s\n#endif\n", SH, UR?"MU":"NU");
 /*
  * Prototype ATL_<pre>_[sq,um]syrkK kernel
  */
@@ -38139,9 +38120,9 @@ void GenSyrkH(char pre, char *outd, ATL_mmnode_t *mb, unsigned int bv)
    }
 /*
  * Prototype/rename all A cpy routs: ATL_<pre>cm2am_syrk<TA>
- * UM case uses gemm's A/B copy, so no need for UM
+ * UR case uses gemm's A/B copy, so no need for UR
  */
-   if (!UM)
+   if (!UR)
    {
       flg = (1<<CPF_TOBLK)|(1<<CPF_AL1);
       flg |= (pre == 'd' || pre == 's') ? (1<<CPF_REAL):0;
@@ -38174,7 +38155,7 @@ void GenSyrkH(char pre, char *outd, ATL_mmnode_t *mb, unsigned int bv)
 /*
  * Prototype all C cpy routs: ATL_<pre>[sq,um]SyrkIntoC_a<alp>_b<bet>
  */
-   if (!UM)
+   if (!UR)
    {
       for (ial=0; ial < 3; ial++)
       {

--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -36329,12 +36329,17 @@ void srch_men(char pre, int verb)
  */
 {
    ATL_mmnode_t *bp, *mmb=NULL;
-   unsigned int U, D, d, maxK;
+   unsigned int U, D, d, maxK, maxKU;
    
    bp = TimeMMFileWithPath(pre, "res", "ipmen.sum", 0, 1, 0, 1, 0, -1);
    if (bp)
    {
+      mmb = bp;
+      bp = TimeMMFileWithPath(pre, "res", "ipsyrk.sum", 0, 1, 0, 1, 0, -1);
+      if (!bp)
+         goto TIME_SYRK;
       KillAllMMNodes(bp);
+      KillAllMMNodes(mmb);
       return;
    }
    bp = ReadMMFileWithPath(pre, "res", "ipgen.sum");
@@ -36361,7 +36366,84 @@ void srch_men(char pre, int verb)
    mmb = ReverseMMQ(mmb);
    MMPruneMflopTol(mmb, 0, 1.0);
    WriteMMFileWithPath(pre, "res", "ipmen.sum", mmb);
-   KillAllMMNodes(mmb);
+/*
+ * Now create syrk kernel  
+ */
+TIME_SYRK:
+   while (mmb->next)                      /* get rid of all but */
+      mmb = KillMMNode(mmb);              /* asymptotic case */
+   maxKU = FLAG_IS_SET(mmb->flag, MMF_KVEC) ? mmb->vlen : 4;
+/*
+ * Try generating with straight params from search
+ */
+   bp = MMGetNodeGEN(pre, 0, 0, mmb->mu, mmb->nu, mmb->ku, mmb->vlen,
+                     FLAG_IS_SET(mmb->flag, MMF_KVEC), mmb->pref, mmb->pfLS,
+                     NULL);
+   bp->flag = ((mmb->flag | (1<<MMF_KRUNTIME)) &
+               (~((1<<MMF_X87)|(1<<MMF_KUISKB))));
+   bp->mbB = mmb->mbB;
+   bp->nbB = mmb->nbB;
+   bp->kbB = mmb->kbB;
+   if (bp->ku > maxKU)
+   {
+      if (FLAG_IS_SET(bp->flag, MMF_KVEC))
+         bp->ku = maxKU;
+      else
+      {
+         unsigned int ku=maxKU, kb=mmb->kbB;
+         while((kb/ku)*ku != kb)
+            ku--;
+         bp->ku = ku;
+      }
+   }
+   bp->mflop[1] = mmb->mflop[0];
+   bp->blask = ATL_KSYRK;
+   if (bp->genstr)
+      free(bp->genstr);
+   bp->genstr = NULL;
+/*
+ * Duplicate this node so we can try BREG1 & NOBCAST
+ */
+   KillMMNode(mmb);
+   mmb = CloneMMNode(bp);
+   mmb->flag |= (1<<MMF_BREG1);
+   bp->mflop[0] = TimeMMKernel(verb, 0, bp, pre, bp->mbB, bp->nbB, bp->kbB,
+                               1, 0, -1);
+   printf("   SYRK/GEMM DEFAULT MFLOP=%.4f\n", bp->mflop[0]/bp->mflop[1]);
+   mmb->mflop[0] = TimeMMKernel(verb, 0, mmb, pre, bp->mbB, bp->nbB, bp->kbB,
+                                1, 0, -1);
+   printf("   SYRK/GEMM BREG1   MFLOP=%.4f\n", mmb->mflop[0]/mmb->mflop[1]);
+/*
+ * bp is best found case so far
+ */
+   if (mmb->mflop[0] >= bp->mflop[0])
+   {
+      ATL_mmnode_t *tp=mmb;
+      mmb = bp;
+      bp = tp;
+   }
+/*
+ * If nu mult of vlen, try NOBCAST
+ */
+   if (!bp->vlen || (bp->nu % bp->vlen) == 0)
+   {
+      mmb->flag = (mmb->flag | (1<<MMF_NOBCAST)) & (~(1<<MMF_BREG1));
+      mmb->mflop[0] = TimeMMKernel(verb, 0, mmb, pre, bp->mbB, bp->nbB, bp->kbB,
+                                   1, 0, -1);
+      printf("   SYRK/GEMM NOBCAST MFLOP=%.4f\n", mmb->mflop[0]/mmb->mflop[1]);
+      if (mmb->mflop[0] >= bp->mflop[0])
+      {
+         ATL_mmnode_t *tp=mmb;
+         mmb = bp;
+         bp = tp;
+      }
+   }
+   KillMMNode(mmb);
+   printf("SYRK/GEMM MFLOP=%.4f\n", bp->mflop[0]/bp->mflop[1]);
+   if (pre == 'c' || pre == 'z')
+      bp->flag |= 1<<MMF_COMPLEX;
+   WriteMMFileWithPath(pre, "res", "ipsyrk.sum", bp);
+   KillMMNode(bp);
 }
 
 int main(int nargs, char **args)
@@ -36394,7 +36476,9 @@ int main(int nargs, char **args)
 
    findBestIP(pre, verb, mmb, NULL);
    srch_men(pre, verb);
+#if 0   
    srch_menUM(pre, verb);
+#endif
    do_ipdek(verb, pre, 0);
    do_ipdek(verb, pre, 1);
 

--- a/AtlasBase/Clint/atlas-ammm.base
+++ b/AtlasBase/Clint/atlas-ammm.base
@@ -528,6 +528,9 @@ ID=55 MU=7 NU=7 KU=4 AUTH='R. Clint Whaley' ROUT='ATL_kmm7x7xVLv16_vsx.S' \
                            const TYPE*, TYPE*, const size_t);
    typedef void (*ablk2cmat_t)(const size_t, const size_t, const SCALAR,
                                const TYPE*, const SCALAR, TYPE *, const size_t);
+   typedef void (*ablk2tcmat_t)(const size_t, ATL_CUINT, ATL_CUINT, ATL_CUINT,
+                               const SCALAR, TYPE *, const SCALAR, TYPE *, 
+                               const size_t);
    typedef void (*cmat2ablk_t)(const size_t, const size_t, const SCALAR,
                                const TYPE*, const size_t, const SCALAR,TYPE*);
    typedef void (*ammswp_t)(ATL_CINT, TYPE*,ATL_CSZT,TYPE*);
@@ -540,6 +543,9 @@ ID=55 MU=7 NU=7 KU=4 AUTH='R. Clint Whaley' ROUT='ATL_kmm7x7xVLv16_vsx.S' \
                            const TYPE*, const TYPE*, TYPE*, const size_t);
    typedef void (*ablk2cmat_t)(const size_t, const size_t, const SCALAR,
                                const TYPE*, const TYPE*, const SCALAR, 
+                               TYPE *, const size_t);
+   typedef void (*ablk2tcmat_t)(const size_t, ATL_CUINT, ATL_CUINT, ATL_CUINT,
+                               const SCALAR, TYPE *, TYPE *, const SCALAR, 
                                TYPE *, const size_t);
    typedef void (*cmat2ablk_t)(const size_t, const size_t, const SCALAR,
                                const TYPE*, const size_t, const SCALAR,
@@ -970,12 +976,13 @@ int Mjoin(PATL,@(rt)her2k)
 @SKIP prototypes for sq/um syrk
 @whiledef rt sq um
 int Mjoin(PATL,@(rt)syrk)
-   (const enum ATLAS_UPLO, const enum ATLAS_TRANS, ATL_CSZT, ATL_CSZT,
-    const SCALAR, const TYPE*, ATL_CSZT, const SCALAR, TYPE*,ATL_CSZT);
+   (ipinfo_t *ip, const enum ATLAS_UPLO, const enum ATLAS_TRANS, ATL_CSZT, 
+    ATL_CSZT, const SCALAR, const TYPE*, ATL_CSZT, const SCALAR, TYPE*,
+    ATL_CSZT);
 #ifdef TCPLX
 int Mjoin(PATL,@(rt)herk)
-   (const enum ATLAS_UPLO, const enum ATLAS_TRANS, ATL_CSZT, ATL_CSZT,
-    const TYPE, const TYPE*, ATL_CSZT, const TYPE, TYPE*,ATL_CSZT);
+   (ipinfo_t *ip, const enum ATLAS_UPLO, const enum ATLAS_TRANS, ATL_CSZT, 
+    ATL_CSZT, const TYPE, const TYPE*, ATL_CSZT, const TYPE, TYPE*, ATL_CSZT);
 #endif
 @endwhile
 /*
@@ -36476,7 +36483,7 @@ int main(int nargs, char **args)
 
    findBestIP(pre, verb, mmb, NULL);
    srch_men(pre, verb);
-#if 0   
+#if 1   
    srch_menUM(pre, verb);
 #endif
    do_ipdek(verb, pre, 0);

--- a/AtlasBase/Clint/atlas-haux.base
+++ b/AtlasBase/Clint/atlas-haux.base
@@ -30,9 +30,6 @@ void ATL_@(pre)trsetU(ATL_CINT M, ATL_CINT N, const @(styp)alpha,
    @whiledef be 0 1 N X
 void ATL_@(pre)geput1T_b@(be)(ATL_CSZT M, ATL_CSZT N, const @(typ) *A, ATL_CSZT lda, 
                      const @(styp)beta, @(typ) *C, ATL_CSZT ldc);
-void ATL_@(pre)amL2skLNB_b@(be)
-   (ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL, 
-    const @(typ) *W,  const @(styp)beta, @(typ) *C, ATL_iptr_t ldc);
    @endwhile
 void ATL_@(pre)geadd(const int M, const int N, const @(styp)alpha, 
                 const @(typ) *A, const int lda, const @(styp)beta, 
@@ -115,6 +112,7 @@ void ATL_@(pre)gescal_@(be)
 /*
  * Real-only aux routines
  */
+@multidef styp double@^ float@^
 @multidef typ double float
 @whiledef pre d s
 void ATL_@(pre)trcpypad4L(enum ATLAS_DIAG Diag, ATL_CINT N, const @(typ) *A, 
@@ -127,7 +125,16 @@ void ATL_@(pre)sycpy@(up)NB_a@(al)(ATL_CSZT N, const @(typ) alpha, const @(typ) 
                       ATL_CSZT lda, @(typ) *C, ATL_CSZT ldc);
       @endwhile
    @endwhile
+@SKIP /* function prototype of real is different.. so, had to place it here*/
+@whiledef be bX b0 b1
+   @whiledef al aX a0 a1
+void ATL_@(pre)amL2skLNB_@(al)@(be)
+   (ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL, const @(styp)alpha, 
+    const @(typ) *rC,  const @(styp)beta, @(typ) *C, ATL_iptr_t ldc);
+   @endwhile
+@endwhile
    @undef typ
+   @undef styp
 @endwhile
 
 /*
@@ -226,6 +233,19 @@ void ATL_@(pre)gemove_aXi0
 void ATL_@(pre)gescal_bXi0
    (const int M, const int N, const @(styp)beta, @(typ) *C, const int ldc);
 
+   @SKIP /* function prototype for complex is different */
+@whiledef be bX br b0 b1
+   @whiledef al aX ar a0 a1
+void ATL_@(pre)amL2skLNB_@(al)@(be)
+   (ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL,const @(styp)alpha, 
+    const @(typ) *rC, const @(typ) *iC, const @(styp)beta, @(typ) *C, 
+    ATL_iptr_t ldc);
+void ATL_@(pre)amL2hkLNB_@(al)@(be)
+   (ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL,const @(styp)alpha, 
+    const @(typ) *rC, const @(typ) *iC, const @(styp)beta, @(typ) *C, 
+    ATL_iptr_t ldc);
+   @endwhile
+@endwhile
    @undef typ
    @undef styp
 @endwhile

--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -1746,188 +1746,250 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
 #ifdef BETA1
    #ifdef ALPHA1
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1b1)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1b1),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1b1)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1b1),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1b1)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1b1),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1b1)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1b1),_L2UT)
       #endif
    #elif defined(ALPHAN) || defined(ALPHAN1)
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNb1)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNb1),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNb1)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNb1),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNb1)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNb1),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNb1)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNb1),_L2UT)
       #endif
    #elif defined(ALPHAR)
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arb1)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arb1),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arb1)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arb1),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arb1)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arb1),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arb1)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arb1),_L2UT)
       #endif
    #else
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXb1)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXb1),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXb1)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXb1),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXb1)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXb1),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXb1)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXb1),_L2UT)
       #endif
    #endif
 #elif defined(BETA0)
    #ifdef ALPHA1
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1b0)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1b0),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1b0)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1b0),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1b0)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1b0),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1b0)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1b0),_L2UT)
       #endif
    #elif defined(ALPHAN) || defined(ALPHAN1)
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNb0)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNb0),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNb0)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNb0),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNb0)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNb0),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNb0)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNb0),_L2UT)
       #endif
    #elif defined(ALPHAR)
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arb0)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arb0),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arb0)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arb0),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arb0)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arb0),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arb0)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arb0),_L2UT)
       #endif
    #else
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXb0)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXb0),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXb0)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXb0),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXb0)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXb0),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXb0)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXb0),_L2UT)
       #endif
    #endif
 #elif defined(BETAN) || defined(BETAN1)
    #ifdef ALPHA1
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1bN)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1bN),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1bN)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1bN),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1bN)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1bN),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1bN)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1bN),_L2UT)
       #endif
    #elif defined(ALPHAN) || defined(ALPHAN1)
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbN)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbN),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbN)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbN),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbN)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbN),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbN)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbN),_L2UT)
       #endif
    #elif defined(ALPHAR)
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbN)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbN),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbN)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbN),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbN)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbN),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbN)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbN),_L2UT)
       #endif
    #else
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbN)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbN),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbN)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbN),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbN)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbN),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbN)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbN),_L2UT)
       #endif
    #endif
 #elif defined(BETAR)
    #ifdef ALPHA1
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1br)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1br),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1br)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1br),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1br)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1br),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1br)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1br),_L2UT)
       #endif
    #elif defined(ALPHAN) || defined(ALPHAN1)
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbr)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbr),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbr)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbr),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbr)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbr),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbr)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbr),_L2UT)
       #endif
    #elif defined(ALPHAR)
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbr)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbr),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbr)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbr),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbr)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbr),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbr)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbr),_L2UT)
       #endif
    #else
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbr)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbr),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbr)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbr),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbr)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbr),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbr)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbr),_L2UT)
       #endif
    #endif
 #else
    #ifdef ALPHA1
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1bX)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1bX),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1bX)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1bX),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1bX)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1bX),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1bX)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1bX),_L2UT)
       #endif
    #elif defined(ALPHAN) || defined(ALPHAN1)
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbX)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbX),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbX)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbX),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbX)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbX),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbX)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbX),_L2UT)
       #endif
    #elif defined(ALPHAR)
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbX)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbX),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbX)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbX),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbX)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbX),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbX)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbX),_L2UT)
       #endif
    #else
       #ifdef Conj_
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbX)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbX),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbX)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbX),_L2UT)
       #else
-         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbX)
-         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbX),_L2UT)
+         #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbX)
+         #define ATL_amL2skLNB_L2UT \
+                  Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbX),_L2UT)
       #endif
    #endif
 #endif
+
 #ifdef TCPLX
+/*
+ * calc needed for alpha/beta multiplication 
+ */
+   #define multX0(rr_, ir_, rx_, ix_, rc_, ic_, Cr_, Ci_) \
+               rr_ = rc_ * rx_; \
+               ir_ = ic_ * rx_; \
+               rr_ -= ic_ * ix_; \
+               ir_ += rc_ * ix_; \
+               Cr_ = rr_; \
+               Ci_ = ir_; 
+   #define multX(rr_, ir_, rx_, ix_, rc_, ic_, Cr_, Ci_) \
+               rr_ += rc_ * rx_; \
+               ir_ += ic_ * rx_; \
+               rr_ -= ic_ * ix_; \
+               ir_ += rc_ * ix_; \
+               Cr_ = rr_; \
+               Ci_ = ir_; 
+   #define multAlphaBeta(r0_,r1_,i0_,i1_,ra_,ia_,rb_,ib_,rB_,iB_,rc_,ic_,Cr_,Ci_)\
+               r0_  = rb_ * rc_; \
+               r1_  = ra_ * rB_; \
+               i0_  = rb_ * ic_; \
+               i1_  = ra_ * iB_; \
+               r0_ -= ib_ * ic_; \
+               i1_ += ib_ * rc_; \
+               r1_ -= ia_ * iB_; \
+               i1_ += ia_ * rB_; \
+               Cr_ = r0_ + r1_; \
+               Ci_ = i0_ + i1_; 
 /*
  * NOTE: we need conj_ case only for _L2UT, although we may compile normal
  * blk2c copy with -DConj_ (for HERK). Due to this different behavior of
  * conj_ for these two blk2c copies, we kept two versions of applyAlpBet.
  */
    #ifdef ALPHA1
-      #define multBeta (rr_, ir_, rb_, ib_, rc_,ic_) \
-               rr_ += rc_ * rb_; \
-               ir_ += ic_ * rb_; \
-               rr_ -= ic_ * ib_; \
-               ir_ += rc_ * ib_; \
-               rc_ = rr_; \
-               ic_ = ir_; 
       #ifdef BETA0
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
@@ -1959,7 +2021,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #elif defined(BETAN) || defined(BETAN1)
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
-               rc_ = rw_ - rc_; ic_ = iw_ - ic;\
+               rc_ = rw_ - rc_; ic_ = iw_ - ic_;\
             }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
@@ -1974,15 +2036,15 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
                const register TYPE rc=rc_, ic=ic_; \
-               register TYPE rr=rw_, ir=iw_ \
-               multBeta(rr, ir, rb, ib, rc_, ic_) \
+               register TYPE rr=rw_, ir=iw_; \
+               multX(rr, ir, rb, ib, rc, ic, rc_, ic_) \
             }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                const register TYPE rc=rc_, ic=ic_; \
                register TYPE rr=rw_, ir=-iw_ \
-               multBeta(rr, ir, rb, ib, rc_, ic_) \
+               multX(rr, ir, rb, ib, rc, ic, rc_, ic_) \
             }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
@@ -2021,12 +2083,12 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #elif defined(BETAN) || defined(BETAN1)
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
-               rc_ = -rw_ - rc_; ic_ = -iw_ - ic;\
+               rc_ = -rw_ - rc_; ic_ = -iw_ - ic_;\
             }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
-               rc_ = -rw_ - rc_; ic_ = iw_ - ic;\
+               rc_ = -rw_ - rc_; ic_ = iw_ - ic_;\
             }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
@@ -2036,15 +2098,15 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
                const register TYPE rc=rc_, ic=ic_; \
-               register TYPE rr=-rw_, ir=-iw_ \
-               multBeta(rr, ir, rb, ib, rc_, ic_) \
+               register TYPE rr=-rw_, ir=-iw_; \
+               multX(rr, ir, rb, ib, rc, ic, rc_, ic_) \
             } 
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                const register TYPE rc=rc_, ic=ic_; \
-               register TYPE rr=-rw_, ir=iw_ \
-               multBeta(rr, ir, rb, ib, rc_, ic_) \
+               register TYPE rr=-rw_, ir=iw_; \
+               multX(rr, ir, rb, ib, rc, ic, rc_, ic_) \
             } 
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
@@ -2052,26 +2114,19 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
          #endif
       #endif
    #elif defined(ALPHAX)
-      #define multAlpha(rr_, ir_, ra_, ia_, rc_, ic_) \
-               rr_ = rc_ * ra_; \
-               ir_ = ic_ * ra_; \
-               rr_ -= ic_ * ia_; \
-               ir_ += rc_ * ia_; \
-               rc_ = rr_; \
-               ic_ = ir_; 
       #ifdef BETA0
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
                const register TYPE rc=rw_, ic=iw_; \
                register TYPE rr, ir; \
-               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+               multX0(rr, ir, ra, ia, rc, ic, rc_, ic_); \
             }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                const register TYPE rc=rw_, ic=-iw_; \
                register TYPE rr, ir; \
-               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+               multX0(rr, ir, ra, ia, rc, ic, rc_, ic_); \
             }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
@@ -2082,14 +2137,14 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
             {\
                const register TYPE rc=rw_, ic=iw_; \
                register TYPE rr=rc_, ir=ic_; \
-               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+               multX(rr, ir, ra, ia, rc, ic, rc_, ic_); \
             }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                const register TYPE rc=rw_, ic=-iw_; \
                register TYPE rr=rc_, ir=ic_; \
-               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+               multX(rr, ir, ra, ia, rc, ic, rc_, ic_); \
             }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
@@ -2100,43 +2155,32 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
             {\
                const register TYPE rc=rw_, ic=iw_; \
                register TYPE rr = -rc_, ir = -ic_; \
-               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+               multX(rr, ir, ra, ia, rc, ic, rc_, ic_); \
             }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                const register TYPE rc=rw_, ic=-iw_; \
                register TYPE rr = -rc_, ir = -ic_; \
-               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+               multX(rr, ir, ra, ia, rc, ic, rc_, ic_); \
             }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
                applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #else /* BETAX */
-         #define multAlphaBeta(r0_,r1_,i0_,i1_,ra_,ia_,rb_,ib_,rB_,iB_,rc_,ic_)\
-               r0_  = rb_ * rc_; \
-               r1_  = ra_ * rB_; \
-               i0_  = rb_ * ic_; \
-               i1_  = ra_ * iB_; \
-               r0_ -= ib_ * ic_; \
-               i1_ += ib_ * rc_; \
-               r1_ -= ia_ * iB_; \
-               i1_ += ia_ * rB_; \
-               rc_ = r0_ + r1_; \
-               ic_ = i0_ + i1_; 
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
                register TYPE rc=rc_, ic=ic_; \
                register TYPE rB=rw_, iB=iw_, r0, i0, r1, i1; \
-               multAlphaBeta(r0, r1, i0, i1, ra, ia, rb, ib, rB, iB, rc_, ic_)\
+               multAlphaBeta(r0,r1, i0,i1, ra,ia, rb,ib, rB,iB, rc,ic, rc_,ic_)\
             }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                register TYPE rc=rc_, ic=ic_; \
                register TYPE rB=rw_, iB=-iw_, r0, i0, r1, i1; \
-               multAlphaBeta(r0, r1, i0, i1, ra, ia, rb, ib, rB, iB, rc_, ic_)\
+               multAlphaBeta(r0,r1, i0,i1, ra,ia, rb,ib, rB,iB, rc,ic, rc_,ic_)\
             }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
@@ -2164,7 +2208,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
    #endif
 #endif
 
-void amL2skLNB
+void ATL_amL2skLNB
 ( 
    ATL_iptr_t N, 
    ATL_CUINT MU, 
@@ -2353,7 +2397,7 @@ void amL2skLNB
 /*
  * L2UT with columnwise accesss for C 
  */   
-void amL2skLNB_L2UT
+void ATL_amL2skLNB_L2UT
 (
    ATL_iptr_t N, 
    ATL_CUINT MU, 
@@ -2390,14 +2434,14 @@ void amL2skLNB_L2UT
  *                       => j > i+nu-1
  *    access of C-workspace is consecutive
  */
-      for (i=0; j > i+nu-1; i=in, rC += incW )
+      for (i=0; j > (i+nu-1); i=in, rC += incW )
       {
          const TYPE *rw0 = rC;
          #ifdef TCPLX
             const TYPE *iw0 = iC;
          #endif
          ATL_UINT ii, jj;
-         TYPE *c = C+i+j*(ldc SHIFT);
+         TYPE *c = C+((i+j*ldc) SHIFT);
          nu = Mmin(NU, N-i);
          in = i + nu;
          for (jj=0; jj < mu; jj++, c += (ldc SHIFT), rw0++)
@@ -2434,7 +2478,7 @@ void amL2skLNB_L2UT
             const TYPE *iw0 = iC;
          #endif
          ATL_UINT ii, jj;
-         TYPE *c = C+i+j*(ldc SHIFT);
+         TYPE *c = C+((i+j*ldc) SHIFT);
          nu = Mmin(NU, N-i);
          in = i + nu;
          for (jj=0; jj < mu; jj++, c += (ldc SHIFT), rw0++)

--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -2332,7 +2332,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
 
 void ATL_amL2skLNB
 ( 
-   ATL_iptr_t N, 
+   const ATL_iptr_t N, 
    ATL_CUINT MU, 
    ATL_CUINT NU, 
    ATL_CUINT shVL, 
@@ -2521,7 +2521,7 @@ void ATL_amL2skLNB
  */   
 void ATL_amL2skLNB_L2UT
 (
-   ATL_iptr_t N, 
+   const ATL_iptr_t N, 
    ATL_CUINT MU, 
    ATL_CUINT NU, 
    ATL_CUINT shVL,

--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -1745,80 +1745,406 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
  */
 #ifdef BETA1
    #ifdef ALPHA1
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1b1)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1b1),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1b1)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1b1),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1b1)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1b1),_L2UT)
+      #endif
    #elif defined(ALPHAN) || defined(ALPHAN1)
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNb1)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNb1),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNb1)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNb1),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNb1)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNb1),_L2UT)
+      #endif
    #elif defined(ALPHAR)
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arb1)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arb1),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arb1)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arb1),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arb1)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arb1),_L2UT)
+      #endif
    #else
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXb1)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXb1),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXb1)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXb1),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXb1)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXb1),_L2UT)
+      #endif
    #endif
 #elif defined(BETA0)
    #ifdef ALPHA1
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1b0)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1b0),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1b0)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1b0),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1b0)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1b0),_L2UT)
+      #endif
    #elif defined(ALPHAN) || defined(ALPHAN1)
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNb0)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNb0),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNb0)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNb0),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNb0)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNb0),_L2UT)
+      #endif
    #elif defined(ALPHAR)
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arb0)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arb0),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arb0)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arb0),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arb0)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arb0),_L2UT)
+      #endif
    #else
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXb0)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXb0),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXb0)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXb0),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXb0)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXb0),_L2UT)
+      #endif
    #endif
 #elif defined(BETAN) || defined(BETAN1)
    #ifdef ALPHA1
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1bN)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1bN),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1bN)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1bN),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1bN)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1bN),_L2UT)
+      #endif
    #elif defined(ALPHAN) || defined(ALPHAN1)
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbN)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbN),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbN)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbN),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbN)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbN),_L2UT)
+      #endif
    #elif defined(ALPHAR)
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbN)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbN),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbN)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbN),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbN)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbN),_L2UT)
+      #endif
    #else
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbN)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbN),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbN)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbN),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbN)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbN),_L2UT)
+      #endif
    #endif
 #elif defined(BETAR)
    #ifdef ALPHA1
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1br)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1br),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1br)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1br),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1br)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1br),_L2UT)
+      #endif
    #elif defined(ALPHAN) || defined(ALPHAN1)
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbr)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbr),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbr)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbr),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbr)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbr),_L2UT)
+      #endif
    #elif defined(ALPHAR)
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbr)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbr),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbr)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbr),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbr)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbr),_L2UT)
+      #endif
    #else
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbr)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbr),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbr)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbr),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbr)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbr),_L2UT)
+      #endif
    #endif
 #else
    #ifdef ALPHA1
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1bX)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1bX),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1bX)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1bX),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1bX)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_a1bX),_L2UT)
+      #endif
    #elif defined(ALPHAN) || defined(ALPHAN1)
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbX)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbX),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbX)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbX),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbX)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aNbX),_L2UT)
+      #endif
    #elif defined(ALPHAR)
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbX)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbX),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbX)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbX),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbX)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbX),_L2UT)
+      #endif
    #else
-      #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbX)
-      #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbX),_L2UT)
+      #ifdef Conj_
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbX)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbX),_L2UT)
+      #else
+         #define amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbX)
+         #define amL2skLNB_L2UT Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_aXbX),_L2UT)
+      #endif
    #endif
 #endif
 #ifdef TCPLX
 /*
- * not implemented the complex copies yet 
+ * NOTE: we need conj_ case only for _L2UT, although we may compile normal 
+ * blk2c copy with -DConj_ (for HERK). Due to this different behavior of 
+ * conj_ for these two blk2c copies, we kept two versions of applyAlpBet. 
  */
+   #ifdef ALPHA1
+      #define multBeta (rr_, ir_, rb_, ib_, rc_,ic_) \
+               rr_ += rc_ * rb_; \
+               ir_ += ic_ * rb_; \
+               rr_ -= ic_ * ib_; \
+               ir_ += rc_ * ib_; \
+               rc_ = rr_; \
+               ic_ = ir_; \
+      #ifdef BETA0
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = rw_; ic_ = iw_;\
+            }\
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = rw_; ic_ = -iw_;\
+            }\
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+      #elif defined(BETA1)
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ += rw_; ic_ += iw_;\
+            }\
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ += rw_; ic_ -= -iw_;\
+            }\
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+      #elif defined(BETAN) || defined(BETAN1)
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = rw_ - rc_; ic_ = iw_ - ic;\
+            }\
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = rw_ - rc_; ic_ = -iw_ - ic;\
+            }\
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+      #else /* BETAX */
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\ 
+               const register TYPE rc=rc_, ic=ic_; \
+               register TYPE rr=rw_, ir=iw_ \
+               multBeta(rr, ir, rb, ib, rc_, ic_) \
+            }\
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\ 
+               const register TYPE rc=rc_, ic=ic_; \
+               register TYPE rr=rw_, ir=-iw_ \
+               multBeta(rr, ir, rb, ib, rc_, ic_) \
+            }\
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+      #endif
+   #elif defined(ALPHAN)
+      #ifdef BETA0
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = -rw_; ic_ = -iw_;\
+            }\
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = -rw_; ic_ = iw_;\
+            }\
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+      #elif defined(BETA1)
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ -= rw_; ic_ -= iw_;\
+            }\
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ -= rw_; ic_ += iw_;\
+            }\
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+      #elif defined(BETAN) || defined(BETAN1)
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = -rw_ - rc_; ic_ = -iw_ - ic;\
+            }\
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = -rw_ - rc_; ic_ = iw_ - ic;\
+            }\
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+      #else /* BETAX */
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\ 
+               const register TYPE rc=rc_, ic=ic_; \
+               register TYPE rr=-rw_, ir=-iw_ \
+               multBeta(rr, ir, rb, ib, rc_, ic_) \
+            } \
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\ 
+               const register TYPE rc=rc_, ic=ic_; \
+               register TYPE rr=-rw_, ir=iw_ \
+               multBeta(rr, ir, rb, ib, rc_, ic_) \
+            } \
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+      #endif
+   #elif defined(ALPHAX)
+      #define multAlpha(rr_, ir_, ra_, ia_, rc_, ic_) \
+               rr_ = rc_ * ra_; \
+               ir_ = ic_ * ra_; \
+               rr_ -= ic_ * ia_; \
+               ir_ += rc_ * ia_; \
+               rc_ = rr_; \
+               ic_ = ir_; \
+      #ifdef BETA0
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\ 
+               const register TYPE rc=rw_, ic=iw_; \
+               register TYPE rr, ir; \
+               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+            }\
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\ 
+               const register TYPE rc=rw_, ic=-iw_; \
+               register TYPE rr, ir; \
+               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+            }\
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+      #elif defined(BETA1)
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\ 
+               const register TYPE rc=rw_, ic=iw_; \
+               register TYPE rr=rc_, ir=ic_; \
+               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+            }\
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\ 
+               const register TYPE rc=rw_, ic=-iw_; \
+               register TYPE rr=rc_, ir=ic_; \
+               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+            }\
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+      #elif defined(BETAN) || defined(BETAN1)
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\ 
+               const register TYPE rc=rw_, ic=iw_; \
+               register TYPE rr = -rc_, ir = -ic_; \
+               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+            }\
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\ 
+               const register TYPE rc=rw_, ic=-iw_; \
+               register TYPE rr = -rc_, ir = -ic_; \
+               multAlpha(rr, ir, ra, ia, rc_, ic_); \
+            }\
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+      #else /* BETAX */
+         #define multAlphaBeta(r0_,r1_,i0_,i1_,ra_,ia_,rb_,ib_,rB_,iB_,rc_,ic_)\
+               r0_  = rb_ * rc_; \
+               r1_  = ra_ * rB_; \
+               i0_  = rb_ * ic_; \
+               i1_  = ra_ * iB_; \
+               r0_ -= ib_ * ic_; \
+               i1_ += ib_ * rc_; \
+               r1_ -= ia_ * iB_; \
+               i1_ += ia_ * rB_; \
+               rc_ = r0_ + r1_; \
+               ic_ = i0_ + i1_; \
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               register TYPE rc=rc_, ic=ic_; \
+               register TYPE rB=rw_, iB=iw_, r0, i0, r1, i1; \
+               multAlphaBeta(r0, r1, i0, i1, ra, ia, rb, ib, rB, iB, rc_, ic_)\
+            }\
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               register TYPE rc=rc_, ic=ic_; \
+               register TYPE rB=rw_, iB=-iw_, r0, i0, r1, i1; \
+               multAlphaBeta(r0, r1, i0, i1, ra, ia, rb, ib, rB, iB, rc_, ic_)\
+            }\
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) \
+         #endif
+   #endif
 #else
+   #define applyAlpBet_L2UT(c_,w_) applyAlpBet(c_, w_)
    #ifdef ALPHA1
       #define applyAlpha(x_) (x_)
    #elif defined(ALPHAN)
@@ -1854,6 +2180,9 @@ void amL2skLNB
 )
 {
 #if 0
+/*
+ * row wise C access, suffers TLB problem 
+ */
    ATL_CUINT incW = ((MU*NU+(1<<shVL)-1)>>shVL)<<shVL;
    ATL_UINT i, in;
 
@@ -1898,9 +2227,10 @@ void amL2skLNB
    const TYPE *rW=rC, *rw;
    #ifdef TCPLX 
    const TYPE *iW=iC, *iw;
+   const TYPE ra=*alpha, ia=alpha[1];
+   const TYPE rb=*beta, ib=beta[1];
    #endif
-   const ATL_iptr_t LDC = (ldc SHIFT);
-   const ATL_iptr_t incC = LDC*NU;
+   const ATL_iptr_t incC = NU*(ldc SHIFT);
 
 
    for (cinc=j=0; j < N; j = jn, C += incC, cinc += blksz)
@@ -1944,7 +2274,7 @@ void amL2skLNB
 /*
  *       copying subblock with diagonal 
  */
-         for (jj=0; jj < nu; jj++, c += LDC, pr += MU)
+         for (jj=0; jj < nu; jj++, c += (ldc SHIFT), pr += MU)
          {
             ATL_CUINT J=j+jj;
             for (ii=0; ii < mu; ii++)
@@ -1953,9 +2283,10 @@ void amL2skLNB
                if (I >= J)
                {
                   ATL_CUINT kk = (ii SHIFT);
-                  applyAlpBet(c[kk], pr[ii]);
                   #ifdef TCPLX
-                     applyAlpBet(c[kk+1], pi[ii]);
+                     applyAlpBet(c[kk], pr[ii], c[kk+1], pi[ii]);
+                  #else
+                     applyAlpBet(c[kk], pr[ii]);
                   #endif 
                }
             }
@@ -1995,10 +2326,11 @@ void amL2skLNB
             for (ii=0; ii < mu; ii++)
             {
                ATL_CUINT kk = (ii SHIFT);
-               applyAlpBet(c[kk], pr[ii]);
                #ifdef TCPLX
-                  applyAlpBet(c[kk+1], pi[ii]);
-               #endif
+                  applyAlpBet(c[kk], pr[ii], c[kk+1], pi[ii]);
+               #else
+                  applyAlpBet(c[kk], pr[ii]);
+               #endif 
             }
          }
          nblks = (in-1+NU) / NU;  /* # of row blocks in this panel */
@@ -2014,11 +2346,28 @@ void amL2skLNB
 /*
  * L2UT with columnwise accesss for C 
  */   
-void amL2skLNB_L2UT(ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL,
-                    const TYPE *W, const SCALAR beta, TYPE *C, ATL_iptr_t ldc)
+void amL2skLNB_L2UT
+(
+   ATL_iptr_t N, 
+   ATL_CUINT MU, 
+   ATL_CUINT NU, 
+   ATL_CUINT shVL,
+   const SCALAR alpha, 
+   const TYPE *rC,
+#ifdef TCPLX
+   const TYPE *iC, 
+#endif
+   const SCALAR beta, 
+   TYPE *C, 
+   ATL_iptr_t ldc
+)
 {
    ATL_CUINT incW = ((MU*NU+(1<<shVL)-1)>>shVL)<<shVL;
    ATL_UINT j, jn;
+   #ifdef TCPLX
+      const TYPE ra=*alpha, ia=alpha[1];
+      const TYPE rb=*beta, ib=beta[1];
+   #endif
 /*
  * since it's upper transpose case, the direction of MU and NU interchanged 
  */
@@ -2034,41 +2383,83 @@ void amL2skLNB_L2UT(ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL,
  *                       => j > i+nu-1
  *    access of C-workspace is consecutive
  */
-      for (i=0; j > i+nu-1; i=in, W += incW )
+      for (i=0; j > i+nu-1; i=in, rC += incW )
       {
-         const TYPE *w0 = W;
+         const TYPE *rw0 = rC;
+         #ifdef TCPLX
+            const TYPE *iw0 = iC;
+         #endif
          ATL_UINT ii, jj;
-         TYPE *c = C+i+j*ldc;
+         TYPE *c = C+i+j*(ldc SHIFT);
          nu = Mmin(NU, N-i);
          in = i + nu;
-         for (jj=0; jj < mu; jj++, c += ldc, w0++)
+         for (jj=0; jj < mu; jj++, c += (ldc SHIFT), rw0++)
          {
-            const TYPE *w = w0;
-            for (ii=0; ii < nu; ii++, w += MU)
-               applyAlpBet(c[ii], *w);
+            const TYPE *pr = rw0;
+            #ifdef TCPLX
+               const TYPE *pi = iw0;
+            #endif
+            for (ii=0; ii < nu; ii++, pr += MU)
+            {
+               ATL_CUINT kk = (ii SHIFT);
+               #ifdef TCPLX
+                  applyAlpBet_L2UT(c[kk], (*pr), c[kk+1], (*pi));
+                  pi += MU;
+               #else
+                  applyAlpBet_L2UT(c[kk], (*pr));
+               #endif 
+            }
+            #ifdef TCPLX
+               iw0++
+            #endif
          }
+         #ifdef
+            iC += incW;
+         #endif
       }
 /*
  *    intersection occurs at later blocks
  */
-      for ( ; i < jn; i=in, W+=incW)
+      for ( ; i < jn; i=in, rC += incW)
       {
-         const TYPE *w0 = W;
+         const TYPE *rw0 = rC;
+         #ifdef TCPLX
+            const TYPE *iw0 = iC;
+         #endif
          ATL_UINT ii, jj;
-         TYPE *c = C+i+j*ldc;
+         TYPE *c = C+i+j*(ldc SHIFT);
          nu = Mmin(NU, N-i);
          in = i + nu;
-         for (jj=0; jj < mu; jj++, c += ldc, w0++)
+         for (jj=0; jj < mu; jj++, c += (ldc SHIFT), rw0++)
          {
-            const TYPE *w = w0;
+            const TYPE *pr = rw0;
+            #ifdef TCPLX
+               const TYPE *pi = iw0;
+            #endif
             ATL_CUINT J=j+jj;
-            for (ii=0; ii < nu; ii++, w += MU)
+            for (ii=0; ii < nu; ii++, pr += MU)
             {
                ATL_CUINT I=i+ii;
                if (I <= J)
-                  applyAlpBet(c[ii], *w);
+               {
+                  ATL_CUINT kk = (ii SHIFT);
+                  #ifdef TCPLX
+                     applyAlpBet_L2UT(c[kk], (*pr), c[kk+1], (*pi));
+                  #else
+                     applyAlpBet_L2UT(c[kk], (*pr));
+                  #endif 
+               }
+               #ifdef TCPLX
+                  pi += MU;
+               #endif
             }
+            #ifdef TCPLX
+               iw0++
+            #endif
          }
+         #ifdef
+            iC += incW;
+         #endif
       }
    }
 }

--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -1748,7 +1748,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1b1)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1b1),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1b1),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1b1)
          #define ATL_amL2skLNB_L2UT \
@@ -1758,7 +1758,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNb1)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNb1),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNb1),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNb1)
          #define ATL_amL2skLNB_L2UT \
@@ -1768,7 +1768,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arb1)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arb1),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arb1),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arb1)
          #define ATL_amL2skLNB_L2UT \
@@ -1778,7 +1778,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXb1)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXb1),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXb1),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXb1)
          #define ATL_amL2skLNB_L2UT \
@@ -1790,7 +1790,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1b0)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1b0),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1b0),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1b0)
          #define ATL_amL2skLNB_L2UT \
@@ -1800,7 +1800,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNb0)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNb0),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNb0),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNb0)
          #define ATL_amL2skLNB_L2UT \
@@ -1810,7 +1810,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arb0)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arb0),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arb0),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arb0)
          #define ATL_amL2skLNB_L2UT \
@@ -1820,7 +1820,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXb0)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXb0),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXb0),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXb0)
          #define ATL_amL2skLNB_L2UT \
@@ -1832,7 +1832,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1bN)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1bN),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1bN),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1bN)
          #define ATL_amL2skLNB_L2UT \
@@ -1842,7 +1842,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbN)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbN),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbN),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbN)
          #define ATL_amL2skLNB_L2UT \
@@ -1852,7 +1852,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbN)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbN),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbN),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbN)
          #define ATL_amL2skLNB_L2UT \
@@ -1862,7 +1862,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbN)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbN),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbN),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbN)
          #define ATL_amL2skLNB_L2UT \
@@ -1874,7 +1874,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1br)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1br),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1br),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1br)
          #define ATL_amL2skLNB_L2UT \
@@ -1884,7 +1884,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbr)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbr),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbr),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbr)
          #define ATL_amL2skLNB_L2UT \
@@ -1894,7 +1894,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbr)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbr),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbr),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbr)
          #define ATL_amL2skLNB_L2UT \
@@ -1904,7 +1904,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbr)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbr),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbr),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbr)
          #define ATL_amL2skLNB_L2UT \
@@ -1916,7 +1916,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_a1bX)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1bX),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_a1bX),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_a1bX)
          #define ATL_amL2skLNB_L2UT \
@@ -1926,7 +1926,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aNbX)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbX),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aNbX),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aNbX)
          #define ATL_amL2skLNB_L2UT \
@@ -1936,7 +1936,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_arbX)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbX),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_arbX),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_arbX)
          #define ATL_amL2skLNB_L2UT \
@@ -1946,7 +1946,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbX)
          #define ATL_amL2skLNB_L2UT \
-                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbX),_L2UT)
+                  Mjoin(Mjoin(Mjoin(PATL,amL2hkLNB),_aXbX),_L2UH)
       #else
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2skLNB),_aXbX)
          #define ATL_amL2skLNB_L2UT \

--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -1916,9 +1916,9 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
 #endif
 #ifdef TCPLX
 /*
- * NOTE: we need conj_ case only for _L2UT, although we may compile normal 
- * blk2c copy with -DConj_ (for HERK). Due to this different behavior of 
- * conj_ for these two blk2c copies, we kept two versions of applyAlpBet. 
+ * NOTE: we need conj_ case only for _L2UT, although we may compile normal
+ * blk2c copy with -DConj_ (for HERK). Due to this different behavior of
+ * conj_ for these two blk2c copies, we kept two versions of applyAlpBet.
  */
    #ifdef ALPHA1
       #define multBeta (rr_, ir_, rb_, ib_, rc_,ic_) \
@@ -1927,66 +1927,66 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
                rr_ -= ic_ * ib_; \
                ir_ += rc_ * ib_; \
                rc_ = rr_; \
-               ic_ = ir_; \
+               ic_ = ir_; 
       #ifdef BETA0
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
                rc_ = rw_; ic_ = iw_;\
-            }\
+            }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                rc_ = rw_; ic_ = -iw_;\
-            }\
+            }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #elif defined(BETA1)
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
                rc_ += rw_; ic_ += iw_;\
-            }\
+            }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                rc_ += rw_; ic_ -= -iw_;\
-            }\
+            }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #elif defined(BETAN) || defined(BETAN1)
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
                rc_ = rw_ - rc_; ic_ = iw_ - ic;\
-            }\
+            }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                rc_ = rw_ - rc_; ic_ = -iw_ - ic;\
-            }\
+            }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #else /* BETAX */
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
-            {\ 
+            {\
                const register TYPE rc=rc_, ic=ic_; \
                register TYPE rr=rw_, ir=iw_ \
                multBeta(rr, ir, rb, ib, rc_, ic_) \
-            }\
+            }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-            {\ 
+            {\
                const register TYPE rc=rc_, ic=ic_; \
                register TYPE rr=rw_, ir=-iw_ \
                multBeta(rr, ir, rb, ib, rc_, ic_) \
-            }\
+            }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #endif
    #elif defined(ALPHAN)
@@ -1994,61 +1994,61 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
                rc_ = -rw_; ic_ = -iw_;\
-            }\
+            }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                rc_ = -rw_; ic_ = iw_;\
-            }\
+            }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #elif defined(BETA1)
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
                rc_ -= rw_; ic_ -= iw_;\
-            }\
+            }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                rc_ -= rw_; ic_ += iw_;\
-            }\
+            }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #elif defined(BETAN) || defined(BETAN1)
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
                rc_ = -rw_ - rc_; ic_ = -iw_ - ic;\
-            }\
+            }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                rc_ = -rw_ - rc_; ic_ = iw_ - ic;\
-            }\
+            }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #else /* BETAX */
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
-            {\ 
+            {\
                const register TYPE rc=rc_, ic=ic_; \
                register TYPE rr=-rw_, ir=-iw_ \
                multBeta(rr, ir, rb, ib, rc_, ic_) \
-            } \
+            } 
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-            {\ 
+            {\
                const register TYPE rc=rc_, ic=ic_; \
                register TYPE rr=-rw_, ir=iw_ \
                multBeta(rr, ir, rb, ib, rc_, ic_) \
-            } \
+            } 
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #endif
    #elif defined(ALPHAX)
@@ -2058,60 +2058,60 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
                rr_ -= ic_ * ia_; \
                ir_ += rc_ * ia_; \
                rc_ = rr_; \
-               ic_ = ir_; \
+               ic_ = ir_; 
       #ifdef BETA0
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
-            {\ 
+            {\
                const register TYPE rc=rw_, ic=iw_; \
                register TYPE rr, ir; \
                multAlpha(rr, ir, ra, ia, rc_, ic_); \
-            }\
+            }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-            {\ 
+            {\
                const register TYPE rc=rw_, ic=-iw_; \
                register TYPE rr, ir; \
                multAlpha(rr, ir, ra, ia, rc_, ic_); \
-            }\
+            }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #elif defined(BETA1)
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
-            {\ 
+            {\
                const register TYPE rc=rw_, ic=iw_; \
                register TYPE rr=rc_, ir=ic_; \
                multAlpha(rr, ir, ra, ia, rc_, ic_); \
-            }\
+            }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-            {\ 
+            {\
                const register TYPE rc=rw_, ic=-iw_; \
                register TYPE rr=rc_, ir=ic_; \
                multAlpha(rr, ir, ra, ia, rc_, ic_); \
-            }\
+            }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #elif defined(BETAN) || defined(BETAN1)
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
-            {\ 
+            {\
                const register TYPE rc=rw_, ic=iw_; \
                register TYPE rr = -rc_, ir = -ic_; \
                multAlpha(rr, ir, ra, ia, rc_, ic_); \
-            }\
+            }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-            {\ 
+            {\
                const register TYPE rc=rw_, ic=-iw_; \
                register TYPE rr = -rc_, ir = -ic_; \
                multAlpha(rr, ir, ra, ia, rc_, ic_); \
-            }\
+            }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
       #else /* BETAX */
          #define multAlphaBeta(r0_,r1_,i0_,i1_,ra_,ia_,rb_,ib_,rB_,iB_,rc_,ic_)\
@@ -2124,24 +2124,25 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
                r1_ -= ia_ * iB_; \
                i1_ += ia_ * rB_; \
                rc_ = r0_ + r1_; \
-               ic_ = i0_ + i1_; \
+               ic_ = i0_ + i1_; 
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
                register TYPE rc=rc_, ic=ic_; \
                register TYPE rB=rw_, iB=iw_, r0, i0, r1, i1; \
                multAlphaBeta(r0, r1, i0, i1, ra, ia, rb, ib, rB, iB, rc_, ic_)\
-            }\
+            }
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                register TYPE rc=rc_, ic=ic_; \
                register TYPE rB=rw_, iB=-iw_, r0, i0, r1, i1; \
                multAlphaBeta(r0, r1, i0, i1, ra, ia, rb, ib, rB, iB, rc_, ic_)\
-            }\
+            }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
-               applyAlpBet(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
+      #endif
    #endif
 #else
    #define applyAlpBet_L2UT(c_,w_) applyAlpBet(c_, w_)
@@ -2290,7 +2291,7 @@ void amL2skLNB
                   #endif 
                }
             }
-            #ifdef TPCLX
+            #ifdef TCPLX
                pi += MU;
             #endif
          }
@@ -2321,7 +2322,10 @@ void amL2skLNB
          TYPE *c = C + (i SHIFT);
          mu = (mu >= MU) ? MU : mu;
          in = i + mu;
-         for (jj=0; jj < nu; jj++, c += ldc, w += MU)
+/*
+ *       copying a full subblock 
+ */
+         for (jj=0; jj < nu; jj++, c += (ldc SHIFT), pr += MU)
          {
             for (ii=0; ii < mu; ii++)
             {
@@ -2332,6 +2336,9 @@ void amL2skLNB
                   applyAlpBet(c[kk], pr[ii]);
                #endif 
             }
+            #ifdef TCPLX
+               pi += MU;
+            #endif
          }
          nblks = (in-1+NU) / NU;  /* # of row blocks in this panel */
          rwpan = nblks*blksz;
@@ -2410,10 +2417,10 @@ void amL2skLNB_L2UT
                #endif 
             }
             #ifdef TCPLX
-               iw0++
+               iw0++;
             #endif
          }
-         #ifdef
+         #ifdef TCPLX
             iC += incW;
          #endif
       }
@@ -2454,10 +2461,10 @@ void amL2skLNB_L2UT
                #endif
             }
             #ifdef TCPLX
-               iw0++
+               iw0++;
             #endif
          }
-         #ifdef
+         #ifdef TCPLX
             iC += incW;
          #endif
       }

--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -1894,7 +1894,6 @@ void amL2skLNB(ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL,
  *    crossing should happen at (jn-1,jn-1)
  */
       rw = rW;
-      in = i + MU;
 /*
  *    NOTE: 
  *    diagonal intersecting a block can be represented as following graph 
@@ -1975,7 +1974,7 @@ void amL2skLNB_L2UT(ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL,
  *                       => j > i+nu-1
  *    access of C-workspace is consecutive
  */
-      for (i=0; j < i+nu-1; i=in, W += incW )
+      for (i=0; j > i+nu-1; i=in, W += incW )
       {
          const TYPE *w0 = W;
          ATL_UINT ii, jj;

--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -2343,7 +2343,7 @@ void ATL_amL2skLNB
 #endif
    const SCALAR beta, 
    TYPE *C, 
-   ATL_iptr_t ldc
+   const ATL_iptr_t ldc
 )
 {
 #if 0
@@ -2532,7 +2532,7 @@ void ATL_amL2skLNB_L2UT
 #endif
    const SCALAR beta, 
    TYPE *C, 
-   ATL_iptr_t ldc
+   const ATL_iptr_t ldc
 )
 {
    ATL_CUINT incW = ((MU*NU+(1<<shVL)-1)>>shVL)<<shVL;

--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -1836,8 +1836,22 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
       #define applyAlpBet(c_, w_) c_ = applyAlpha(w_) + beta*(c_)
    #endif
 #endif
-void amL2skLNB(ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL, 
-               const TYPE *W, const SCALAR beta, TYPE *C, ATL_iptr_t ldc)
+
+void amL2skLNB
+( 
+   ATL_iptr_t N, 
+   ATL_CUINT MU, 
+   ATL_CUINT NU, 
+   ATL_CUINT shVL, 
+   const SCALAR alpha, 
+   const TYPE *rC, 
+#ifdef TCPLX
+   const TYPE *iC, 
+#endif
+   const SCALAR beta, 
+   TYPE *C, 
+   ATL_iptr_t ldc
+)
 {
 #if 0
    ATL_CUINT incW = ((MU*NU+(1<<shVL)-1)>>shVL)<<shVL;
@@ -1880,9 +1894,15 @@ void amL2skLNB(ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL,
    }
 #else
    ATL_CUINT blksz = ((MU*NU+(1<<shVL)-1)>>shVL)<<shVL;
-   ATL_UINT j, jn, cinc;
-   const TYPE *rW=W, *rw;
-   const ATL_iptr_t incC = ldc*NU;
+   ATL_UINT j, jn, cinc, rwpan;
+   const TYPE *rW=rC, *rw;
+   #ifdef TCPLX 
+   const TYPE *iW=iC, *iw;
+   #endif
+   const ATL_iptr_t LDC = (ldc SHIFT);
+   const ATL_iptr_t incC = LDC*NU;
+
+
    for (cinc=j=0; j < N; j = jn, C += incC, cinc += blksz)
    {
       ATL_UINT i, in, nu = N-j, nd;
@@ -1894,6 +1914,9 @@ void amL2skLNB(ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL,
  *    crossing should happen at (jn-1,jn-1)
  */
       rw = rW;
+      #ifdef TCPLX 
+         iw = iW;
+      #endif
 /*
  *    NOTE: 
  *    diagonal intersecting a block can be represented as following graph 
@@ -1911,26 +1934,48 @@ void amL2skLNB(ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL,
       for(; i < jn ; i = in)
       {
          ATL_UINT mu=N-i, ii, jj, nblks;
-         const TYPE *w = rw + cinc;
-         TYPE *c = C + i;
+         const TYPE *pr = rw + cinc;
+         #ifdef TCPLX
+            const TYPE *pi = iw + cinc;
+         #endif
+         TYPE *c = C + (i SHIFT);
          mu = (mu >= MU) ? MU : mu;
          in = i + mu;
-         for (jj=0; jj < nu; jj++, c += ldc, w += MU)
+/*
+ *       copying subblock with diagonal 
+ */
+         for (jj=0; jj < nu; jj++, c += LDC, pr += MU)
          {
             ATL_CUINT J=j+jj;
             for (ii=0; ii < mu; ii++)
             {
                ATL_CUINT I=i+ii;
                if (I >= J)
-                  applyAlpBet(c[ii], w[ii]);
+               {
+                  ATL_CUINT kk = (ii SHIFT);
+                  applyAlpBet(c[kk], pr[ii]);
+                  #ifdef TCPLX
+                     applyAlpBet(c[kk+1], pi[ii]);
+                  #endif 
+               }
             }
+            #ifdef TPCLX
+               pi += MU;
+            #endif
          }
          nblks = (in-1+NU) / NU;  /* # of row blocks in this panel */
-         rw += nblks*blksz; /* finished all blocks in rowpanel */
+         rwpan = nblks*blksz;
+         rw += rwpan; /* finished all blocks in rowpanel */
+         #ifdef TCPLX
+            iw += rwpan; /* finished all blocks in rowpanel */
+         #endif
 /*
  *       Diagonal blocks may finish rows, if so increment rW
  */
          rW = (in <= jn) ? rw : rW;
+         #ifdef TCPLX
+            iW = (in <= jn) ? iw : iW;
+         #endif
       }
 /*
  *    Diagonal above any remaining blocks
@@ -1938,15 +1983,30 @@ void amL2skLNB(ATL_iptr_t N, ATL_CUINT MU, ATL_CUINT NU, ATL_CUINT shVL,
       for (; i < N; i = in)
       {
          ATL_UINT mu=N-i, ii, jj, nblks;
-         const TYPE *w = rw + cinc;
-         TYPE *c = C + i;
+         const TYPE *pr = rw + cinc;
+         #ifdef TCPLX
+            const TYPE *pi = iw + cinc;
+         #endif
+         TYPE *c = C + (i SHIFT);
          mu = (mu >= MU) ? MU : mu;
          in = i + mu;
          for (jj=0; jj < nu; jj++, c += ldc, w += MU)
+         {
             for (ii=0; ii < mu; ii++)
-               applyAlpBet(c[ii], w[ii]);
+            {
+               ATL_CUINT kk = (ii SHIFT);
+               applyAlpBet(c[kk], pr[ii]);
+               #ifdef TCPLX
+                  applyAlpBet(c[kk+1], pi[ii]);
+               #endif
+            }
+         }
          nblks = (in-1+NU) / NU;  /* # of row blocks in this panel */
-         rw += nblks*blksz;
+         rwpan = nblks*blksz;
+         rw += rwpan;
+         #ifdef TCPLX
+            iw += rwpan;
+         #endif
       }
    }
 #endif

--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -2026,7 +2026,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
          #ifdef Conj_
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
-               rc_ = rw_ - rc_; ic_ = -iw_ - ic;\
+               rc_ = rw_ - rc_; ic_ = -iw_ - ic_;\
             }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
@@ -2057,7 +2057,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                const register TYPE rc=rc_, ic=ic_; \
-               register TYPE rr=rw_, ir=-iw_ \
+               register TYPE rr=rw_, ir=-iw_; \
                multX(rr, ir, rb, ib, rc, ic, rc_, ic_) \
             }
          #else

--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -1816,7 +1816,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
          #define ATL_amL2skLNB_L2UT \
                   Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arb0),_L2UT)
       #endif
-   #else
+   #else /* ALPHAX */
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXb0)
          #define ATL_amL2skLNB_L2UT \
@@ -1858,7 +1858,7 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
          #define ATL_amL2skLNB_L2UT \
                   Mjoin(Mjoin(Mjoin(PATL,amL2skLNB),_arbN),_L2UT)
       #endif
-   #else
+   #else /* ALPHAX */
       #ifdef Conj_
          #define ATL_amL2skLNB Mjoin(Mjoin(PATL,amL2hkLNB),_aXbN)
          #define ATL_amL2skLNB_L2UT \
@@ -2032,6 +2032,20 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
                applyAlpBet(rc_, rw_, ic_, iw_) 
          #endif
+      #elif defined(BETAR)
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = rw_ + rb * rc_; ic_ = iw_ + rb * ic_;\
+            }
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = rw_ + rb * rc_; ic_ = -iw_ + rb * ic_;\
+            }
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
+         #endif
       #else /* BETAX */
          #define applyAlpBet(rc_, rw_, ic_, iw_) \
             {\
@@ -2089,6 +2103,96 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
             {\
                rc_ = -rw_ - rc_; ic_ = iw_ - ic_;\
+            }
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
+         #endif
+      #elif defined(BETAR) 
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = -rw_ + rb * rc_; ic_ = -iw_ + rb * ic_;\
+            }
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = -rw_ + rb * rc_; ic_ = iw_ + rb * ic_;\
+            }
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
+         #endif
+      #else /* BETAX */
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               const register TYPE rc=rc_, ic=ic_; \
+               register TYPE rr=-rw_, ir=-iw_; \
+               multX(rr, ir, rb, ib, rc, ic, rc_, ic_) \
+            } 
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               const register TYPE rc=rc_, ic=ic_; \
+               register TYPE rr=-rw_, ir=iw_; \
+               multX(rr, ir, rb, ib, rc, ic, rc_, ic_) \
+            } 
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
+         #endif
+      #endif
+   #elif defined(ALPHAR)
+      #ifdef BETA0
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = ra * rw_; ic_ = ra * iw_;\
+            }
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = ra * rw_; ic_ = -ra * iw_;\
+            }
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
+         #endif
+      #elif defined(BETA1)
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ += (ra * rw_); ic_ += (ra * iw_);\
+            }
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ += (ra * rw_); ic_ -= (ra * iw_);\
+            }
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
+         #endif
+      #elif defined(BETAN) || defined(BETAN1)
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = ra * rw_ - rc_; ic_ = ra * iw_ - ic_;\
+            }
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = ra * rw_ - rc_; ic_ = -ra * iw_ - ic_;\
+            }
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
+         #endif
+      #elif defined(BETAR) 
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = ra * rw_ + rb * rc_; ic_ = ra * iw_ + rb * ic_;\
+            }
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               rc_ = ra * rw_ + rb * rc_; ic_ = -ra * iw_ + rb * ic_;\
             }
          #else
             #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
@@ -2162,6 +2266,24 @@ void Mjoin(Mjoin(PATL,geput1T),BEN)
             {\
                const register TYPE rc=rw_, ic=-iw_; \
                register TYPE rr = -rc_, ir = -ic_; \
+               multX(rr, ir, ra, ia, rc, ic, rc_, ic_); \
+            }
+         #else
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+               applyAlpBet(rc_, rw_, ic_, iw_) 
+         #endif
+      #elif defined(BETAR)
+         #define applyAlpBet(rc_, rw_, ic_, iw_) \
+            {\
+               const register TYPE rc=rw_, ic=iw_; \
+               register TYPE rr = rb * rc_, ir = rb * ic_; \
+               multX(rr, ir, ra, ia, rc, ic, rc_, ic_); \
+            }
+         #ifdef Conj_
+            #define applyAlpBet_L2UT(rc_, rw_, ic_, iw_) \
+            {\
+               const register TYPE rc=rw_, ic=-iw_; \
+               register TYPE rr = rb * rc_, ir = rb * ic_; \
                multX(rr, ir, ra, ia, rc, ic, rc_, ic_); \
             }
          #else

--- a/AtlasBase/Clint/atlas-make.base
+++ b/AtlasBase/Clint/atlas-make.base
@@ -3237,10 +3237,10 @@ res/@(pr)trmm@(sd)@(tr).sum : res/@(pr)trmmK@(sd)@(tr).sum xtrmmview
    @endwhile
 @endwhile
 res/@(pre)AMSYRKFNL.sum : res/@(pre)gAMSYRK.sum res/@(cpr)gAMSYRK.sum \
-                     res/@(pre)ipsyrkUM.sum res/@(cpr)ipsyrkUM.sum
+                     res/@(pre)ipsyrk.sum res/@(cpr)ipsyrk.sum
 	- rm -f res/@(pre)AMSYRKFNL.sum
 	cat res/[@(pre),@(cpr)]gAMSYRK.sum > res/@(pre)AMSYRKFNL.sum
-	cat res/[@(pre),@(cpr)]ipsyrkUM.sum >> res/@(pre)AMSYRKFNL.sum
+	cat res/[@(pre),@(cpr)]ipsyrk.sum >> res/@(pre)AMSYRKFNL.sum
 @(pre)install_amm: xammkgen xbfisrch res/@(upr)FNLK1.sum force_build \
    res/@(pre)AMSYRKFNL.sum res/@(pre)trsmL_LN.sum res/@(pre)trsmL_LT.sum \
    res/@(pre)trsmR_LN.sum res/@(pre)trsmR_LT.sum \

--- a/AtlasBase/Clint/atlas-make.base
+++ b/AtlasBase/Clint/atlas-make.base
@@ -478,7 +478,7 @@ clean : sclean dclean cclean zclean
    ATL_@(pre)trmm.o ATL_@(pre)iptrmmL.o ATL_@(pre)iptrmmR.o 
    ATL_@(pre)trmmL_alloc.o ATL_@(pre)trmmR_alloc.o 
    ATL_@(pre)syrk.o ATL_@(pre)opsyrk.o ATL_@(pre)ipsyrk.o
-   ATL_@(pre)sqsyrk.o ATL_@(pre)umsyrk.o
+   ATL_@(pre)sqsyrk.o ATL_@(pre)ursyrk.o
    ATL_@(pre)syr2k.o ATL_@(pre)opsyr2k.o ATL_@(pre)ipsyr2k.o 
    ATL_@(pre)symmL.o ATL_@(pre)symmR.o ATL_@(pre)ipsymmL.o ATL_@(pre)ipsymmR.o
 @SKIP   ATL_@(pre)ipsymmL_tN.o ATL_@(pre)ipsymmR_tM.o
@@ -489,7 +489,7 @@ clean : sclean dclean cclean zclean
       ATL_@(pre)heLL2ipBlk.o ATL_@(pre)heLU2ipBlk.o
       ATL_@(pre)heRL2ipBlk.o ATL_@(pre)heRU2ipBlk.o
       ATL_@(pre)herk.o ATL_@(pre)opherk.o ATL_@(pre)ipherk.o 
-      ATL_@(pre)sqherk.o ATL_@(pre)umherk.o 
+      ATL_@(pre)sqherk.o ATL_@(pre)urherk.o 
       ATL_@(pre)her2k.o ATL_@(pre)opher2k.o ATL_@(pre)ipher2k.o
       ATL_@(pre)tminfoL_LC.o ATL_@(pre)tminfoL_UC.o
       ATL_@(pre)tminfoR_LC.o ATL_@(pre)tminfoR_UC.o
@@ -526,7 +526,7 @@ clean : sclean dclean cclean zclean
 @SKIP ipsymmL_tN ipsymmR_tM
 @multidef rt ipsyGetCopyA ipsyGetCopyB
 @multidef rt ipsymmR ipsymmL syLL2ipBlk syLU2ipBlk syRL2ipBlk syRU2ipBlk
-@whiledef rt syr2k ipsyr2k opsyr2k syrk sqsyrk umsyrk opsyrk ipsyrk symmL symmR
+@whiledef rt syr2k ipsyr2k opsyr2k syrk sqsyrk ursyrk opsyrk ipsyrk symmL symmR
 ATL_@(pre)@(rt).o : $(mySRCdir)/ATL_@(rt).c $(@(pre)u3dep)
 	$(@up@(pre)KC) $(@(pre)KCFLAGS) -D@(typ)=1 \
            -c -o $@ $(mySRCdir)/ATL_@(rt).c
@@ -537,8 +537,8 @@ ATL_@(pre)@(rt).o : $(mySRCdir)/ATL_@(rt).c $(@(pre)u3dep)
 	$(@up@(pre)KC) $(@(pre)KCFLAGS) -D@(typ)=1 \
            -c -o $@ $(mySRCdir)/ATL_@(rt).c
 @endwhile
-   @multidef r2 syr2k opsyr2k ipsyr2k syrk sqsyrk umsyrk opsyrk ipsyrk symmL symmR
-   @whiledef rt her2k opher2k ipher2k herk sqherk umherk opherk ipherk hemmL hemmR
+   @multidef r2 syr2k opsyr2k ipsyr2k syrk sqsyrk ursyrk opsyrk ipsyrk symmL symmR
+   @whiledef rt her2k opher2k ipher2k herk sqherk urherk opherk ipherk hemmL hemmR
 ATL_@(pre)@(rt).o : $(mySRCdir)/ATL_@(r2).c $(@(pre)u3dep)
 	$(@up@(pre)KC) $(@(pre)KCFLAGS) -D@(typ)=1 -DConj_=1 \
            -c -o $@ $(mySRCdir)/ATL_@(r2).c
@@ -9191,7 +9191,7 @@ ATL_@(pre)@(rt).o : $(@(pre)INCdep) $(mySRCdir)/ATL_@(rt).c \
 @whiledef rt ipsyrkinfo opsyrkInfo
 ATL_@(pre)@(rt).o : $(@(pre)INCdep) $(mySRCdir)/ATL_@(rt).c \
    $(INCAdir)/atlas_@(pre)amm_sum.h $(INCAdir)/atlas_@(pre)syrk_view.h \
-   $(INCAdir)/atlas_@(pre)amm_sqsyrk.h $(INCAdir)/atlas_@(pre)amm_umsyrk.h 
+   $(INCAdir)/atlas_@(pre)amm_sqsyrk.h $(INCAdir)/atlas_@(pre)amm_ursyrk.h 
 	$(@(UPR)KC) -D@(typ)=1 -o $@ -c $(@(pre)KCFLAGS) $(mySRCdir)/ATL_@(rt).c
 @endwhile
 @multidef rt oploops iploops ammm_tN ammm_1b
@@ -9223,7 +9223,7 @@ ATL_@(pre)trsm_ammLL.o : $(@(pre)INCdep) $(mySRCdir)/ATL_trsm_ammLL.c
    @whiledef rt ipherkinfo
 ATL_@(pre)@(rt).o : $(@(pre)INCdep) $(mySRCdir)/ATL_@(rt2).c \
    $(INCAdir)/atlas_@(pre)amm_sum.h $(INCAdir)/atlas_@(pre)syrk_view.h \
-   $(INCAdir)/atlas_@(pre)amm_sqsyrk.h $(INCAdir)/atlas_@(pre)amm_umsyrk.h 
+   $(INCAdir)/atlas_@(pre)amm_sqsyrk.h $(INCAdir)/atlas_@(pre)amm_ursyrk.h 
 	$(@(UPR)KC) -D@(typ)=1 -DConj_=1 -o $@ -c $(@(pre)KCFLAGS) $(mySRCdir)/ATL_@(rt2).c
       @undef rt2
    @endwhile

--- a/AtlasBase/Clint/atlas-maux.base
+++ b/AtlasBase/Clint/atlas-maux.base
@@ -22,11 +22,6 @@ ptobj = ATL_ptflushcache.o ATL_NumaTouchSpread.o
       @multidef rout trsetU trsetL geset gemaxnrm
       @multidef rout syApAt syApAt_NB geApBt_NB sqtrans geswapT
       @multidef rout axpby trcollapse gecollapse
-      @whiledef al 1 N X
-         @whiledef be 0 1 N X
-            @define rout @amL2skLNB_a@(al)b@(be)@
-         @endwhile
-      @endwhile
       @multidef rout geput1T_b0 geput1T_b1 geput1T_bN geput1T_bX
       @multidef rout sycpyLNB_a1 sycpyLNB_an sycpyLNB_aX
       @multidef rout sycpyUNB_a1 sycpyUNB_an sycpyUNB_aX
@@ -36,11 +31,11 @@ ptobj = ATL_ptflushcache.o ATL_NumaTouchSpread.o
       @endwhile
    @endwhile
    @whiledef pre z c
-      @whiledef al 1 N R X
-         @define rout @amL2skLNB_a@(al)bR@
-      @endwhile
-      @whiledef be 0 1 N R X
-         @define rout @amL2skLNB_aRb@(be)@
+      @whiledef al 1 N r X
+         @whiledef be 0 1 N r X
+            ATL_@(pre)amL2skLNB_a@(al)b@(be).o
+            ATL_@(pre)amL2hkLNB_a@(al)b@(be).o
+         @endwhile
       @endwhile
       @multidef rout hecpyUNB_a1 hecpyUNB_an hecpyUNB_aX hecpyUNB_ar sycpyUNB_ar
       @multidef rout hecpyLNB_a1 hecpyLNB_an hecpyLNB_aX hecpyLNB_ar sycpyLNB_ar
@@ -67,6 +62,11 @@ ptobj = ATL_ptflushcache.o ATL_NumaTouchSpread.o
       @endwhile
    @endwhile
    @whiledef pre d s
+      @whiledef al 1 N X
+         @whiledef be 0 1 N X
+            ATL_@(pre)amL2skLNB_a@(al)b@(be).o
+         @endwhile
+      @endwhile
       ATL_@(pre)trcpypad4L.o ATL_@(pre)trcpypad4U.o
       @whiledef al a0 a1 aX
          @whiledef rout gemove
@@ -221,15 +221,6 @@ ATL_@(pre)@(rout)_a@(al)_b@(be).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_@(rou
          @endwhile
       @endwhile
    @endwhile
-   @whiledef be 0 1 R N X 
-      @whiledef al 0 1 R N  X 
-         @whiledef rout amL2skLNB
-ATL_@(pre)@(rout)_a@(al)b@(be).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_@(rout).c
-	@(KC) $(NM) $@ $(OJ) @(KF) -D@(typ) -DALPHA@up@(al) \
-              -DBETA@up@(be) $(mySRCdir)/kernel/ATL_@(rout).c
-         @endwhile
-      @endwhile
-   @endwhile
 
 #
 #  Routines with beta dependencies only
@@ -290,6 +281,22 @@ ATL_@(pre)@(rout).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_@(rout).c
    @endwhile
 @endwhile
 #
+# routines handled differently when coming in real 
+#
+@multidef typ DREAL SREAL
+@whiledef pre d s
+   @whiledef be 0 1 N X 
+      @whiledef al 0 1 N X 
+         @whiledef rout amL2skLNB
+ATL_@(pre)@(rout)_a@(al)b@(be).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_@(rout).c
+	$(@up@(pre)KC) $(NM) $@ $(OJ) $(CDEFS) $(@up@(pre)KCFLAGS) -D@(typ) \
+            -DALPHA@up@(al) -DBETA@up@(be) $(mySRCdir)/kernel/ATL_@(rout).c
+         @endwhile
+      @endwhile
+   @endwhile
+   @undef typ 
+@endwhile
+#
 # routines coming only in complex types
 #
 @multidef UPR D S
@@ -333,6 +340,15 @@ ATL_@(pre)@(rout)Conj_a@(al)_b@(be).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_@
          @endwhile
       @endwhile
    @endwhile
+   @whiledef be 0 1 r N X 
+      @whiledef al 1 r N  X 
+         @whiledef rout amL2skLNB
+ATL_@(pre)@(rout)_a@(al)b@(be).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_@(rout).c
+	@(KC) $(NM) $@ $(OJ) @(KCFLAGS) -D@(typ) -DALPHA@up@(al) \
+              -DBETA@up@(be) $(mySRCdir)/kernel/ATL_@(rout).c
+         @endwhile
+      @endwhile
+   @endwhile
 #
 # Routines with beta and Conj_ Dependencies
 #
@@ -341,6 +357,20 @@ ATL_@(pre)geput1H_b@(be).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_geput1T.c
 	@(KC) $(NM) $@ $(OJ) @(KCFLAGS) -D@(typ) -DBETA@up@(be)=1 -DConj_=1 \
               $(mySRCdir)/kernel/ATL_geput1T.c
    @endwhile
+#
+#  Routines with alpha, beta and Conj
+#
+   @define rt @amL2hkLNB@
+   @define crt @amL2skLNB@
+   @whiledef be 0 1 r N X 
+      @whiledef al 0 1 r N  X 
+ATL_@(pre)@(rt)_a@(al)b@(be).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_@(crt).c
+	@(KC) $(NM) $@ $(OJ) @(KCFLAGS) -D@(typ) -DALPHA@up@(al) \
+              -DBETA@up@(be) -DConj_=1 $(mySRCdir)/kernel/ATL_@(crt).c
+      @endwhile
+   @endwhile
+   @undef rt
+   @undef crt
 
    @undef typ
    @undef UPR

--- a/AtlasBase/Clint/atlas-maux.base
+++ b/AtlasBase/Clint/atlas-maux.base
@@ -22,7 +22,11 @@ ptobj = ATL_ptflushcache.o ATL_NumaTouchSpread.o
       @multidef rout trsetU trsetL geset gemaxnrm
       @multidef rout syApAt syApAt_NB geApBt_NB sqtrans geswapT
       @multidef rout axpby trcollapse gecollapse
-      @multidef rout amL2skLNB_b0 amL2skLNB_b1 amL2skLNB_bN amL2skLNB_bX
+      @whiledef al 1 N X
+         @whiledef be 0 1 N X
+            @define rout @amL2skLNB_a@(al)b@(be)@
+         @endwhile
+      @endwhile
       @multidef rout geput1T_b0 geput1T_b1 geput1T_bN geput1T_bX
       @multidef rout sycpyLNB_a1 sycpyLNB_an sycpyLNB_aX
       @multidef rout sycpyUNB_a1 sycpyUNB_an sycpyUNB_aX
@@ -32,6 +36,12 @@ ptobj = ATL_ptflushcache.o ATL_NumaTouchSpread.o
       @endwhile
    @endwhile
    @whiledef pre z c
+      @whiledef al 1 N R X
+         @define rout @amL2skLNB_a@(al)bR@
+      @endwhile
+      @whiledef be 0 1 N R X
+         @define rout @amL2skLNB_aRb@(be)@
+      @endwhile
       @multidef rout hecpyUNB_a1 hecpyUNB_an hecpyUNB_aX hecpyUNB_ar sycpyUNB_ar
       @multidef rout hecpyLNB_a1 hecpyLNB_an hecpyLNB_aX hecpyLNB_ar sycpyLNB_ar
       @multidef rout geput1H_b0 geput1H_b1 geput1H_bN geput1H_bX
@@ -211,6 +221,15 @@ ATL_@(pre)@(rout)_a@(al)_b@(be).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_@(rou
          @endwhile
       @endwhile
    @endwhile
+   @whiledef be 0 1 R N X 
+      @whiledef al 0 1 R N  X 
+         @whiledef rout amL2skLNB
+ATL_@(pre)@(rout)_a@(al)b@(be).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_@(rout).c
+	@(KC) $(NM) $@ $(OJ) @(KF) -D@(typ) -DALPHA@up@(al) \
+              -DBETA@up@(be) $(mySRCdir)/kernel/ATL_@(rout).c
+         @endwhile
+      @endwhile
+   @endwhile
 
 #
 #  Routines with beta dependencies only
@@ -223,7 +242,7 @@ ATL_@(pre)@(rout)_b@(be).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_@(rout).c
       @endwhile
    @endwhile
    @whiledef be 0 1 N X
-      @whiledef rout geput1T amL2skLNB
+      @whiledef rout geput1T
 ATL_@(pre)@(rout)_b@(be).o : $(@(pre)INCdep) $(mySRCdir)/kernel/ATL_@(rout).c
 	@(KC) $(NM) $@ $(OJ) @(KF) -D@(typ) -DBETA@up@(be)=1 \
               $(mySRCdir)/kernel/ATL_@(rout).c

--- a/AtlasBase/Clint/atlas-parse.base
+++ b/AtlasBase/Clint/atlas-parse.base
@@ -3426,7 +3426,7 @@ int SprintMMName(char *name, char pre, char *nm, ATL_mmnode_t *mp, int kb)
       if (mp->mu == mp->nu && !FLAG_IS_SET(mp->flag, MMF_RIGHT))
          strcpy(name, "ATL_XsqsyrkK");
       else
-         strcpy(name, "ATL_XumsyrkK");
+         strcpy(name, "ATL_XursyrkK"); /* umsyrk is converted into ursyrk */
       name[4] = pre;
       return(12);
    }

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -2528,8 +2528,8 @@ int syrk_amm
  *          && ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(ipmen.idxK) == ATL_URSYRK_KVEC 
  */
       Mjoin(PATL,ipmenInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta);
-      if (ipmen.mu == ATL_URSYRK_MU && ipmen.nu == ATL_URSYRK_NU 
-            && ipmen.ku == ATL_URSYRK_KU)
+      if (ipmen.mu == ATL_URSYRKK_MU && ipmen.nu == ATL_URSYRKK_NU 
+            && ipmen.ku == ATL_URSYRKK_KU)
       #ifdef Conj_
          ierr = ursyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
       #else

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -3485,15 +3485,11 @@ int opsyrk
            op.pmb, op.pnb, op.kb);
    #endif
 /*
- * apply ursyrk when possible
- * FIXME: opinfo_t doesn't have idxK to point the kernel. How can we verify
- * whether the mdim of the gemm kernel is match with syrk? MVEC kernel may have 
- * KU > 1 (and match with KVEC) for the unrolling! If we have idxK in opinfo_t,
- * we can add following test to make sure mdim matched as well: 
- * ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(op.idxK)) == ATL_URSYRKK_KVEC
+ * apply ursyrk when gemm and syrk can share copies 
  */
    if (op.mu == ATL_URSYRKK_MU && op.nu == ATL_URSYRKK_NU 
-         && op.ku ==ATL_URSYRKK_KU && op.vlen == ATL_URSYRKK_VLEN)
+         && op.ku ==ATL_URSYRKK_KU && op.vlen == ATL_URSYRKK_VLEN 
+         && ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(op.idxK)) == ATL_URSYRKK_KVEC )
       ierr = opursyrk(&op, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
    else
       ierr = opsqsyrk(&op, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -1659,7 +1659,7 @@ int syrk
    free(vp);
    return(0);
 }
-@ROUT ATL_umsyrk
+@ROUT ATL_umsyrk ATL_ursyrk
 @extract -b @(topd)/cw.inc lang=C -def cwdate 2016
 #define ATL_GLOBIDX 1
 #include "atlas_misc.h"
@@ -1669,558 +1669,6 @@ int syrk
 #include Mstr(Mjoin(ATLAS_PRE,sysinfo.h))
 #include Mstr(Mjoin(ATLAS_PRE,opgen_view.h))
 #include Mstr(Mjoin(ATLAS_PRE,amm_umsyrk.h))
-/*
- * Service routine, particularly for parallel.  Takes its blocking from ip
- * (assuming that is what is being used below diagonal blocks
- * flag bits, meaning if set (opposite if unset):
- * 0/1: C is upper
- * 1/2: TA == AtlasNoTrans
- * 2/4: use beta=0 syrk kernel (else use beta=1)
- *
- * If (Uplo==Upper && sy2blk)
- *    (1) flag&1 == 1; (2) wU non-NULL; (3) sy2blk is beta=0.
- * ==> wU can be aliased wt wS if you don't need correct wS on output
- */
-#ifdef Conj_
-   #define syrkBlk Mjoin(PATL,umherkBlk)
-   #define syrk_K  Mjoin(PATL,umherk_KLoop)
-   #define syrk  Mjoin(PATL,umherk)
-#else
-   #define syrkBlk Mjoin(PATL,umsyrkBlk)
-   #define syrk_K  Mjoin(PATL,umsyrk_KLoop)
-   #define syrk  Mjoin(PATL,umsyrk)
-#endif
-/*#define MEM_DEBUG 1*/
-
-void syrkBlk
-(
-   ipinfo_t *ip,
-   int flag,      /* bitvec: 0: set means C is upper, 1: set TA==AtlasNoTrans*/
-   size_t d,      /* which global diagonal blk of C is being computed */
-   size_t k,      /* which K block of A is being computed */
-   const TYPE *A, /* if non-NULL, base A ptr to copy */
-   const TYPE *B, /* if non-NULL, base A ptr to copy */
-   ablk2cmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
-   const SCALAR beta, /* only needed if blk2c non-NULL */
-   TYPE *C,       /* if blk2c && non-NULL, which C to write to */
-   TYPE *wA,      /* if non-NULL, ip-based A workspace */
-   TYPE *wAn,     /* next A wrkspc to be prefetched */
-   TYPE *wB,      /* if non-NULL ip-based At workspace */
-   TYPE *wBn,     /* next B wrkspc to be prefetched */
-   TYPE *rC,      /* real portion of wC (unused for real routines) */
-   TYPE *wC      /* if non-NULL: ptr to syrk-storage C wrkspc */
-)
-{
-   ATL_CUINT kb = (k != ip->nfkblks) ? ip->kb : ip->kb0;
-   ATL_UINT mb, nb, kbS, nnu, nmu;
-   size_t nfblks = ip->nfnblks;
-   #ifdef TCPLX
-      TYPE *rA, *rB;
-   #endif
-   if (d == nfblks + ip->npnblks - 1)
-   {
-      nb = ip->nF;
-      #ifdef TCPLX
-         if (d < nfblks)
-         {
-            rA = wA + ip->szA;
-            rB = wB + ip->szB;
-         }
-         else
-         {
-            rA = wA + ip->pszA;
-            rB = wB + ip->pszB;
-         }
-      #endif
-   }
-   else if (d < nfblks)
-   {
-      nb = ip->nb;
-      #ifdef TCPLX
-         rA = wA + ip->szA;
-         rB = wB + ip->szB;
-      #endif
-   }
-   else
-   {
-      nb = ip->pnb;
-      #ifdef TCPLX
-         rA = wA + ip->pszA;
-         rB = wB + ip->pszB;
-      #endif
-   }
-/*
- * calc nmu and nnu. one must be multiple of other
- */
-   if (ip->mu > ip->nu)
-   {
-      nmu = (nb+ip->mu-1)/ip->mu;
-      nnu = nmu * (ip->mu/ip->nu); /* NU must be multiple of MU */
-   }
-   else
-   {
-      nnu = (nb+ip->nu-1)/ip->nu;
-      nmu = nnu * (ip->nu/ip->mu); /* NU must be multiple of MU */
-   }
-   kbS = ((kb+ip->ku-1)/ip->ku)*ip->ku; /* same as KB0 */
-/*
- * copy A
- */
-   if (A)  /* want to copy input array */
-   {
-      A = IdxA_ip(ip, A, d, k);
-      #ifdef TCPLX
-         ip->a2blk(kb, nb, ip->alpA, A, ip->lda, rA, wA);
-      #else
-         ip->a2blk(kb, nb, ip->alpA, A, ip->lda, wA);
-      #endif
-   }
-   if (B)
-   {
-      B = IdxB_ip(ip, B, k, d);
-      #ifdef TCPLX
-         ip->b2blk(kb, nb, ip->alpB, B, ip->ldb, rB, wB);
-      #else
-         ip->b2blk(kb, nb, ip->alpB, B, ip->ldb, wB);
-      #endif
-   }
-   if (wC)  /* want to compute SYRK on this block into wC */
-   {
-      #ifdef TCPLX
-         if (flag&4)
-         {
-            Mjoin(PATL,amsyrkK_b0)(nmu, nnu, kbS, wA, wB, rC, rA, wB, wC);
-            Mjoin(PATL,amsyrkK_b0)(nmu, nnu, kbS, rA, wB, wC, rA, rB, rC);
-         }
-         else
-         {
-            Mjoin(PATL,amsyrkK_bn)(nmu, nnu, kbS, wA, wB, rC, rA, wB, wC);
-            Mjoin(PATL,amsyrkK_b1)(nmu, nnu, kbS, rA, wB, wC, rA, rB, rC);
-         }
-         Mjoin(PATL,amsyrkK_bn)(nmu, nnu, kbS, rA, rB, rC, wA, rB, wC);
-         Mjoin(PATL,amsyrkK_b1)(nmu, nnu, kbS, wA, rB, wC, wA, wB, wC);
-      #else
-         if (flag&4)
-            Mjoin(PATL,amsyrkK_b0)(nmu, nnu, kbS, wA, wB, wC, wA, wB, wC);
-         else
-            Mjoin(PATL,amsyrkK_b1)(nmu, nnu, kbS, wA, wB, wC, wA, wB, wC);
-      #endif
-   }
-   if (blk2c)
-   {
-      const size_t ldc=ip->ldc;
-      #ifdef TCPLX
-         const TYPE *alp = ip->alpC;
-      #else
-         TYPE alp = ip->alpC;
-      #endif
-      if (ip->alpA != ip->alpB)
-         alp = (ip->alpA != ip->alpC) ? ip->alpA : ip->alpB;
-      if (C)
-      {
-         C = IdxC_ip(ip, C, d, d);
-         #ifdef TCPLX
-            blk2c(nb, nb, alp, rC, wC, beta, C, ldc);
-            #ifdef Conj_  /* must zero complex part of diagonal! */
-               Mjoin(PATLU,zero)(nb, C+1, (ldc+1)SHIFT);
-            #endif
-         #else
-            blk2c(nb, nb, alp, wC, beta, C, ldc);
-         #endif
-      }
-   }
-}
-
-void syrk_K  /* inner-product based syrk/herk loop over K loop */
-(
-   ipinfo_t *ip,
-   int flag,      /* bitvec: 0: set means C is upper, 1: set TA==AtlasNoTrans*/
-   size_t d,      /* which global diagonal blk of C is being computed */
-   const TYPE *A, /* if non-NULL, base A ptr to copy */
-   const TYPE *B, /* if non-NULL, base B ptr to copy */
-   ablk2cmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
-   const SCALAR beta, /* only needed if blk2c non-NULL */
-   TYPE *C,       /* if blk2c non-NULL, which C to write to, else ignored */
-   TYPE *wA,      /* if non-NULL, ip-based A workspace */
-   TYPE *wB,      /* if non-NULL ip-based At workspace */
-   TYPE *rC,      /* real portion of wC (unused in real routines) */
-   TYPE *wC       /* if non-NULL: ptr to syrk-storage C wrkspc */
-)
-{
-   const size_t nfkblks = ip->nfkblks;
-   size_t k;
-   ATL_UINT szA, szB;
-   if (d < ip->nfnblks)
-   {
-      /*szA = szB = ip->szA;*/
-      szA = ip->szA;
-      szB = ip->szB;
-   }
-   else
-   {
-      szA = ip->pszA;
-      szB = ip->pszB;
-   }
-   #ifdef TCPLX
-      szA += szA;
-      szB += szB;
-   #endif
-/*
- * For first K block, use beta=0 kernel to init wC
- */
-   if (nfkblks)
-   {
-      TYPE *wAn=(wA)? wA+szA:NULL, *wBn=(wB) ? wB+szB : NULL;
-      syrkBlk(ip, flag|4, d, 0, A, B, NULL, beta, NULL, wA,wAn, wB,wBn,
-                 rC, wC);
-      wA = wAn;
-      wB = wBn;
-   }
-   else /* this is first & last block! */
-   {
-      syrkBlk(ip, flag|4, d, 0, A, B, blk2c, beta, C, wA, wA, wB, wB,
-                rC, wC);
-      return;
-   }
-/*
- * Handle all blocks except first (handled above) & last (handled below)
- */
-   for (k=1; k < nfkblks; k++)
-   {
-      TYPE *wAn=(wA)? wA+szA:NULL, *wBn=(wB) ? wB+szB : NULL;
-      syrkBlk(ip, flag, d, k, A, B, NULL, beta, NULL, wA, wAn, wB, wBn,
-                rC, wC);
-      wA = wAn;
-      wB = wBn;
-   }
-/*
- * Last block actually writes to C
- */
-   syrkBlk(ip, flag, d, k, A, B, blk2c, beta, C, wA,wA, wB,wB, rC,wC);
-}
-
-int syrk
-(
-   const enum ATLAS_UPLO  Uplo,
-   const enum ATLAS_TRANS TA,
-   ATL_CSZT  N,
-   ATL_CSZT K,
-   #ifdef Conj_
-   const TYPE ralpha,
-   #else
-   const SCALAR alpha,
-   #endif
-   const TYPE *A,
-   ATL_CSZT lda,
-   #ifdef Conj_
-   const TYPE rbeta,
-   #else
-   const SCALAR beta,
-   #endif
-   TYPE *C,
-   ATL_CSZT ldc
-)
-{
-   size_t sz, szA, szB, szC, szS, nnblks, extra;
-   void *vp=NULL;
-   TYPE *wA, *wB, *wC, *wS, *wCs, *rC, *rCs, *rS;
-   double timG;
-   int nb, nbS, flg, idx;
-   int k, ierr;
-   ablk2cmat_t blk2sy, blk2c;
-   ipinfo_t ip;
-   #ifdef Conj_
-      TYPE alpha[2]={ralpha, ATL_rzero}, beta[2]={rbeta, ATL_rzero};
-      const enum ATLAS_TRANS TB=(TA==AtlasNoTrans)?AtlasConjTrans:AtlasNoTrans;
-   #else
-      const enum ATLAS_TRANS TB = (TA==AtlasNoTrans) ? AtlasTrans:AtlasNoTrans;
-   #endif
-#ifdef MEM_DEBUG
-   void *vA=NULL, *vB=NULL, *vC=NULL;
-#endif
-   Mjoin(PATL,ipmenUMInfo)(&ip, TA, TB, N,N,K, lda, lda, ldc, alpha, beta);
-   nb = (ip.nfnblks) ? ip.nb : ip.pnb;
-   nnblks = ip.nfnblks + ip.npnblks;
-/*
- * Main idea:
- * 1. with syrk+gemm of full blks, syrk can always reuse the workspace of gemm
- *    no need to allocate extra space for syrk
- * 2. syrk only: need to allocate only considering the syrk
- */
-/*
- * Need space for only one column-panel of At
- */
-   szB = ip.nfnblks ? ip.szA : ip.pszA;
-   szB *= (ip.nfkblks+1);
-/*
- * space calc for single syrk block
- */
-   if (nnblks == 1)    /* single blk in n-dimension: syrk only*/
-   {
-      int smnu=(ip.mu > ip.nu)?ip.mu:ip.nu; /* max of mu, nu*/
-      nbS = (nb+smnu-1)/smnu;
-      szC = ((nbS+1)*nbS)>>1;
-      nbS *= smnu;
-/*
- *    considering mu and nu as one is multiple of other, the size of subblock
- *    is smnu*smnu (rounded with ku).
- */
-      szC *= ((smnu*smnu+ip.ku-1)/ip.ku)*ip.ku;
-      szS =  ((ip.kb+ip.ku-1)/ip.ku)*ip.ku;
-      szA = nbS * szS * (ip.nfkblks + 1);
-      extra = (smnu+smnu)*smnu;  /* may not need */
-   }
-   else
-   {
-/*
- *    A needs entire matrix minus one row/col panel
- */
-      szA = szB * (ip.nfnblks + ip.npnblks - 1);
-      szC = ip.szC;
-      extra = ip.exsz;
-   }
-#ifdef MEM_DEBUG
-/*
- * DEBUG: to debug, I allocate memory individually.... so that I can use
- * valgrind to find out of memory access error
- */
-   sz = ATL_MulBySize(szA) + 2*ATL_Cachelen;
-   if (sz < ATL_MaxMalloc)
-      vA = malloc(sz);
-   if (!vA)
-      return(1);  /* keep recurring, can't malloc space! */
-   wA = ATL_AlignPtr(vA);
-
-   sz = ATL_MulBySize(szB) + 2*ATL_Cachelen;
-   if (sz < ATL_MaxMalloc)
-      vB = malloc(sz);
-   if (!vB)
-      return(1);  /* keep recurring, can't malloc space! */
-   wB = ATL_AlignPtr(vB);
-
-   sz = ATL_MulBySize(szC + extra) + 2*ATL_Cachelen;
-   if (sz < ATL_MaxMalloc)
-      vC = malloc(sz);
-   if (!vC)
-      return(1);  /* keep recurring, can't malloc space! */
-   wC = ATL_AlignPtr(vC);
-#else
-/*
- * use it for timing to reduce mulitple malloc.
- */
-   sz = ATL_MulBySize(szC + szA+szB + extra) + 5*ATL_Cachelen;
-   if (sz < ATL_MaxMalloc)
-      vp = malloc(sz);
-   if (!vp)
-      return(1);  /* keep recurring, can't malloc space! */
-   wA = ATL_AlignPtr(vp);
-   wB = wA + (szA SHIFT);
-   wB = ATL_AlignPtr(wB);
-   wC = wB + (szB SHIFT);
-   wC = ATL_AlignPtr(wC);
-#endif
-   #ifdef TCPLX
-      rC = wC + szC;
-   #else
-      rC = wC;
-   #endif
-/*
- * ============================================================================
- * First, we compute diagonals of C, and in the process we will copy A/A^T
- * for use in computing non-diaginal blocks using inner-product amm.
- * ============================================================================
- */
-   flg = (TA == AtlasNoTrans) ? 2 : 0;
-/*
- * NOTE: alpha may be already applied on A-copy. So, use ip.alpC instead of
- * alpha to select appropriate copy routines
- */
-   if (Uplo == AtlasLower)
-   {
-      if (SCALAR_IS_ONE(beta))
-      {
-         if (SCALAR_IS_NONE(ip.alpC))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNb1);
-         else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
-                     Mjoin(PATL,SyrkIntoC_a1b1):Mjoin(PATL,SyrkIntoC_aXb1);
-      }
-      else if (SCALAR_IS_NONE(beta))
-      {
-         if (SCALAR_IS_NONE(ip.alpC))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNbN);
-         else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
-                     Mjoin(PATL,SyrkIntoC_a1bN):Mjoin(PATL,SyrkIntoC_aXbN);
-      }
-      else if (SCALAR_IS_ZERO(beta))
-      {
-         if (SCALAR_IS_NONE(ip.alpC))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNb0);
-         else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
-                     Mjoin(PATL,SyrkIntoC_a1b0):Mjoin(PATL,SyrkIntoC_aXb0);
-      }
-      else
-      {
-         if (SCALAR_IS_NONE(ip.alpC))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNbX);
-         else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
-                     Mjoin(PATL,SyrkIntoC_a1bX):Mjoin(PATL,SyrkIntoC_aXbX);
-      }
-   }
-   else
-   {
-      if (SCALAR_IS_ONE(beta))
-      {
-         if (SCALAR_IS_NONE(ip.alpC))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNb1_L2UT);
-         else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
-                     Mjoin(PATL,SyrkIntoC_a1b1_L2UT)
-                     :Mjoin(PATL,SyrkIntoC_aXb1_L2UT);
-      }
-      else if (SCALAR_IS_NONE(beta))
-      {
-         if (SCALAR_IS_NONE(ip.alpC))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNbN_L2UT);
-         else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
-                     Mjoin(PATL,SyrkIntoC_a1bN_L2UT)
-                     :Mjoin(PATL,SyrkIntoC_aXbN_L2UT);
-      }
-      else if (SCALAR_IS_ZERO(beta))
-      {
-         if (SCALAR_IS_NONE(ip.alpC))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNb0_L2UT);
-         else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
-                     Mjoin(PATL,SyrkIntoC_a1b0_L2UT)
-                     :Mjoin(PATL,SyrkIntoC_aXb0_L2UT);
-      }
-      else
-      {
-         if (SCALAR_IS_NONE(ip.alpC))
-            blk2sy = Mjoin(PATL,SyrkIntoC_aNbX_L2UT);
-         else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
-                     Mjoin(PATL,SyrkIntoC_a1bX_L2UT)
-                     :Mjoin(PATL,SyrkIntoC_aXbX_L2UT);
-      }
-   }
-/*
- * syrk-upper
- */
-   if (Uplo == AtlasUpper)
-   {
-      flg |= 1;
-/*
- *    1st syrk: copies both formats, no reuse
- */
-      syrk_K(&ip, flg, 0, A, A, blk2sy, beta, C, wB, wA, rC, wC);
-      if (N > nb)
-      {
-         const size_t incC = nb*((ldc+1)SHIFT);
-         size_t i;
-/*
- *       Compute all C blks within this rowpan of C, copies B (At), reuse A
- */
-         blk2c = ip.blk2c;
-         Mjoin(PATL,iploopsNK)(&ip, 0, 1, NULL, A, C, 11, wB, wA, rC, wC,
-                               beta, blk2c);
-/*
- *       Loop over all col-pans of C, excepting first & last;
- *       A already fully copied, B will be copied by syrk_Kloop call.
- */
-         for (i=1; i < nnblks-1; i++)
-         {
-/*
- *          syrk copies A and reuses B copy
- */
-            syrk_K(&ip, flg, i, A, NULL, blk2sy, beta, C, wB, wA,
-                          rC, wC);
-            wA += szB SHIFT;
-/*
- *          gemm can reuse both the copies
- */
-            Mjoin(PATL,iploopsNK)(&ip, i, i+1, NULL, NULL, C+i*(nb SHIFT), 11,
-                                  wB, wA, rC, wC, beta, blk2c);
-         }
-/*
- *       Last colpan is only 1 diag blk
- */
-         syrk_K(&ip, flg, i, A, NULL, blk2sy, beta, C, wB, wA,
-                       rC, wC);
-      }
-   }
-/*
- * Lower doesn't need to copy first row panel of A or last col panel of At
- * to GEMM storage.  If C only block, should call syrk_IP instead!
- */
-   else
-   {
-      const size_t incC = (ldc SHIFT) * nb;
-      size_t j;
-      TYPE *c;
-/*
- *    Compute first diag block, copies both
- */
-      syrk_K(&ip, flg, 0, A, A, blk2sy, beta, C, wA, wB, rC, wC);
-      if (N > nb)
-      {
-/*
- *       Compute all C blks within this colpan of C, copying rest of A, reuse B
- */
-         blk2c = ip.blk2c;
-         Mjoin(PATL,iploopsMK)(&ip, 1, 0, A, NULL, C, 7, wA, wB, rC, wC,
-                               beta, blk2c);
-/*
- *       Loop over all col-pans of C, excepting first & last;
- *       A already fully copied, B will be copied by syrk_Kloop call.
- */
-         c = C + incC;
-         for (j=1; j < nnblks-1; j++)
-         {
-/*
- *          syrk reuse A and copies B
- */
-            syrk_K(&ip, flg, j, NULL, A, blk2sy, beta, C, wA, wB,
-                          rC, wC);
-            wA += szB SHIFT;
-/*
- *          gemm reuses both the copies
- */
-            Mjoin(PATL,iploopsMK)(&ip, j+1, j, NULL, NULL, c, 7, wA, wB, rC, wC,
-                                  beta, blk2c);
-            c += incC;
-         }
-/*
- *       Last colpan is only 1 diag blk, still reuses A
- */
-         syrk_K(&ip, flg, j, NULL, A, blk2sy, beta, C, wA, wB,
-                       rC, wC);
-      }
-   }
-#ifdef MEM_DEBUG
-   free(vA);
-   free(vB);
-   free(vC);
-#else
-   free(vp);
-#endif
-   return(0);
-}
-@ROUT ATL_ursyrk
-@extract -b @(topd)/cw.inc lang=C -def cwdate 2016
-#define ATL_GLOBIDX 1
-#include "atlas_misc.h"
-#include "atlas_level1.h"
-#include "atlas_level2.h"
-#include "atlas_level3.h"
-#include Mstr(Mjoin(ATLAS_PRE,sysinfo.h))
-#include Mstr(Mjoin(ATLAS_PRE,opgen_view.h))
-#include Mstr(Mjoin(ATLAS_PRE,amm_ursyrk.h))
 /*
  * Service routine, particularly for parallel.  Takes its blocking from ip
  * (assuming that is what is being used below diagonal blocks
@@ -2252,7 +1700,11 @@ void syrkBlk
    size_t k,      /* which K block of A is being computed */
    const TYPE *A, /* if non-NULL, base A ptr to copy */
    const TYPE *B, /* if non-NULL, base A ptr to copy */
-   ablk2tcmat_t blk2c, /* if non-NULL sy storage to tri C storage copy func */
+@ROUT ATL_umsyrk
+   ablk2cmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
+@ROUT ATL_ursyrk
+   ablk2tcmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
+@ROUT ATL_umsyrk ATL_ursyrk
    const SCALAR beta, /* only needed if blk2c non-NULL */
    TYPE *C,       /* if blk2c && non-NULL, which C to write to */
    TYPE *wA,      /* if non-NULL, ip-based A workspace */
@@ -2370,16 +1822,26 @@ void syrkBlk
          alp = (ip->alpA != ip->alpC) ? ip->alpA : ip->alpB;
       if (C)
       {
+@ROUT ATL_ursyrk
          ATL_UINT shVL;
          for (shVL=0; !(ip->vlen&(1<<shVL)); shVL++) ;
+@ROUT ATL_umsyrk ATL_ursyrk
          C = IdxC_ip(ip, C, d, d);
          #ifdef TCPLX
+@ROUT ATL_ursyrk
             blk2c(nb, ip->mu, ip->nu, shVL, alp, rC, wC, beta, C, ldc);
+@ROUT ATL_umsyrk             
+            blk2c(nb, nb, alp, rC, wC, beta, C, ldc);
+@ROUT ATL_umsyrk ATL_ursyrk
             #ifdef Conj_  /* must zero complex part of diagonal! */
                Mjoin(PATLU,zero)(nb, C+1, (ldc+1)SHIFT);
             #endif
          #else
+@ROUT ATL_ursyrk
             blk2c(nb, ip->mu, ip->nu, shVL, alp, wC, beta, C, ldc);
+@ROUT ATL_umsyrk             
+            blk2c(nb, nb, alp, wC, beta, C, ldc);
+@ROUT ATL_umsyrk ATL_ursyrk
          #endif
       }
    }
@@ -2392,7 +1854,11 @@ void syrk_K  /* inner-product based syrk/herk loop over K loop */
    size_t d,      /* which global diagonal blk of C is being computed */
    const TYPE *A, /* if non-NULL, base A ptr to copy */
    const TYPE *B, /* if non-NULL, base B ptr to copy */
+@ROUT ATL_ursyrk
+   ablk2cmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
+@ROUT ATL_umsyrk             
    ablk2tcmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
+@ROUT ATL_umsyrk ATL_ursyrk
    const SCALAR beta, /* only needed if blk2c non-NULL */
    TYPE *C,       /* if blk2c non-NULL, which C to write to, else ignored */
    TYPE *wA,      /* if non-NULL, ip-based A workspace */
@@ -2481,8 +1947,12 @@ int syrk
    double timG;
    int nb, nbS, flg, idx;
    int k, ierr;
+@ROUT ATL_ursyrk
    ablk2cmat_t blk2c;
    ablk2tcmat_t blk2sy;
+@ROUT ATL_umsyrk             
+   ablk2cmat_t blk2sy, blk2c;
+@ROUT ATL_umsyrk ATL_ursyrk
    ipinfo_t ip;
    #ifdef Conj_
       TYPE alpha[2]={ralpha, ATL_rzero}, beta[2]={rbeta, ATL_rzero};
@@ -2490,9 +1960,15 @@ int syrk
    #else
       const enum ATLAS_TRANS TB = (TA==AtlasNoTrans) ? AtlasTrans:AtlasNoTrans;
    #endif
+@BEGINSKIP
+/*
+ * for debugging the memory overflow, we want to allocate workspaces 
+ * individually. not doing it for the performance otherwise. 
+ */
 #ifdef MEM_DEBUG
    void *vA=NULL, *vB=NULL, *vC=NULL;
 #endif
+@ENDSKIP
    Mjoin(PATL,ipmenUMInfo)(&ip, TA, TB, N,N,K, lda, lda, ldc, alpha, beta);
    nb = (ip.nfnblks) ? ip.nb : ip.pnb;
    nnblks = ip.nfnblks + ip.npnblks;
@@ -2534,7 +2010,7 @@ int syrk
       szC = ip.szC;
       extra = ip.exsz;
    }
-@BEGINSKIP
+@BEGINSKIP 
 #ifdef MEM_DEBUG
 /*
  * DEBUG: to debug, I allocate memory individually.... so that I can use

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -2333,6 +2333,7 @@ int syrk_amm
    double timG;
    int nb, nbS, flg, idx;
    int i, k, ierr;
+   unsigned short kmaj;
    #ifdef Conj_
       TYPE alpha[2]={ralpha, ATL_rzero}, beta[2]={rbeta, ATL_rzero};
       const enum ATLAS_TRANS TB=(TA==AtlasNoTrans)?AtlasConjTrans:AtlasNoTrans;
@@ -2512,20 +2513,25 @@ int syrk_amm
  * We want not only to match mu-nu-ku but also vlen and kvec to make sure 
  * ursyrk can share A/B copies with gemm as well 
  */
+   kmaj = ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(ipmen.idxK));
    if (ipmen.mu == ATL_URSYRKK_MU && ipmen.nu == ATL_URSYRKK_NU
          && ipmen.ku == ATL_URSYRKK_KU && ipmen.vlen == ATL_URSYRKK_VLEN
-         && ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(ipmen.idxK)) == ATL_URSYRKK_KVEC )
+         && ((!kmaj && !ATL_URSYRKK_KVEC) || (kmaj && ATL_URSYRKK_KVEC)) )
+   {
       #ifdef Conj_
          ierr = ursyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
       #else
          ierr = ursyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
       #endif
+   }
    else
+   {
       #ifdef Conj_
          ierr = sqsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
       #else
          ierr = sqsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
       #endif
+   }
    
    return(ierr);
 }
@@ -3461,8 +3467,8 @@ int opsyrk
    ATL_CSZT ldc
 )
 {
-   int i;
-   int ierr;
+   int i, ierr;
+   unsigned short kmaj;
    #ifdef Conj_
       TYPE alpha[2]={ralpha, ATL_rzero}, beta[2]={rbeta, ATL_rzero};
       const enum ATLAS_TRANS TB=(TA==AtlasNoTrans)?AtlasConjTrans:AtlasNoTrans;
@@ -3487,9 +3493,10 @@ int opsyrk
 /*
  * apply ursyrk when gemm and syrk can share copies 
  */
+   kmaj = ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(op.idxK));
    if (op.mu == ATL_URSYRKK_MU && op.nu == ATL_URSYRKK_NU 
          && op.ku ==ATL_URSYRKK_KU && op.vlen == ATL_URSYRKK_VLEN 
-         && ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(op.idxK)) == ATL_URSYRKK_KVEC )
+         && ((!kmaj && !ATL_URSYRKK_KVEC) || (kmaj && ATL_URSYRKK_KVEC)) ) 
       ierr = opursyrk(&op, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
    else
       ierr = opsqsyrk(&op, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -1683,13 +1683,19 @@ int syrk
  * ==> wU can be aliased wt wS if you don't need correct wS on output
  */
 #ifdef Conj_
-   #define syrkBlk Mjoin(PATL,umherkBlk)
-   #define syrk_K  Mjoin(PATL,umherk_KLoop)
-   #define syrk  Mjoin(PATL,umherk)
+@ROUT ATL_umsyrk `   #define syrkBlk Mjoin(PATL,umherkBlk)`
+@ROUT ATL_ursyrk `   #define syrkBlk Mjoin(PATL,urherkBlk)`
+@ROUT ATL_umsyrk `   #define syrk_K  Mjoin(PATL,umherk_KLoop)`
+@ROUT ATL_ursyrk `   #define syrk_K  Mjoin(PATL,urherk_KLoop)`
+@ROUT ATL_umsyrk `   #define syrk  Mjoin(PATL,umherk)`
+@ROUT ATL_ursyrk `   #define syrk  Mjoin(PATL,urherk)`
 #else
-   #define syrkBlk Mjoin(PATL,umsyrkBlk)
-   #define syrk_K  Mjoin(PATL,umsyrk_KLoop)
-   #define syrk  Mjoin(PATL,umsyrk)
+@ROUT ATL_umsyrk `   #define syrkBlk Mjoin(PATL,umsyrkBlk)`
+@ROUT ATL_ursyrk `   #define syrkBlk Mjoin(PATL,ursyrkBlk)`
+@ROUT ATL_umsyrk `   #define syrk_K  Mjoin(PATL,umsyrk_KLoop)`
+@ROUT ATL_ursyrk `   #define syrk_K  Mjoin(PATL,ursyrk_KLoop)`
+@ROUT ATL_umsyrk `   #define syrk  Mjoin(PATL,umsyrk)`
+@ROUT ATL_ursyrk `   #define syrk  Mjoin(PATL,ursyrk)`
 #endif
 @SKIP /*#define MEM_DEBUG 1*/
 
@@ -2255,7 +2261,7 @@ int syrk
 #include Mstr(Mjoin(ATLAS_PRE,opgen_view.h))
 @SKIP #include Mstr(Mjoin(ATLAS_PRE,amm_syrk.h))
 #include Mstr(Mjoin(ATLAS_PRE,amm_sqsyrk.h))
-#include Mstr(Mjoin(ATLAS_PRE,amm_umsyrk.h))
+#include Mstr(Mjoin(ATLAS_PRE,amm_ursyrk.h))
 #ifndef Conj_
    #define ATL_DECL_ 1
 #endif
@@ -2285,7 +2291,7 @@ int syrk
    #define ipsyrk  Mjoin(PATL,ipherk)
    #define SYRK Mjoin(PATL,herk)
    #define herk_FLG 1
-   #define umsyrk  Mjoin(PATL,umherk)
+   #define ursyrk  Mjoin(PATL,urherk)
    #define sqsyrk  Mjoin(PATL,sqherk)
 #else
    #define syrk_amm  Mjoin(PATL,syrk_amm)
@@ -2293,7 +2299,7 @@ int syrk
    #define ipsyrk  Mjoin(PATL,ipsyrk)
    #define SYRK Mjoin(PATL,syrk)
    #define herk_FLG 0
-   #define umsyrk  Mjoin(PATL,umsyrk)
+   #define ursyrk  Mjoin(PATL,ursyrk)
    #define sqsyrk  Mjoin(PATL,sqsyrk)
 #endif
 
@@ -2498,7 +2504,7 @@ int syrk_amm
  * We will decide between sqsyrk and umsyrk based on the pref data from 
  * amm_syrkPerf.h.  
  */
-#if 1
+#if 0
    #if 1  /* apply umsyrk*/ 
       Mjoin(PATL,ipmenUMInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta); 
       #ifdef Conj_
@@ -2653,18 +2659,18 @@ void SYRK
 #include Mstr(Mjoin(ATLAS_PRE,sysinfo.h))
 @SKIP #include Mstr(Mjoin(ATLAS_PRE,amm_syrk.h))
 #include Mstr(Mjoin(ATLAS_PRE,amm_sqsyrk.h))
-#include Mstr(Mjoin(ATLAS_PRE,amm_umsyrk.h))
+#include Mstr(Mjoin(ATLAS_PRE,amm_ursyrk.h))
 #ifdef Conj_
    #define sqsyrkBlk Mjoin(PATL,sqherkBlk_OP)
-   #define umsyrkBlk Mjoin(PATL,umherkBlk_OP)
+   #define ursyrkBlk Mjoin(PATL,urherkBlk_OP)
    #define opsqsyrk Mjoin(PATL,opsqherk)
-   #define opumsyrk Mjoin(PATL,opumherk)
+   #define opursyrk Mjoin(PATL,opurherk)
    #define opsyrk Mjoin(PATL,opherk)
 #else
    #define sqsyrkBlk Mjoin(PATL,sqsyrkBlk_OP)
-   #define umsyrkBlk Mjoin(PATL,umsyrkBlk_OP)
+   #define ursyrkBlk Mjoin(PATL,ursyrkBlk_OP)
    #define opsqsyrk Mjoin(PATL,opsqsyrk)
-   #define opumsyrk Mjoin(PATL,opumsyrk)
+   #define opursyrk Mjoin(PATL,opursyrk)
    #define opsyrk Mjoin(PATL,opsyrk)
 #endif
 /*
@@ -3129,14 +3135,13 @@ int opsqsyrk
    free(vp);
    return(0);
 }
-void umsyrkBlk
+void ursyrkBlk
 (
    opinfo_t *op,
-   int flag,      /* bitvec: 0: set means C is upper, 1: set TA==AtlasNoTrans */
    size_t d,      /* which global diagonal blk of C is being computed */
    const TYPE *A, /* if non-NULL, base A ptr to copy in wA */
    const TYPE *B, /* if non-NULL, base A ptr to copy in wB */
-   ablk2cmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
+   ablk2tcmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
    TYPE *C,       /* if blk2c non-NULL, which C to write to, else ignored */
    TYPE *wA,      /* if non-NULL, op-based A workspace */
    TYPE *wAn,     /* next A wrkspc to be prefetched */
@@ -3250,12 +3255,12 @@ void umsyrkBlk
  *    copy routines and similar kernels
  */
       #ifdef TCPLX
-         Mjoin(PATL,umsyrkK_b0)(nmu, nnu, kbS, wA, wB, rC, rA, wB, wC);
-         Mjoin(PATL,umsyrkK_b0)(nmu, nnu, kbS, rA, wB, wC, rA, rB, rC);
-         Mjoin(PATL,umsyrkK_bn)(nmu, nnu, kbS, rA, rB, rC, wA, rB, wC);
-         Mjoin(PATL,umsyrkK_b1)(nmu, nnu, kbS, wA, rB, wC, wA, wB, wC);
+         Mjoin(PATL,ursyrkK_b0)(nmu, nnu, kbS, wA, wB, rC, rA, wB, wC);
+         Mjoin(PATL,ursyrkK_b0)(nmu, nnu, kbS, rA, wB, wC, rA, rB, rC);
+         Mjoin(PATL,ursyrkK_bn)(nmu, nnu, kbS, rA, rB, rC, wA, rB, wC);
+         Mjoin(PATL,ursyrkK_b1)(nmu, nnu, kbS, wA, rB, wC, wA, wB, wC);
       #else
-         Mjoin(PATL,umsyrkK_b0)(nmu, nnu, kbS, wA, wB, wC, wA, wB, wC);
+         Mjoin(PATL,ursyrkK_b0)(nmu, nnu, kbS, wA, wB, wC, wA, wB, wC);
       #endif
    }
    if (blk2c)
@@ -3267,33 +3272,22 @@ void umsyrkBlk
       #else
          TYPE alp = (op->alpA == ATL_rone) ? op->alpB : op->alpA;
       #endif
+      ATL_UINT shVL;
+      
+      for (shVL=0; !(op->vlen&(1<<shVL)); shVL++) ;
       C += d*op->nb*((ldc+1)SHIFT);
-      if (flag&1)  /* Upper matrix */
-      {
-         #ifdef TCPLX
-            blk2c(nb, nb, alp, rC, wC, beta, C, ldc);
-            #ifdef Conj_  /* must zero complex part of diagonal! */
-               Mjoin(PATLU,zero)(nb, C+1, (ldc+1)SHIFT);
-            #endif
-         #else
-            blk2c(nb, nb, alp, wC, beta, C, ldc);
+      #ifdef TCPLX
+         blk2c(nb, op->mu, op->nu, shVL, alp, rC, wC, beta, C, ldc);
+         #ifdef Conj_  /* must zero complex part of diagonal! */
+            Mjoin(PATLU,zero)(nb, C+1, (ldc+1)SHIFT);
          #endif
-      }
-      else
-      {
-         #ifdef TCPLX
-            blk2c(nb, nb, alp, rC, wC, beta, C, ldc);
-            #ifdef Conj_  /* must zero complex part of diagonal! */
-               Mjoin(PATLU,zero)(nb, C+1, (ldc+1)SHIFT);
-            #endif
-         #else
-            blk2c(nb, nb, alp, wC, beta, C, ldc);
-         #endif
-      }
+      #else
+         blk2c(nb, op->mu, op->nu, shVL, alp, wC, beta, C, ldc);
+      #endif
    }
 }
 
-int opumsyrk
+int opursyrk
 (
    opinfo_t *op,
    const enum ATLAS_UPLO  Uplo,
@@ -3313,7 +3307,8 @@ int opumsyrk
    TYPE *wA, *wB, *wC, *wS, *wU, *rC, *rCs, *rS;
    int nb, nbS, flg, idx, extra;
    cm2am_t sy2blk;
-   ablk2cmat_t blk2sy, blk2c;
+   ablk2cmat_t blk2c;
+   ablk2tcmat_t blk2sy;
    int smnu;
 
    nnblks = op->nfnblks + op->npnblks;
@@ -3324,24 +3319,24 @@ int opumsyrk
    if (Uplo == AtlasLower)
    {
       if (SCALAR_IS_ONE(beta))
-         blk2sy = Mjoin(PATL,umSyrkIntoC_a1b1);
+         blk2sy = Mjoin(PATL,urSyrkIntoC_a1b1);
       else if (SCALAR_IS_NONE(beta))
-         blk2sy = Mjoin(PATL,umSyrkIntoC_a1bN);
+         blk2sy = Mjoin(PATL,urSyrkIntoC_a1bN);
       else if (SCALAR_IS_ZERO(beta))
-         blk2sy = Mjoin(PATL,umSyrkIntoC_a1b0);
+         blk2sy = Mjoin(PATL,urSyrkIntoC_a1b0);
       else
-         blk2sy = Mjoin(PATL,umSyrkIntoC_a1bX);
+         blk2sy = Mjoin(PATL,urSyrkIntoC_a1bX);
    }
    else  /* C is Upper */
    {
       if (SCALAR_IS_ONE(beta))
-         blk2sy = Mjoin(PATL,umSyrkIntoC_a1b1_L2UT);
+         blk2sy = Mjoin(PATL,urSyrkIntoC_a1b1_L2UT);
       else if (SCALAR_IS_NONE(beta))
-         blk2sy = Mjoin(PATL,umSyrkIntoC_a1bN_L2UT);
+         blk2sy = Mjoin(PATL,urSyrkIntoC_a1bN_L2UT);
       else if (SCALAR_IS_ZERO(beta))
-         blk2sy = Mjoin(PATL,umSyrkIntoC_a1b0_L2UT);
+         blk2sy = Mjoin(PATL,urSyrkIntoC_a1b0_L2UT);
       else
-         blk2sy = Mjoin(PATL,umSyrkIntoC_a1bX_L2UT);
+         blk2sy = Mjoin(PATL,urSyrkIntoC_a1bX_L2UT);
    }
    flg = (TA == AtlasNoTrans) ? 2 : 0;
    if (TA == AtlasUpper)
@@ -3370,7 +3365,7 @@ int opumsyrk
          rC = wC;
       #endif
       flg |= (Uplo == AtlasUpper) ? 1 : 0;
-      umsyrkBlk(op, flg, 0, A, A, blk2sy, C, wA, wA, wB, wB, rC, wC);
+      ursyrkBlk(op, 0, A, A, blk2sy, C, wA, wA, wB, wB, rC, wC);
       free(vp);
       return(0);
    }
@@ -3407,7 +3402,7 @@ int opumsyrk
  *    SYRK uses same copy routines as GEMM. copy of B can be reused in GEMM
  *    of the column panels
  */
-      umsyrkBlk(op, flg, 0, A, A, blk2sy, C, wA, wA, wB, wB, rC, wC);
+      ursyrkBlk(op, 0, A, A, blk2sy, C, wA, wA, wB, wB, rC, wC);
 /*
  *    Do rank-K update on ge blks beneath diag, copying entire A at same time
  */
@@ -3423,14 +3418,14 @@ int opumsyrk
  *          After the first call of oploopsM the whole wA is populated
  *       2. compute wB which can be reused in subsequent oploopsM
  */
-         umsyrkBlk(op, flg, j, NULL, A, blk2sy, C, wA,wA, wB,wB, rC, wC);
+         ursyrkBlk(op, j, NULL, A, blk2sy, C, wA,wA, wB,wB, rC, wC);
          wA += (szAblk SHIFT);
          Mjoin(PATL,oploopsM)(op, j+1, j, NULL, NULL, C, 1, wA, wB, rC, wC);
       }
 /*
  *    Last col panel is only one diagonal
  */
-      umsyrkBlk(op, flg, j, NULL, A, blk2sy, C, wA, wA, wB, wB, rC, wC);
+      ursyrkBlk(op, j, NULL, A, blk2sy, C, wA, wA, wB, wB, rC, wC);
    }
    else
    {
@@ -3438,8 +3433,7 @@ int opumsyrk
 /*
  *    GEMM will reuse A*T, Syrk can reuse B later... wB is wA
  */
-      flg |= 1;
-      umsyrkBlk(op, flg, 0, A, A, blk2sy, C, wB, wB, wA, wA, rC, wC);
+      ursyrkBlk(op, 0, A, A, blk2sy, C, wB, wB, wA, wA, rC, wC);
 /*
  *    Do rank-K update on ge blks beneath diag, copying entire A^T at same time
  */
@@ -3449,14 +3443,14 @@ int opumsyrk
  */
       for (i=1; i < nnblks-1; i++)
       {
-         umsyrkBlk(op, flg, i, A, NULL, blk2sy, C, wB,wB, wA,wA, rC, wC);
+         ursyrkBlk(op, i, A, NULL, blk2sy, C, wB,wB, wA,wA, rC, wC);
          wA += (szAblk SHIFT);
          Mjoin(PATL,oploopsN)(op, i, i+1, NULL, NULL, C, 2, wB, wA, rC, wC);
       }
 /*
  *    Last col panel is only one diagonal
  */
-      umsyrkBlk(op, flg, i, A, NULL, blk2sy, C, wB, wB, wA, wA, rC, wC);
+      ursyrkBlk(op, i, A, NULL, blk2sy, C, wB, wB, wA, wA, rC, wC);
    }
    free(vp);
    return(0);
@@ -3508,18 +3502,18 @@ int opsyrk
            op.pmb, op.pnb, op.kb);
    #endif
 /*
- * mu,nu,ku, must match with amm_umsyrk.h to apply umsyrk until we manage 
- * to have opgenview for UM
+ * mu,nu,ku, must match with amm_umsyrk.h to apply ursyrk until we manage 
+ * to have opgenview for UR
  */
    ismul = 1;
-   if (op.mu != ATL_UMSYRKK_MU || op.nu != ATL_UMSYRKK_NU 
-         || op.ku !=ATL_UMSYRKK_KU )
+   if (op.mu != ATL_URSYRKK_MU || op.nu != ATL_URSYRKK_NU 
+         || op.ku !=ATL_URSYRKK_KU )
       ismul = 0;
 /*
- * try to use umsyrk first if possible 
+ * try to use ursyrk first if possible 
  */
    if (ismul)
-      ierr = opumsyrk(&op, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
+      ierr = opursyrk(&op, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
    else
       ierr = opsqsyrk(&op, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
    return(ierr);
@@ -3536,7 +3530,7 @@ int opsyrk
 #include Mstr(Mjoin(ATLAS_PRE,syrk_view.h)) /* blocking & perf info */
 @SKIP #include Mstr(Mjoin(ATLAS_PRE,amm_syrk.h))  /* syrk kernel info */
 #include Mstr(Mjoin(ATLAS_PRE,amm_sqsyrk.h))
-#include Mstr(Mjoin(ATLAS_PRE,amm_umsyrk.h))
+#include Mstr(Mjoin(ATLAS_PRE,amm_ursyrk.h))
 
 static INLINE void ATL_syr1
 (

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -2500,16 +2500,16 @@ int syrk_amm
 #if 1  /* apply umsyrk*/ 
    Mjoin(PATL,ipmenUMInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta); 
    #ifdef Conj_
-      ierr = umsyrk(Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
+      ierr = umsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
    #else
-      ierr = umsyrk(Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
+      ierr = umsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
    #endif
 #else /* sqsyrk */
    Mjoin(PATL,ipmenInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta); 
    #ifdef Conj_
-      ierr = sqsyrk(Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
+      ierr = sqsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
    #else
-      ierr = sqsyrk(Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
+      ierr = sqsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
    #endif
 #endif
    return(ierr);

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -1862,9 +1862,9 @@ void syrk_K  /* inner-product based syrk/herk loop over K loop */
    const TYPE *A, /* if non-NULL, base A ptr to copy */
    const TYPE *B, /* if non-NULL, base B ptr to copy */
 @ROUT ATL_ursyrk
-   ablk2cmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
-@ROUT ATL_umsyrk             
    ablk2tcmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
+@ROUT ATL_umsyrk             
+   ablk2cmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
 @ROUT ATL_umsyrk ATL_ursyrk
    const SCALAR beta, /* only needed if blk2c non-NULL */
    TYPE *C,       /* if blk2c non-NULL, which C to write to, else ignored */

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -2211,6 +2211,563 @@ int syrk
 #endif
    return(0);
 }
+@ROUT ATL_ursyrk
+@extract -b @(topd)/cw.inc lang=C -def cwdate 2016
+#define ATL_GLOBIDX 1
+#include "atlas_misc.h"
+#include "atlas_level1.h"
+#include "atlas_level2.h"
+#include "atlas_level3.h"
+#include Mstr(Mjoin(ATLAS_PRE,sysinfo.h))
+#include Mstr(Mjoin(ATLAS_PRE,opgen_view.h))
+#include Mstr(Mjoin(ATLAS_PRE,amm_ursyrk.h))
+/*
+ * Service routine, particularly for parallel.  Takes its blocking from ip
+ * (assuming that is what is being used below diagonal blocks
+ * flag bits, meaning if set (opposite if unset):
+ * 0/1: C is upper
+ * 1/2: TA == AtlasNoTrans
+ * 2/4: use beta=0 syrk kernel (else use beta=1)
+ *
+ * If (Uplo==Upper && sy2blk)
+ *    (1) flag&1 == 1; (2) wU non-NULL; (3) sy2blk is beta=0.
+ * ==> wU can be aliased wt wS if you don't need correct wS on output
+ */
+#ifdef Conj_
+   #define syrkBlk Mjoin(PATL,umherkBlk)
+   #define syrk_K  Mjoin(PATL,umherk_KLoop)
+   #define syrk  Mjoin(PATL,umherk)
+#else
+   #define syrkBlk Mjoin(PATL,umsyrkBlk)
+   #define syrk_K  Mjoin(PATL,umsyrk_KLoop)
+   #define syrk  Mjoin(PATL,umsyrk)
+#endif
+@SKIP /*#define MEM_DEBUG 1*/
+
+void syrkBlk
+(
+   ipinfo_t *ip,
+   int flag,      /* bitvec: 0: set means C is upper, 1: set TA==AtlasNoTrans*/
+   size_t d,      /* which global diagonal blk of C is being computed */
+   size_t k,      /* which K block of A is being computed */
+   const TYPE *A, /* if non-NULL, base A ptr to copy */
+   const TYPE *B, /* if non-NULL, base A ptr to copy */
+   ablk2tcmat_t blk2c, /* if non-NULL sy storage to tri C storage copy func */
+   const SCALAR beta, /* only needed if blk2c non-NULL */
+   TYPE *C,       /* if blk2c && non-NULL, which C to write to */
+   TYPE *wA,      /* if non-NULL, ip-based A workspace */
+   TYPE *wAn,     /* next A wrkspc to be prefetched */
+   TYPE *wB,      /* if non-NULL ip-based At workspace */
+   TYPE *wBn,     /* next B wrkspc to be prefetched */
+   TYPE *rC,      /* real portion of wC (unused for real routines) */
+   TYPE *wC      /* if non-NULL: ptr to syrk-storage C wrkspc */
+)
+{
+   ATL_CUINT kb = (k != ip->nfkblks) ? ip->kb : ip->kb0;
+   ATL_UINT mb, nb, kbS, nnu, nmu;
+   size_t nfblks = ip->nfnblks;
+   #ifdef TCPLX
+      TYPE *rA, *rB;
+   #endif
+   if (d == nfblks + ip->npnblks - 1)
+   {
+      nb = ip->nF;
+      #ifdef TCPLX
+         if (d < nfblks)
+         {
+            rA = wA + ip->szA;
+            rB = wB + ip->szB;
+         }
+         else
+         {
+            rA = wA + ip->pszA;
+            rB = wB + ip->pszB;
+         }
+      #endif
+   }
+   else if (d < nfblks)
+   {
+      nb = ip->nb;
+      #ifdef TCPLX
+         rA = wA + ip->szA;
+         rB = wB + ip->szB;
+      #endif
+   }
+   else
+   {
+      nb = ip->pnb;
+      #ifdef TCPLX
+         rA = wA + ip->pszA;
+         rB = wB + ip->pszB;
+      #endif
+   }
+/*
+ * calc nmu and nnu. one must be multiple of other
+ */
+   if (ip->mu > ip->nu)
+   {
+      nmu = (nb+ip->mu-1)/ip->mu;
+      nnu = nmu * (ip->mu/ip->nu); /* NU must be multiple of MU */
+   }
+   else
+   {
+      nnu = (nb+ip->nu-1)/ip->nu;
+      nmu = nnu * (ip->nu/ip->mu); /* NU must be multiple of MU */
+   }
+   kbS = ((kb+ip->ku-1)/ip->ku)*ip->ku; /* same as KB0 */
+/*
+ * copy A
+ */
+   if (A)  /* want to copy input array */
+   {
+      A = IdxA_ip(ip, A, d, k);
+      #ifdef TCPLX
+         ip->a2blk(kb, nb, ip->alpA, A, ip->lda, rA, wA);
+      #else
+         ip->a2blk(kb, nb, ip->alpA, A, ip->lda, wA);
+      #endif
+   }
+   if (B)
+   {
+      B = IdxB_ip(ip, B, k, d);
+      #ifdef TCPLX
+         ip->b2blk(kb, nb, ip->alpB, B, ip->ldb, rB, wB);
+      #else
+         ip->b2blk(kb, nb, ip->alpB, B, ip->ldb, wB);
+      #endif
+   }
+   if (wC)  /* want to compute SYRK on this block into wC */
+   {
+      #ifdef TCPLX
+         if (flag&4)
+         {
+            Mjoin(PATL,amsyrkK_b0)(nmu, nnu, kbS, wA, wB, rC, rA, wB, wC);
+            Mjoin(PATL,amsyrkK_b0)(nmu, nnu, kbS, rA, wB, wC, rA, rB, rC);
+         }
+         else
+         {
+            Mjoin(PATL,amsyrkK_bn)(nmu, nnu, kbS, wA, wB, rC, rA, wB, wC);
+            Mjoin(PATL,amsyrkK_b1)(nmu, nnu, kbS, rA, wB, wC, rA, rB, rC);
+         }
+         Mjoin(PATL,amsyrkK_bn)(nmu, nnu, kbS, rA, rB, rC, wA, rB, wC);
+         Mjoin(PATL,amsyrkK_b1)(nmu, nnu, kbS, wA, rB, wC, wA, wB, wC);
+      #else
+         if (flag&4)
+            Mjoin(PATL,amsyrkK_b0)(nmu, nnu, kbS, wA, wB, wC, wA, wB, wC);
+         else
+            Mjoin(PATL,amsyrkK_b1)(nmu, nnu, kbS, wA, wB, wC, wA, wB, wC);
+      #endif
+   }
+   if (blk2c)
+   {
+      const size_t ldc=ip->ldc;
+      #ifdef TCPLX
+         const TYPE *alp = ip->alpC;
+      #else
+         TYPE alp = ip->alpC;
+      #endif
+      if (ip->alpA != ip->alpB)
+         alp = (ip->alpA != ip->alpC) ? ip->alpA : ip->alpB;
+      if (C)
+      {
+         ATL_UINT shVL;
+         for (shVL=0; !(ip->vlen&(1<<shVL)); shVL++) ;
+         C = IdxC_ip(ip, C, d, d);
+         #ifdef TCPLX
+            blk2c(nb, ip->mu, ip->nu, shVL, alp, rC, wC, beta, C, ldc);
+            #ifdef Conj_  /* must zero complex part of diagonal! */
+               Mjoin(PATLU,zero)(nb, C+1, (ldc+1)SHIFT);
+            #endif
+         #else
+            blk2c(nb, ip->mu, ip->nu, shVL, alp, wC, beta, C, ldc);
+         #endif
+      }
+   }
+}
+
+void syrk_K  /* inner-product based syrk/herk loop over K loop */
+(
+   ipinfo_t *ip,
+   int flag,      /* bitvec: 0: set means C is upper, 1: set TA==AtlasNoTrans*/
+   size_t d,      /* which global diagonal blk of C is being computed */
+   const TYPE *A, /* if non-NULL, base A ptr to copy */
+   const TYPE *B, /* if non-NULL, base B ptr to copy */
+   ablk2tcmat_t blk2c, /* if non-NULL sy storage to C storage copy func */
+   const SCALAR beta, /* only needed if blk2c non-NULL */
+   TYPE *C,       /* if blk2c non-NULL, which C to write to, else ignored */
+   TYPE *wA,      /* if non-NULL, ip-based A workspace */
+   TYPE *wB,      /* if non-NULL ip-based At workspace */
+   TYPE *rC,      /* real portion of wC (unused in real routines) */
+   TYPE *wC       /* if non-NULL: ptr to syrk-storage C wrkspc */
+)
+{
+   const size_t nfkblks = ip->nfkblks;
+   size_t k;
+   ATL_UINT szA, szB;
+   if (d < ip->nfnblks)
+   {
+      /*szA = szB = ip->szA;*/
+      szA = ip->szA;
+      szB = ip->szB;
+   }
+   else
+   {
+      szA = ip->pszA;
+      szB = ip->pszB;
+   }
+   #ifdef TCPLX
+      szA += szA;
+      szB += szB;
+   #endif
+/*
+ * For first K block, use beta=0 kernel to init wC
+ */
+   if (nfkblks)
+   {
+      TYPE *wAn=(wA)? wA+szA:NULL, *wBn=(wB) ? wB+szB : NULL;
+      syrkBlk(ip, flag|4, d, 0, A, B, NULL, beta, NULL, wA,wAn, wB,wBn,
+                 rC, wC);
+      wA = wAn;
+      wB = wBn;
+   }
+   else /* this is first & last block! */
+   {
+      syrkBlk(ip, flag|4, d, 0, A, B, blk2c, beta, C, wA, wA, wB, wB,
+                rC, wC);
+      return;
+   }
+/*
+ * Handle all blocks except first (handled above) & last (handled below)
+ */
+   for (k=1; k < nfkblks; k++)
+   {
+      TYPE *wAn=(wA)? wA+szA:NULL, *wBn=(wB) ? wB+szB : NULL;
+      syrkBlk(ip, flag, d, k, A, B, NULL, beta, NULL, wA, wAn, wB, wBn,
+                rC, wC);
+      wA = wAn;
+      wB = wBn;
+   }
+/*
+ * Last block actually writes to C
+ */
+   syrkBlk(ip, flag, d, k, A, B, blk2c, beta, C, wA,wA, wB,wB, rC,wC);
+}
+
+int syrk
+(
+   const enum ATLAS_UPLO  Uplo,
+   const enum ATLAS_TRANS TA,
+   ATL_CSZT  N,
+   ATL_CSZT K,
+   #ifdef Conj_
+   const TYPE ralpha,
+   #else
+   const SCALAR alpha,
+   #endif
+   const TYPE *A,
+   ATL_CSZT lda,
+   #ifdef Conj_
+   const TYPE rbeta,
+   #else
+   const SCALAR beta,
+   #endif
+   TYPE *C,
+   ATL_CSZT ldc
+)
+{
+   size_t sz, szA, szB, szC, szS, nnblks, extra;
+   void *vp=NULL;
+   TYPE *wA, *wB, *wC, *wS, *wCs, *rC, *rCs, *rS;
+   double timG;
+   int nb, nbS, flg, idx;
+   int k, ierr;
+   ablk2cmat_t blk2c;
+   ablk2tcmat_t blk2sy;
+   ipinfo_t ip;
+   #ifdef Conj_
+      TYPE alpha[2]={ralpha, ATL_rzero}, beta[2]={rbeta, ATL_rzero};
+      const enum ATLAS_TRANS TB=(TA==AtlasNoTrans)?AtlasConjTrans:AtlasNoTrans;
+   #else
+      const enum ATLAS_TRANS TB = (TA==AtlasNoTrans) ? AtlasTrans:AtlasNoTrans;
+   #endif
+#ifdef MEM_DEBUG
+   void *vA=NULL, *vB=NULL, *vC=NULL;
+#endif
+   Mjoin(PATL,ipmenUMInfo)(&ip, TA, TB, N,N,K, lda, lda, ldc, alpha, beta);
+   nb = (ip.nfnblks) ? ip.nb : ip.pnb;
+   nnblks = ip.nfnblks + ip.npnblks;
+/*
+ * Main idea:
+ * 1. with syrk+gemm of full blks, syrk can always reuse the workspace of gemm
+ *    no need to allocate extra space for syrk
+ * 2. syrk only: need to allocate only considering the syrk
+ */
+/*
+ * Need space for only one column-panel of At
+ */
+   szB = ip.nfnblks ? ip.szA : ip.pszA;
+   szB *= (ip.nfkblks+1);
+/*
+ * space calc for single syrk block
+ */
+   if (nnblks == 1)    /* single blk in n-dimension: syrk only*/
+   {
+      int smnu=(ip.mu > ip.nu)?ip.mu:ip.nu; /* max of mu, nu*/
+      nbS = (nb+smnu-1)/smnu;
+      szC = ((nbS+1)*nbS)>>1;
+      nbS *= smnu;
+/*
+ *    considering mu and nu as one is multiple of other, the size of subblock
+ *    is smnu*smnu (rounded with ku).
+ */
+      szC *= ((smnu*smnu+ip.ku-1)/ip.ku)*ip.ku;
+      szS =  ((ip.kb+ip.ku-1)/ip.ku)*ip.ku;
+      szA = nbS * szS * (ip.nfkblks + 1);
+      extra = (smnu+smnu)*smnu;  /* may not need */
+   }
+   else
+   {
+/*
+ *    A needs entire matrix minus one row/col panel
+ */
+      szA = szB * (ip.nfnblks + ip.npnblks - 1);
+      szC = ip.szC;
+      extra = ip.exsz;
+   }
+@BEGINSKIP
+#ifdef MEM_DEBUG
+/*
+ * DEBUG: to debug, I allocate memory individually.... so that I can use
+ * valgrind to find out of memory access error
+ */
+   sz = ATL_MulBySize(szA) + 2*ATL_Cachelen;
+   if (sz < ATL_MaxMalloc)
+      vA = malloc(sz);
+   if (!vA)
+      return(1);  /* keep recurring, can't malloc space! */
+   wA = ATL_AlignPtr(vA);
+
+   sz = ATL_MulBySize(szB) + 2*ATL_Cachelen;
+   if (sz < ATL_MaxMalloc)
+      vB = malloc(sz);
+   if (!vB)
+      return(1);  /* keep recurring, can't malloc space! */
+   wB = ATL_AlignPtr(vB);
+
+   sz = ATL_MulBySize(szC + extra) + 2*ATL_Cachelen;
+   if (sz < ATL_MaxMalloc)
+      vC = malloc(sz);
+   if (!vC)
+      return(1);  /* keep recurring, can't malloc space! */
+   wC = ATL_AlignPtr(vC);
+#else
+@ENDSKIP
+/*
+ * use it for timing to reduce mulitple malloc.
+ */
+   sz = ATL_MulBySize(szC + szA+szB + extra) + 5*ATL_Cachelen;
+   if (sz < ATL_MaxMalloc)
+      vp = malloc(sz);
+   if (!vp)
+      return(1);  /* keep recurring, can't malloc space! */
+   wA = ATL_AlignPtr(vp);
+   wB = wA + (szA SHIFT);
+   wB = ATL_AlignPtr(wB);
+   wC = wB + (szB SHIFT);
+   wC = ATL_AlignPtr(wC);
+@SKIP #endif
+   #ifdef TCPLX
+      rC = wC + szC;
+   #else
+      rC = wC;
+   #endif
+/*
+ * ============================================================================
+ * First, we compute diagonals of C, and in the process we will copy A/A^T
+ * for use in computing non-diaginal blocks using inner-product amm.
+ * ============================================================================
+ */
+   flg = (TA == AtlasNoTrans) ? 2 : 0;
+/*
+ * NOTE: alpha may be already applied on A-copy. So, use ip.alpC instead of
+ * alpha to select appropriate copy routines
+ */
+   if (Uplo == AtlasLower)
+   {
+      if (SCALAR_IS_ONE(beta))
+      {
+         if (SCALAR_IS_NONE(ip.alpC))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNb1);
+         else
+            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+                     Mjoin(PATL,SyrkIntoC_a1b1):Mjoin(PATL,SyrkIntoC_aXb1);
+      }
+      else if (SCALAR_IS_NONE(beta))
+      {
+         if (SCALAR_IS_NONE(ip.alpC))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNbN);
+         else
+            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+                     Mjoin(PATL,SyrkIntoC_a1bN):Mjoin(PATL,SyrkIntoC_aXbN);
+      }
+      else if (SCALAR_IS_ZERO(beta))
+      {
+         if (SCALAR_IS_NONE(ip.alpC))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNb0);
+         else
+            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+                     Mjoin(PATL,SyrkIntoC_a1b0):Mjoin(PATL,SyrkIntoC_aXb0);
+      }
+      else
+      {
+         if (SCALAR_IS_NONE(ip.alpC))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNbX);
+         else
+            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+                     Mjoin(PATL,SyrkIntoC_a1bX):Mjoin(PATL,SyrkIntoC_aXbX);
+      }
+   }
+   else
+   {
+      if (SCALAR_IS_ONE(beta))
+      {
+         if (SCALAR_IS_NONE(ip.alpC))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNb1_L2UT);
+         else
+            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+                     Mjoin(PATL,SyrkIntoC_a1b1_L2UT)
+                     :Mjoin(PATL,SyrkIntoC_aXb1_L2UT);
+      }
+      else if (SCALAR_IS_NONE(beta))
+      {
+         if (SCALAR_IS_NONE(ip.alpC))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNbN_L2UT);
+         else
+            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+                     Mjoin(PATL,SyrkIntoC_a1bN_L2UT)
+                     :Mjoin(PATL,SyrkIntoC_aXbN_L2UT);
+      }
+      else if (SCALAR_IS_ZERO(beta))
+      {
+         if (SCALAR_IS_NONE(ip.alpC))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNb0_L2UT);
+         else
+            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+                     Mjoin(PATL,SyrkIntoC_a1b0_L2UT)
+                     :Mjoin(PATL,SyrkIntoC_aXb0_L2UT);
+      }
+      else
+      {
+         if (SCALAR_IS_NONE(ip.alpC))
+            blk2sy = Mjoin(PATL,SyrkIntoC_aNbX_L2UT);
+         else
+            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+                     Mjoin(PATL,SyrkIntoC_a1bX_L2UT)
+                     :Mjoin(PATL,SyrkIntoC_aXbX_L2UT);
+      }
+   }
+/*
+ * syrk-upper
+ */
+   if (Uplo == AtlasUpper)
+   {
+      flg |= 1;
+/*
+ *    1st syrk: copies both formats, no reuse
+ */
+      syrk_K(&ip, flg, 0, A, A, blk2sy, beta, C, wB, wA, rC, wC);
+      if (N > nb)
+      {
+         const size_t incC = nb*((ldc+1)SHIFT);
+         size_t i;
+/*
+ *       Compute all C blks within this rowpan of C, copies B (At), reuse A
+ */
+         blk2c = ip.blk2c;
+         Mjoin(PATL,iploopsNK)(&ip, 0, 1, NULL, A, C, 11, wB, wA, rC, wC,
+                               beta, blk2c);
+/*
+ *       Loop over all col-pans of C, excepting first & last;
+ *       A already fully copied, B will be copied by syrk_Kloop call.
+ */
+         for (i=1; i < nnblks-1; i++)
+         {
+/*
+ *          syrk copies A and reuses B copy
+ */
+            syrk_K(&ip, flg, i, A, NULL, blk2sy, beta, C, wB, wA,
+                          rC, wC);
+            wA += szB SHIFT;
+/*
+ *          gemm can reuse both the copies
+ */
+            Mjoin(PATL,iploopsNK)(&ip, i, i+1, NULL, NULL, C+i*(nb SHIFT), 11,
+                                  wB, wA, rC, wC, beta, blk2c);
+         }
+/*
+ *       Last colpan is only 1 diag blk
+ */
+         syrk_K(&ip, flg, i, A, NULL, blk2sy, beta, C, wB, wA,
+                       rC, wC);
+      }
+   }
+/*
+ * Lower doesn't need to copy first row panel of A or last col panel of At
+ * to GEMM storage.  If C only block, should call syrk_IP instead!
+ */
+   else
+   {
+      const size_t incC = (ldc SHIFT) * nb;
+      size_t j;
+      TYPE *c;
+/*
+ *    Compute first diag block, copies both
+ */
+      syrk_K(&ip, flg, 0, A, A, blk2sy, beta, C, wA, wB, rC, wC);
+      if (N > nb)
+      {
+/*
+ *       Compute all C blks within this colpan of C, copying rest of A, reuse B
+ */
+         blk2c = ip.blk2c;
+         Mjoin(PATL,iploopsMK)(&ip, 1, 0, A, NULL, C, 7, wA, wB, rC, wC,
+                               beta, blk2c);
+/*
+ *       Loop over all col-pans of C, excepting first & last;
+ *       A already fully copied, B will be copied by syrk_Kloop call.
+ */
+         c = C + incC;
+         for (j=1; j < nnblks-1; j++)
+         {
+/*
+ *          syrk reuse A and copies B
+ */
+            syrk_K(&ip, flg, j, NULL, A, blk2sy, beta, C, wA, wB,
+                          rC, wC);
+            wA += szB SHIFT;
+/*
+ *          gemm reuses both the copies
+ */
+            Mjoin(PATL,iploopsMK)(&ip, j+1, j, NULL, NULL, c, 7, wA, wB, rC, wC,
+                                  beta, blk2c);
+            c += incC;
+         }
+/*
+ *       Last colpan is only 1 diag blk, still reuses A
+ */
+         syrk_K(&ip, flg, j, NULL, A, blk2sy, beta, C, wA, wB,
+                       rC, wC);
+      }
+   }
+#ifdef MEM_DEBUG
+   free(vA);
+   free(vB);
+   free(vC);
+#else
+   free(vp);
+#endif
+   return(0);
+}
 @ROUT ATL_syrk
 @extract -b @(topd)/cw.inc lang=C -def cwdate 2016
 #include "atlas_misc.h"

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -1402,6 +1402,7 @@ void syrk_K  /* inner-product based syrk/herk loop over K loop */
 
 int syrk
 (
+   ipinfo_t *ip,
    const enum ATLAS_UPLO  Uplo,
    const enum ATLAS_TRANS TA,
    ATL_CSZT  N,
@@ -1430,18 +1431,17 @@ int syrk
    int ierr;
    cm2am_t sy2blk;
    ablk2cmat_t blk2sy, blk2c;
-   ipinfo_t ip;
    #ifdef Conj_
       TYPE alpha[2]={ralpha, ATL_rzero}, beta[2]={rbeta, ATL_rzero};
       const enum ATLAS_TRANS TB=(TA==AtlasNoTrans)?AtlasConjTrans:AtlasNoTrans;
    #else
       const enum ATLAS_TRANS TB = (TA==AtlasNoTrans) ? AtlasTrans:AtlasNoTrans;
    #endif
-   Mjoin(PATL,ipmenInfo)(&ip, TA, TB, N,N,K, lda, lda, ldc, alpha, beta);
+   /*Mjoin(PATL,ipmenInfo)(&ip, TA, TB, N,N,K, lda, lda, ldc, alpha, beta);*/
    #if 0
    printf("D=(%u,%u), B=(%u,%u,%u), b=(%u,%u,%u), nB=(%u,%u,%u)\n",
           (unsigned int)N,(unsigned int)K, ip.mb, ip.nb, ip.kb,
-          ip.pmb, ip.pnb, ip.kb0, ip.nfmblks, ip.nfnblks, ip.nfkblks);
+          ip->pmb, ip->pnb, ip->kb0, ip->nfmblks, ip->nfnblks, ip->nfkblks);
    #endif
 /*
  * Will eventually need syrk timed for all square blocks to select best case.
@@ -1450,23 +1450,23 @@ int syrk
 /*
  * Need space for only one column-panel of At
  */
-   szB = ip.nfnblks ? ip.szA : ip.pszA;
-   szB *= (ip.nfkblks+1);
+   szB = ip->nfnblks ? ip->szA : ip->pszA;
+   szB *= (ip->nfkblks+1);
 /*
  * A needs entire matrix minus one row/col panel
  */
-   szA = szB * (ip.nfnblks + ip.npnblks - 1);
-   nb = (ip.nfnblks) ? ip.nb : ip.pnb;
+   szA = szB * (ip->nfnblks + ip->npnblks - 1);
+   nb = (ip->nfnblks) ? ip->nb : ip->pnb;
    nbS = (nb+ATL_SYRKK_NU-1)/ATL_SYRKK_NU;
    szC = ((nbS+1)*nbS)>>1;  /* only need lower tri blks, not full nnu*nnu */
    nbS *= ATL_SYRKK_NU;
    szC *= ((ATL_SYRKK_NU*ATL_SYRKK_NU+ATL_SYRKK_VLEN-1)/ATL_SYRKK_VLEN)
           * ATL_SYRKK_VLEN;
-   extra = ip.exsz;
+   extra = ip->exsz;
    extra = Mmax(extra, (ATL_SYRKK_NU+ATL_SYRKK_NU)*ATL_SYRKK_NU);
-   szS = ((ip.kb + ATL_SYRKK_KU-1)/ATL_SYRKK_KU)*ATL_SYRKK_KU;
+   szS = ((ip->kb + ATL_SYRKK_KU-1)/ATL_SYRKK_KU)*ATL_SYRKK_KU;
    szS *= nbS;
-   sz = Mmax(ip.szC,szC);
+   sz = Mmax(ip->szC,szC);
    sz = ATL_MulBySize(sz + szS + szA+szB + extra) + 5*ATL_Cachelen;
    if (sz < ATL_MaxMalloc)
       vp = malloc(sz);
@@ -1483,7 +1483,7 @@ int syrk
       wA = NULL;
    wCs = wC;
    #ifdef TCPLX
-      rC = wC + ip.szC;
+      rC = wC + ip->szC;
       rCs = wC + szC;
       rS = wS + szS;
    #else
@@ -1572,7 +1572,7 @@ int syrk
                      :Mjoin(PATL,SyrkIntoC_aXbX_L2UT);
       }
    }
-   nnblks = ip.nfnblks + ip.npnblks;
+   nnblks = ip->nfnblks + ip->npnblks;
    flg = (TA == AtlasNoTrans) ? 2 : 0;
 /*
  * Upper doesn't need to copy first row panel of A or last col panel of At
@@ -1581,7 +1581,7 @@ int syrk
    if (Uplo == AtlasUpper)
    {
       flg |= 1;
-      syrk_K(&ip, flg, 0, A, sy2blk, blk2sy, beta, C, rS, wS, wB, NULL,
+      syrk_K(ip, flg, 0, A, sy2blk, blk2sy, beta, C, rS, wS, wB, NULL,
              rCs, wC, wCs);
       if (N > nb)
       {
@@ -1590,8 +1590,8 @@ int syrk
 /*
  *       Compute all C blks within this rowpan of C, copy rest of At
  */
-         blk2c = ip.blk2c;
-         Mjoin(PATL,iploopsNK)(&ip, 0, 1, NULL, A, C, 11, wB, wA, rC, wC,
+         blk2c = ip->blk2c;
+         Mjoin(PATL,iploopsNK)(ip, 0, 1, NULL, A, C, 11, wB, wA, rC, wC,
                                beta, blk2c);
 /*
  *       Loop over all col-pans of C, excepting first & last;
@@ -1599,16 +1599,16 @@ int syrk
  */
          for (i=1; i < nnblks-1; i++)
          {
-            syrk_K(&ip, flg, i, A, sy2blk, blk2sy, beta, C, rS, wS, wB, NULL,
+            syrk_K(ip, flg, i, A, sy2blk, blk2sy, beta, C, rS, wS, wB, NULL,
                    rCs, wC, wCs);
             wA += szB SHIFT;
-            Mjoin(PATL,iploopsNK)(&ip, i, i+1, NULL, NULL, C+i*(nb SHIFT), 11,
+            Mjoin(PATL,iploopsNK)(ip, i, i+1, NULL, NULL, C+i*(nb SHIFT), 11,
                                   wB, wA, rC, wC, beta, blk2c);
          }
 /*
  *       Last colpan is only 1 diag blk, so don't copy A or B for gemm
  */
-         syrk_K(&ip, flg, i, A, sy2blk, blk2sy, beta, C, rS, wS, NULL, NULL,
+         syrk_K(ip, flg, i, A, sy2blk, blk2sy, beta, C, rS, wS, NULL, NULL,
                 rCs, wC, wCs);
       }
    }
@@ -1625,15 +1625,15 @@ int syrk
  *    Compute first diag block, copying At to wB for use by all of this colpan
  *    of C's gemm computation
  */
-      syrk_K(&ip, flg, 0, A, sy2blk, blk2sy, beta, C, rS, wS, NULL, wB,
+      syrk_K(ip, flg, 0, A, sy2blk, blk2sy, beta, C, rS, wS, NULL, wB,
              rCs, wC, wCs);
       if (N > nb)
       {
 /*
  *       Compute all C blks within this colpan of C, copying rest of A
  */
-         blk2c = ip.blk2c;
-         Mjoin(PATL,iploopsMK)(&ip, 1, 0, A, NULL, C, 7, wA, wB, rC, wC,
+         blk2c = ip->blk2c;
+         Mjoin(PATL,iploopsMK)(ip, 1, 0, A, NULL, C, 7, wA, wB, rC, wC,
                                beta, blk2c);
 /*
  *       Loop over all col-pans of C, excepting first & last;
@@ -1642,17 +1642,17 @@ int syrk
          c = C + incC;
          for (j=1; j < nnblks-1; j++)
          {
-            syrk_K(&ip, flg, j, A, sy2blk, blk2sy, beta, C, rS, wS,
+            syrk_K(ip, flg, j, A, sy2blk, blk2sy, beta, C, rS, wS,
                    NULL, wB, rCs, wC, wCs);
             wA += szB SHIFT;
-            Mjoin(PATL,iploopsMK)(&ip, j+1, j, NULL, NULL, c, 7, wA, wB, rC, wC,
+            Mjoin(PATL,iploopsMK)(ip, j+1, j, NULL, NULL, c, 7, wA, wB, rC, wC,
                                   beta, blk2c);
             c += incC;
          }
 /*
  *       Last colpan is only 1 diag blk, so don't copy A or B for gemm
  */
-         syrk_K(&ip, flg, j, A, sy2blk, blk2sy, beta, C, rS, wS,
+         syrk_K(ip, flg, j, A, sy2blk, blk2sy, beta, C, rS, wS,
                 NULL, NULL, rCs, wC, wCs);
       }
    }
@@ -1921,6 +1921,7 @@ void syrk_K  /* inner-product based syrk/herk loop over K loop */
 
 int syrk
 (
+   ipinfo_t *ip,
    const enum ATLAS_UPLO  Uplo,
    const enum ATLAS_TRANS TA,
    ATL_CSZT  N,
@@ -1953,7 +1954,6 @@ int syrk
 @ROUT ATL_umsyrk             
    ablk2cmat_t blk2sy, blk2c;
 @ROUT ATL_umsyrk ATL_ursyrk
-   ipinfo_t ip;
    #ifdef Conj_
       TYPE alpha[2]={ralpha, ATL_rzero}, beta[2]={rbeta, ATL_rzero};
       const enum ATLAS_TRANS TB=(TA==AtlasNoTrans)?AtlasConjTrans:AtlasNoTrans;
@@ -1969,9 +1969,9 @@ int syrk
    void *vA=NULL, *vB=NULL, *vC=NULL;
 #endif
 @ENDSKIP
-   Mjoin(PATL,ipmenUMInfo)(&ip, TA, TB, N,N,K, lda, lda, ldc, alpha, beta);
-   nb = (ip.nfnblks) ? ip.nb : ip.pnb;
-   nnblks = ip.nfnblks + ip.npnblks;
+   /*Mjoin(PATL,ipmenUMInfo)(&ip, TA, TB, N,N,K, lda, lda, ldc, alpha, beta);*/
+   nb = (ip->nfnblks) ? ip->nb : ip->pnb;
+   nnblks = ip->nfnblks + ip->npnblks;
 /*
  * Main idea:
  * 1. with syrk+gemm of full blks, syrk can always reuse the workspace of gemm
@@ -1981,14 +1981,14 @@ int syrk
 /*
  * Need space for only one column-panel of At
  */
-   szB = ip.nfnblks ? ip.szA : ip.pszA;
-   szB *= (ip.nfkblks+1);
+   szB = ip->nfnblks ? ip->szA : ip->pszA;
+   szB *= (ip->nfkblks+1);
 /*
  * space calc for single syrk block
  */
    if (nnblks == 1)    /* single blk in n-dimension: syrk only*/
    {
-      int smnu=(ip.mu > ip.nu)?ip.mu:ip.nu; /* max of mu, nu*/
+      int smnu=(ip->mu > ip->nu)?ip->mu:ip->nu; /* max of mu, nu*/
       nbS = (nb+smnu-1)/smnu;
       szC = ((nbS+1)*nbS)>>1;
       nbS *= smnu;
@@ -1996,9 +1996,9 @@ int syrk
  *    considering mu and nu as one is multiple of other, the size of subblock
  *    is smnu*smnu (rounded with ku).
  */
-      szC *= ((smnu*smnu+ip.ku-1)/ip.ku)*ip.ku;
-      szS =  ((ip.kb+ip.ku-1)/ip.ku)*ip.ku;
-      szA = nbS * szS * (ip.nfkblks + 1);
+      szC *= ((smnu*smnu+ip->ku-1)/ip->ku)*ip->ku;
+      szS =  ((ip->kb+ip->ku-1)/ip->ku)*ip->ku;
+      szA = nbS * szS * (ip->nfkblks + 1);
       extra = (smnu+smnu)*smnu;  /* may not need */
    }
    else
@@ -2006,9 +2006,9 @@ int syrk
 /*
  *    A needs entire matrix minus one row/col panel
  */
-      szA = szB * (ip.nfnblks + ip.npnblks - 1);
-      szC = ip.szC;
-      extra = ip.exsz;
+      szA = szB * (ip->nfnblks + ip->npnblks - 1);
+      szC = ip->szC;
+      extra = ip->exsz;
    }
 @BEGINSKIP 
 #ifdef MEM_DEBUG
@@ -2065,41 +2065,41 @@ int syrk
  */
    flg = (TA == AtlasNoTrans) ? 2 : 0;
 /*
- * NOTE: alpha may be already applied on A-copy. So, use ip.alpC instead of
+ * NOTE: alpha may be already applied on A-copy. So, use ip->alpC instead of
  * alpha to select appropriate copy routines
  */
    if (Uplo == AtlasLower)
    {
       if (SCALAR_IS_ONE(beta))
       {
-         if (SCALAR_IS_NONE(ip.alpC))
+         if (SCALAR_IS_NONE(ip->alpC))
             blk2sy = Mjoin(PATL,SyrkIntoC_aNb1);
          else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+            blk2sy = SCALAR_IS_ONE(ip->alpC) ?
                      Mjoin(PATL,SyrkIntoC_a1b1):Mjoin(PATL,SyrkIntoC_aXb1);
       }
       else if (SCALAR_IS_NONE(beta))
       {
-         if (SCALAR_IS_NONE(ip.alpC))
+         if (SCALAR_IS_NONE(ip->alpC))
             blk2sy = Mjoin(PATL,SyrkIntoC_aNbN);
          else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+            blk2sy = SCALAR_IS_ONE(ip->alpC) ?
                      Mjoin(PATL,SyrkIntoC_a1bN):Mjoin(PATL,SyrkIntoC_aXbN);
       }
       else if (SCALAR_IS_ZERO(beta))
       {
-         if (SCALAR_IS_NONE(ip.alpC))
+         if (SCALAR_IS_NONE(ip->alpC))
             blk2sy = Mjoin(PATL,SyrkIntoC_aNb0);
          else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+            blk2sy = SCALAR_IS_ONE(ip->alpC) ?
                      Mjoin(PATL,SyrkIntoC_a1b0):Mjoin(PATL,SyrkIntoC_aXb0);
       }
       else
       {
-         if (SCALAR_IS_NONE(ip.alpC))
+         if (SCALAR_IS_NONE(ip->alpC))
             blk2sy = Mjoin(PATL,SyrkIntoC_aNbX);
          else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+            blk2sy = SCALAR_IS_ONE(ip->alpC) ?
                      Mjoin(PATL,SyrkIntoC_a1bX):Mjoin(PATL,SyrkIntoC_aXbX);
       }
    }
@@ -2107,37 +2107,37 @@ int syrk
    {
       if (SCALAR_IS_ONE(beta))
       {
-         if (SCALAR_IS_NONE(ip.alpC))
+         if (SCALAR_IS_NONE(ip->alpC))
             blk2sy = Mjoin(PATL,SyrkIntoC_aNb1_L2UT);
          else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+            blk2sy = SCALAR_IS_ONE(ip->alpC) ?
                      Mjoin(PATL,SyrkIntoC_a1b1_L2UT)
                      :Mjoin(PATL,SyrkIntoC_aXb1_L2UT);
       }
       else if (SCALAR_IS_NONE(beta))
       {
-         if (SCALAR_IS_NONE(ip.alpC))
+         if (SCALAR_IS_NONE(ip->alpC))
             blk2sy = Mjoin(PATL,SyrkIntoC_aNbN_L2UT);
          else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+            blk2sy = SCALAR_IS_ONE(ip->alpC) ?
                      Mjoin(PATL,SyrkIntoC_a1bN_L2UT)
                      :Mjoin(PATL,SyrkIntoC_aXbN_L2UT);
       }
       else if (SCALAR_IS_ZERO(beta))
       {
-         if (SCALAR_IS_NONE(ip.alpC))
+         if (SCALAR_IS_NONE(ip->alpC))
             blk2sy = Mjoin(PATL,SyrkIntoC_aNb0_L2UT);
          else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+            blk2sy = SCALAR_IS_ONE(ip->alpC) ?
                      Mjoin(PATL,SyrkIntoC_a1b0_L2UT)
                      :Mjoin(PATL,SyrkIntoC_aXb0_L2UT);
       }
       else
       {
-         if (SCALAR_IS_NONE(ip.alpC))
+         if (SCALAR_IS_NONE(ip->alpC))
             blk2sy = Mjoin(PATL,SyrkIntoC_aNbX_L2UT);
          else
-            blk2sy = SCALAR_IS_ONE(ip.alpC) ?
+            blk2sy = SCALAR_IS_ONE(ip->alpC) ?
                      Mjoin(PATL,SyrkIntoC_a1bX_L2UT)
                      :Mjoin(PATL,SyrkIntoC_aXbX_L2UT);
       }
@@ -2151,7 +2151,7 @@ int syrk
 /*
  *    1st syrk: copies both formats, no reuse
  */
-      syrk_K(&ip, flg, 0, A, A, blk2sy, beta, C, wB, wA, rC, wC);
+      syrk_K(ip, flg, 0, A, A, blk2sy, beta, C, wB, wA, rC, wC);
       if (N > nb)
       {
          const size_t incC = nb*((ldc+1)SHIFT);
@@ -2159,8 +2159,8 @@ int syrk
 /*
  *       Compute all C blks within this rowpan of C, copies B (At), reuse A
  */
-         blk2c = ip.blk2c;
-         Mjoin(PATL,iploopsNK)(&ip, 0, 1, NULL, A, C, 11, wB, wA, rC, wC,
+         blk2c = ip->blk2c;
+         Mjoin(PATL,iploopsNK)(ip, 0, 1, NULL, A, C, 11, wB, wA, rC, wC,
                                beta, blk2c);
 /*
  *       Loop over all col-pans of C, excepting first & last;
@@ -2171,19 +2171,19 @@ int syrk
 /*
  *          syrk copies A and reuses B copy
  */
-            syrk_K(&ip, flg, i, A, NULL, blk2sy, beta, C, wB, wA,
+            syrk_K(ip, flg, i, A, NULL, blk2sy, beta, C, wB, wA,
                           rC, wC);
             wA += szB SHIFT;
 /*
  *          gemm can reuse both the copies
  */
-            Mjoin(PATL,iploopsNK)(&ip, i, i+1, NULL, NULL, C+i*(nb SHIFT), 11,
+            Mjoin(PATL,iploopsNK)(ip, i, i+1, NULL, NULL, C+i*(nb SHIFT), 11,
                                   wB, wA, rC, wC, beta, blk2c);
          }
 /*
  *       Last colpan is only 1 diag blk
  */
-         syrk_K(&ip, flg, i, A, NULL, blk2sy, beta, C, wB, wA,
+         syrk_K(ip, flg, i, A, NULL, blk2sy, beta, C, wB, wA,
                        rC, wC);
       }
    }
@@ -2199,14 +2199,14 @@ int syrk
 /*
  *    Compute first diag block, copies both
  */
-      syrk_K(&ip, flg, 0, A, A, blk2sy, beta, C, wA, wB, rC, wC);
+      syrk_K(ip, flg, 0, A, A, blk2sy, beta, C, wA, wB, rC, wC);
       if (N > nb)
       {
 /*
  *       Compute all C blks within this colpan of C, copying rest of A, reuse B
  */
-         blk2c = ip.blk2c;
-         Mjoin(PATL,iploopsMK)(&ip, 1, 0, A, NULL, C, 7, wA, wB, rC, wC,
+         blk2c = ip->blk2c;
+         Mjoin(PATL,iploopsMK)(ip, 1, 0, A, NULL, C, 7, wA, wB, rC, wC,
                                beta, blk2c);
 /*
  *       Loop over all col-pans of C, excepting first & last;
@@ -2218,20 +2218,20 @@ int syrk
 /*
  *          syrk reuse A and copies B
  */
-            syrk_K(&ip, flg, j, NULL, A, blk2sy, beta, C, wA, wB,
+            syrk_K(ip, flg, j, NULL, A, blk2sy, beta, C, wA, wB,
                           rC, wC);
             wA += szB SHIFT;
 /*
  *          gemm reuses both the copies
  */
-            Mjoin(PATL,iploopsMK)(&ip, j+1, j, NULL, NULL, c, 7, wA, wB, rC, wC,
+            Mjoin(PATL,iploopsMK)(ip, j+1, j, NULL, NULL, c, 7, wA, wB, rC, wC,
                                   beta, blk2c);
             c += incC;
          }
 /*
  *       Last colpan is only 1 diag blk, still reuses A
  */
-         syrk_K(&ip, flg, j, NULL, A, blk2sy, beta, C, wA, wB,
+         syrk_K(ip, flg, j, NULL, A, blk2sy, beta, C, wA, wB,
                        rC, wC);
       }
    }
@@ -2498,12 +2498,14 @@ int syrk_amm
  * amm_syrkPerf.h.  
  */
 #if 1  /* apply umsyrk*/ 
+   Mjoin(PATL,ipmenUMInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta); 
    #ifdef Conj_
       ierr = umsyrk(Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
    #else
       ierr = umsyrk(Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
    #endif
 #else /* sqsyrk */
+   Mjoin(PATL,ipmenInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta); 
    #ifdef Conj_
       ierr = sqsyrk(Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
    #else

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -2259,8 +2259,8 @@ int syrk
 #include "atlas_level1.h"
 #include "atlas_level2.h"
 #include "atlas_level3.h"
-#include Mstr(Mjoin(ATLAS_UPR,amm_kern.h))
 #include Mstr(Mjoin(ATLAS_PRE,sysinfo.h))
+#include Mstr(Mjoin(ATLAS_UPR,amm_kern.h))
 #include Mstr(Mjoin(ATLAS_PRE,opgen_view.h))
 @SKIP #include Mstr(Mjoin(ATLAS_PRE,amm_syrk.h))
 #include Mstr(Mjoin(ATLAS_PRE,amm_sqsyrk.h))
@@ -2640,6 +2640,7 @@ void SYRK
 #include "atlas_level1.h"
 #include "atlas_level2.h"
 #include Mstr(Mjoin(ATLAS_PRE,sysinfo.h))
+#include Mstr(Mjoin(ATLAS_UPR,amm_kern.h))
 @SKIP #include Mstr(Mjoin(ATLAS_PRE,amm_syrk.h))
 #include Mstr(Mjoin(ATLAS_PRE,amm_sqsyrk.h))
 #include Mstr(Mjoin(ATLAS_PRE,amm_ursyrk.h))
@@ -3396,9 +3397,8 @@ int opursyrk
       for (j=1; j < nnblks-1; j++)
       {
 /*
- *       ****** big idea:
- *       1. Resue A from previous wA calculated in oploopsM last time.
- *          After the first call of oploopsM the whole wA is populated
+ *       1. Reuse A from previous wA calculated in oploopsM last time.
+ *          After the first call of oploopsM, the whole wA is populated
  *       2. compute wB which can be reused in subsequent oploopsM
  */
          ursyrkBlk(op, j, NULL, A, blk2sy, C, wA,wA, wB,wB, rC, wC);

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -1668,7 +1668,8 @@ int syrk
 #include "atlas_level3.h"
 #include Mstr(Mjoin(ATLAS_PRE,sysinfo.h))
 #include Mstr(Mjoin(ATLAS_PRE,opgen_view.h))
-#include Mstr(Mjoin(ATLAS_PRE,amm_umsyrk.h))
+@ROUT ATL_ursyrk `#include Mstr(Mjoin(ATLAS_PRE,amm_ursyrk.h))` 
+@ROUT ATL_umsyrk `#include Mstr(Mjoin(ATLAS_PRE,amm_umsyrk.h))` 
 /*
  * Service routine, particularly for parallel.  Takes its blocking from ip
  * (assuming that is what is being used below diagonal blocks
@@ -2497,20 +2498,45 @@ int syrk_amm
  * We will decide between sqsyrk and umsyrk based on the pref data from 
  * amm_syrkPerf.h.  
  */
-#if 1  /* apply umsyrk*/ 
-   Mjoin(PATL,ipmenUMInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta); 
-   #ifdef Conj_
-      ierr = umsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
-   #else
-      ierr = umsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
+#if 1
+   #if 1  /* apply umsyrk*/ 
+      Mjoin(PATL,ipmenUMInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta); 
+      #ifdef Conj_
+         ierr = umsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
+      #else
+         ierr = umsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
+      #endif
+   #else /* sqsyrk */
+      Mjoin(PATL,ipmenInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta); 
+      #ifdef Conj_
+         ierr = sqsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
+      #else
+         ierr = sqsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
+      #endif
    #endif
-#else /* sqsyrk */
-   Mjoin(PATL,ipmenInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta); 
-   #ifdef Conj_
-      ierr = sqsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
-   #else
-      ierr = sqsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
-   #endif
+#else
+/*
+ * applying ursyrk code
+ * FIXME: need extra checking for kvec:
+ *        ipmen.vlen == ATL_URSYRK_VLEN 
+ *          && ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(ipmen.idxK) == ATL_URSYRK_KVEC 
+ */
+      Mjoin(PATL,ipmenInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta);
+      if (ipmen.mu == ATL_URSYRK_MU && ipmen.nu == ATL_URSYRK_NU 
+            && ipmen.ku == ATL_URSYRK_KU)
+      #ifdef Conj_
+         ierr = ursyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
+      #else
+         ierr = ursyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
+      #endif
+      else
+      #ifdef Conj_
+         ierr = sqsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
+      #else
+         ierr = sqsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
+      #endif
+
+
 #endif
    return(ierr);
 }

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -2242,13 +2242,15 @@ int syrk
                        rC, wC);
       }
    }
+@BEGINSKIP
 #ifdef MEM_DEBUG
    free(vA);
    free(vB);
    free(vC);
 #else
+@ENDSKIP
    free(vp);
-#endif
+@SKIP #endif
    return(0);
 }
 @ROUT ATL_syrk

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -2259,6 +2259,7 @@ int syrk
 #include "atlas_level1.h"
 #include "atlas_level2.h"
 #include "atlas_level3.h"
+#include Mstr(Mjoin(ATLAS_UPR,amm_kern.h))
 #include Mstr(Mjoin(ATLAS_PRE,sysinfo.h))
 #include Mstr(Mjoin(ATLAS_PRE,opgen_view.h))
 @SKIP #include Mstr(Mjoin(ATLAS_PRE,amm_syrk.h))
@@ -2503,49 +2504,29 @@ int syrk_amm
  * For now, just pretend syrk time doesn't matter
  */
 /*
- * We will decide between sqsyrk and umsyrk based on the pref data from 
+ * We may need to decide between sqsyrk and ursyrk based on the pref data from 
  * amm_syrkPerf.h.  
  */
-#if 0
-   #if 1  /* apply umsyrk*/ 
-      Mjoin(PATL,ipmenUMInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta); 
-      #ifdef Conj_
-         ierr = umsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
-      #else
-         ierr = umsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
-      #endif
-   #else /* sqsyrk */
-      Mjoin(PATL,ipmenInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta); 
-      #ifdef Conj_
-         ierr = sqsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
-      #else
-         ierr = sqsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
-      #endif
-   #endif
-#else
+   Mjoin(PATL,ipmenInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta);
 /*
- * applying ursyrk code
- * FIXME: need extra checking for kvec:
- *        ipmen.vlen == ATL_URSYRK_VLEN 
- *          && ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(ipmen.idxK) == ATL_URSYRK_KVEC 
+ * We want not only to match mu-nu-ku but also vlen and kvec to make sure 
+ * ursyrk can share A/B copies with gemm as well 
  */
-      Mjoin(PATL,ipmenInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta);
-      if (ipmen.mu == ATL_URSYRKK_MU && ipmen.nu == ATL_URSYRKK_NU 
-            && ipmen.ku == ATL_URSYRKK_KU)
+   if (ipmen.mu == ATL_URSYRKK_MU && ipmen.nu == ATL_URSYRKK_NU
+         && ipmen.ku == ATL_URSYRKK_KU && ipmen.vlen == ATL_URSYRKK_VLEN
+         && ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(ipmen.idxK) == ATL_URSYRKK_KVEC) )
       #ifdef Conj_
          ierr = ursyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
       #else
          ierr = ursyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
       #endif
-      else
+   else
       #ifdef Conj_
          ierr = sqsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
       #else
          ierr = sqsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
       #endif
-
-
-#endif
+   
    return(ierr);
 }
 

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -2514,7 +2514,7 @@ int syrk_amm
  */
    if (ipmen.mu == ATL_URSYRKK_MU && ipmen.nu == ATL_URSYRKK_NU
          && ipmen.ku == ATL_URSYRKK_KU && ipmen.vlen == ATL_URSYRKK_VLEN
-         && ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(ipmen.idxK) == ATL_URSYRKK_KVEC) )
+         && ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(ipmen.idxK)) == ATL_URSYRKK_KVEC )
       #ifdef Conj_
          ierr = ursyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
       #else
@@ -3461,7 +3461,7 @@ int opsyrk
    ATL_CSZT ldc
 )
 {
-   int i, ismul;
+   int i;
    int ierr;
    #ifdef Conj_
       TYPE alpha[2]={ralpha, ATL_rzero}, beta[2]={rbeta, ATL_rzero};
@@ -3485,17 +3485,15 @@ int opsyrk
            op.pmb, op.pnb, op.kb);
    #endif
 /*
- * mu,nu,ku, must match with amm_umsyrk.h to apply ursyrk until we manage 
- * to have opgenview for UR
+ * apply ursyrk when possible
+ * FIXME: opinfo_t doesn't have idxK to point the kernel. How can we verify
+ * whether the mdim of the gemm kernel is match with syrk? MVEC kernel may have 
+ * KU > 1 (and match with KVEC) for the unrolling! If we have idxK in opinfo_t,
+ * we can add following test to make sure mdim matched as well: 
+ * ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(op.idxK)) == ATL_URSYRKK_KVEC
  */
-   ismul = 1;
-   if (op.mu != ATL_URSYRKK_MU || op.nu != ATL_URSYRKK_NU 
-         || op.ku !=ATL_URSYRKK_KU )
-      ismul = 0;
-/*
- * try to use ursyrk first if possible 
- */
-   if (ismul)
+   if (op.mu == ATL_URSYRKK_MU && op.nu == ATL_URSYRKK_NU 
+         && op.ku ==ATL_URSYRKK_KU && op.vlen == ATL_URSYRKK_VLEN)
       ierr = opursyrk(&op, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
    else
       ierr = opsqsyrk(&op, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);

--- a/AtlasBase/Clint/trmm-micro.base
+++ b/AtlasBase/Clint/trmm-micro.base
@@ -1883,6 +1883,7 @@ int ATL_iptrmm
          ATL_SZT Tsz, Rsz, Csz; /* workspace size for TRMM */
          TYPE *BW, *L, *R, *w;
          void *vp=NULL;
+         unsigned short kmaj;
          ipinfo_t gip;
          #ifdef TCPLX
             TYPE ONE[2] = {ATL_rone, ATL_rzero};
@@ -1911,9 +1912,10 @@ int ATL_iptrmm
  *       check if gemm and trmm use similar kernel, update copy routine 
  *       accordingly to share copies with gemm 
  */
+         kmaj = ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(gip.idxK));
          if (gip.mu == si.mu && gip.nu == si.nu && gip.ku == si.ku 
                && gip.vlen == si.vlen 
-               && si.kvec == ATL_AMM_KMAJOR(ATL_AMM_GetFLAG(gip.idxK)))
+               && ((!si.kvec && !kmaj) || (si.kvec && kmaj)) )
             tminfo(1, bv, &si, &gip, (bv&16)?AtlasNonUnit:AtlasUnit, (bv&1)?NR:NT, 
                    (bv&1)?NT:NR, alpha, lda, ldb);
 /*

--- a/AtlasBase/make.base
+++ b/AtlasBase/make.base
@@ -1616,7 +1616,7 @@ batfn = $(basdRCW)/trmm-micro.base
 @ROUT ATLAS/tune/blas/trsm `@multidef rt trsmsrch`
 @ROUT ATLAS/src/blas/ulevel3 
 @multidef u3 
-   ipsyr2k opsyr2k syr2k syrk sqsyrk umsyrk ursyrk opsyrk ipsyrk symmL symmR 
+   ipsyr2k opsyr2k syr2k syrk sqsyrk ursyrk opsyrk ipsyrk symmL symmR 
    ipsymmL ipsymmR ipsyGetCopyA ipsyGetCopyB
 @SKIP   ipsymmL_tN ipsymmR_tM 
    heLL2ipBlk heLU2ipBlk syLL2ipBlk syLU2ipBlk

--- a/AtlasBase/make.base
+++ b/AtlasBase/make.base
@@ -1616,7 +1616,7 @@ batfn = $(basdRCW)/trmm-micro.base
 @ROUT ATLAS/tune/blas/trsm `@multidef rt trsmsrch`
 @ROUT ATLAS/src/blas/ulevel3 
 @multidef u3 
-   ipsyr2k opsyr2k syr2k syrk sqsyrk umsyrk opsyrk ipsyrk symmL symmR 
+   ipsyr2k opsyr2k syr2k syrk sqsyrk umsyrk ursyrk opsyrk ipsyrk symmL symmR 
    ipsymmL ipsymmR ipsyGetCopyA ipsyGetCopyB
 @SKIP   ipsymmL_tN ipsymmR_tM 
    heLL2ipBlk heLU2ipBlk syLL2ipBlk syLU2ipBlk


### PR DESCRIPTION
Added blk2C copies and syrk kernel generator for arbitrary mu and nu. URSYRK uses those copies and kernels. 

Known issues:
-------------------- 
1. Performance regression on Epyc64 for using less performed generated syrk (not using FMAC when vlen=2 for double on that machine).
 
2. Since we are using ipmen / opmen for the gemm kernels in URSYRK / OPURSYRK, we may need to match the mdim info of gemm and syrk kernel as well to share A/B copies. I used idxK of ipinfo_t to point the kernel in amm_kern.h and to find kvec info, but unable to do so for opsyrk since opinfo_t doesn't have idxK to point the gemm kernel. It doesn't create any problem so far for any of our test machines though. 