### PR TITLE
Implementation of parameterized-unrolling for A-copy and C-copy

### DIFF
--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -2786,8 +2786,8 @@ void ATL_blk2CT
  * since it's upper transpose case, the direction of MU and NU interchanged
 @ROUT ATL_amblk2CT ` * N and M interchanged as well  `
  */
-@ROUT ATL_amL2skLNB `   for (j=0; j < N; j = jn) `
-@ROUT ATL_amblk2CT    `   for (j=0; j < M; j = jn) `
+@ROUT ATL_amL2skLNB `   for (j=0; j < N; j = jn, C += incC) `
+@ROUT ATL_amblk2CT    `   for (j=0; j < M; j = jn, C += incC) `
    {
       ATL_UINT i, in, mu , nu;
 @ROUT ATL_amL2skLNB `      mu = Mmin(N-j, MU); `
@@ -2801,12 +2801,12 @@ void ATL_blk2CT
  *                       => j > i+nu-1
  *    access of C-workspace is consecutive
  */
-      for (i=0; j > (i+nu-1); i=in, rC += incW, C += incC )
+      for (i=0; j > (i+nu-1); i=in, rC += incW)
 @ROUT ATL_amblk2CT
 /*
  *    M & N interchaged. So, N becomes number of rows 
  */
-      for (i=0; i < N; i = in, rC += incW, C += incC)
+      for (i=0; i < N; i = in, rC += incW)
 @ROUT ATL_amL2skLNB ATL_amblk2CT 
       {
          #ifdef C2BLK

--- a/AtlasBase/Clint/atlas-kaux.base
+++ b/AtlasBase/Clint/atlas-kaux.base
@@ -2781,6 +2781,7 @@ void ATL_blk2CT
       const TYPE ra=*alpha, ia=alpha[1];
       const TYPE rb=*beta, ib=beta[1];
    #endif
+   const ATL_iptr_t incC = MU*(ldc SHIFT); /* MU & NU interchanged */
 /*
  * since it's upper transpose case, the direction of MU and NU interchanged
 @ROUT ATL_amblk2CT ` * N and M interchanged as well  `
@@ -2800,12 +2801,12 @@ void ATL_blk2CT
  *                       => j > i+nu-1
  *    access of C-workspace is consecutive
  */
-      for (i=0; j > (i+nu-1); i=in, rC += incW )
+      for (i=0; j > (i+nu-1); i=in, rC += incW, C += incC )
 @ROUT ATL_amblk2CT
 /*
  *    M & N interchaged. So, N becomes number of rows 
  */
-      for (i=0; i < N; i = in, rC += incW)
+      for (i=0; i < N; i = in, rC += incW, C += incC)
 @ROUT ATL_amL2skLNB ATL_amblk2CT 
       {
          #ifdef C2BLK
@@ -2813,13 +2814,13 @@ void ATL_blk2CT
             #ifdef TCPLX
                TYPE *iw0 = iC;
             #endif
-            const TYPE *c = C+((i+j*ldc) SHIFT);
+            const TYPE *c = C + (i SHIFT);
          #else
             const TYPE *rw0 = rC;
             #ifdef TCPLX
                const TYPE *iw0 = iC;
             #endif
-            TYPE *c = C+((i+j*ldc) SHIFT);
+            TYPE *c = C + (i SHIFT);
          #endif
          ATL_UINT ii, jj;
          nu = Mmin(NU, N-i);
@@ -2870,13 +2871,13 @@ void ATL_blk2CT
       for ( ; i < jn; i=in, rC += incW)
       {
          #ifdef C2BLK
-            const TYPE *c = C+((i+j*ldc) SHIFT);
+            const TYPE *c = C + (i SHIFT);
             TYPE *rw0 = rC;
             #ifdef TCPLX
                TYPE *iw0 = iC;
             #endif
          #else
-            TYPE *c = C+((i+j*ldc) SHIFT);
+            TYPE *c = C + (i SHIFT);
             const TYPE *rw0 = rC;
             #ifdef TCPLX
                const TYPE *iw0 = iC;

--- a/AtlasBase/Clint/atlas-make.base
+++ b/AtlasBase/Clint/atlas-make.base
@@ -2652,6 +2652,8 @@ outF=
 bcast=1
 vlen=1
 cpvlen=1
+cpUR=15  # bitpattern controlling unrolling in copy routines 
+SYRKU=0  # 1 = unrestricted, 0 = restricted SYRK C-copy (unrolled) 
 extdefs=
 knam=ATL_USERCPMM
 @whiledef iv szExtra
@@ -2720,11 +2722,11 @@ cpyhelp :
 	@@echo "-->can take MTXD '-D M lda N COLWISE'\n"
 	@@echo "make PREcpytest TRANS=[0,1] TO_BLK=[0,1] CPM=[C,A] [CNJ=-DConj_=1] sz=<bsz> alphan=[1,N,X] betan=[0,1,N,X] [CNJ="-DConj_=1" kfnam=<cp2test> cpgood=<good cp>"
 	@@echo "make PREammmcpytst [blk2C=rt] [CM2blk=rt] mu= nu= alpha= beta= vlen="
-	@@echo "make gen_[sy,]blk2C rt= pre= vlen= mu= nu= cpvlen= beta= alpha="
-	@@echo "make gen_[sy,]C2blk rt= pre= vlen= mu= nu= cpvlen= beta= alpha="
-	@@echo "make gen_A[T,N]2blk rt= kmaj= UR= alpha="
-	@@echo "make gen_A[T,N]2blk rt= kmaj= UR= alpha="
-	@@echo "make gen_cA[T,N]2blk rt= kmaj= UR= alpha= rout=FUNCNM"
+	@@echo "make gen_[sy,]blk2C rt= pre= vlen= mu= nu= cpvlen= beta= alpha= cpUR="
+	@@echo "make gen_[sy,]C2blk rt= pre= vlen= mu= nu= cpvlen= beta= alpha= cpUR="
+	@@echo "make gen_A[T,N]2blk rt= kmaj= UR= alpha= cpUR="
+	@@echo "make gen_A[T,N]2blk rt= kmaj= UR= alpha= cpUR="
+	@@echo "make gen_cA[T,N]2blk rt= kmaj= UR= alpha= rout=FUNCNM cpUR="
 
 trsmhelp :
 	@@echo "make gen_ntrsm_cpC tALL=[T,N] mu=# nu=# rt=filename.h"
@@ -2801,7 +2803,7 @@ genall_@(rt): $(BINdir)/xextract $(mySRCdir)/micro-cpg.base
       @whiledef al 1 N1 X
 	echo "#if defined(BETA@(be)) && defined(ALPHA@(al))" >> $(rt)
 	make gen_@(rt2) rt=ATL_tmp.c pre=$(pre) vlen=$(vlen) mu=$(mu) \
-             nu=$(nu) cpvlen=$(cpvlen) beta=@(ib) alpha=@(ia)
+             nu=$(nu) cpvlen=$(cpvlen) beta=@(ib) alpha=@(ia) cpUR=$(cpUR)
 	cat ATL_tmp.c >> $(rt)
 	echo "#endif" >> $(rt)
          @undef ia
@@ -2815,14 +2817,15 @@ genall_@(rt): $(BINdir)/xextract $(mySRCdir)/micro-cpg.base
 gen_@(rt) : $(BINdir)/xextract $(mySRCdir)/micro-cpg.base
 	$(extC) -b $(mySRCdir)/micro-cpg.base -o $(rt) pre=$(pre) vec=NA \
                 rout=@(rt) -def vl $(vlen) -def mu $(mu) -def nu $(nu) \
-                -def cpvl $(cpvlen) -def beta $(beta) -def alpha $(alpha)
+                -def cpvl $(cpvlen) -def beta $(beta) -def alpha $(alpha) \
+                -def cpUR $(cpUR)
 @endwhile
 @whiledef rt blk2C C2blk
 gen_sy@(rt) : $(BINdir)/xextract $(mySRCdir)/micro-cpg.base
 	$(extC) -b $(mySRCdir)/micro-cpg.base -o $(rt) pre=$(pre) vec=NA \
                 rout=@(rt) -def vl $(vlen) -def mu $(mu) -def nu $(nu) \
                 -def cpvl $(cpvlen) -def beta $(beta) -def alpha $(alpha) \
-                -def TRI 1
+                -def TRI 1 -def cpUR $(cpUR) -def SYRKU $(SYRKU)
 @endwhile
 @define pr @@
 @whiledef pr c
@@ -2835,7 +2838,7 @@ genall_@(pr)A2blk:
       @whiledef al 1 N1 X
 	echo "   #if defined(ALPHA@(al))" >> $(rt)
 	make gen_@(pr)A@(ta)2blk UR=$(UR) alpha=@(ia) dupB=$(dupB) \
-             kmaj=$(kmaj) rt=ATL_tmp.c
+             kmaj=$(kmaj) rt=ATL_tmp.c cpUR=$(cpUR)
 	cat ATL_tmp.c >> $(rt)
 	echo "   #endif /* end ALPHA@(al) */" >> $(rt)
          @undef ia
@@ -2851,7 +2854,7 @@ genall_@(pr)blk2A:
       @whiledef al 1 N1 X
 	echo "   #if defined(ALPHA@(al))" >> $(rt)
 	make gen_@(pr)blk2A@(ta) UR=$(UR) alpha=@(ia) dupB=$(dupB) \
-             kmaj=$(kmaj) rt=ATL_tmp.c
+             kmaj=$(kmaj) rt=ATL_tmp.c cpUR=$(cpUR)
 	cat ATL_tmp.c >> $(rt)
 	echo "   #endif /* end ALPHA@(al) */" >> $(rt)
          @undef ia
@@ -2863,7 +2866,7 @@ genall_@(pr)blk2A:
 gen_@(pr)@(tg) : $(basf) force_build
 	$(extC) -def mu "${UR}" -def nu "${UR}" -def ku "${ku}" \
         -def alpha "${alpha}" -def dupB "${dupB}" -def kmaj "${kmaj}" \
-        -o $(rt) rout=ATL_@(pr)@(rt)
+        -o $(rt) rout=ATL_@(pr)@(rt) -def cpUR "${cpUR}"
    @undef tg
 @endwhile
 @multidef tg blk2AN blk2AT AN2blk AT2blk
@@ -2871,7 +2874,7 @@ gen_@(pr)@(tg) : $(basf) force_build
 gen_@(pr)t@(tg) : $(trmmbasf) force_build
 	$(extT) -def mu "${UR}" -def nu "${UR}" -def ku "${ku}" \
         -def alpha "${alpha}" -def dupB "${dupB}" -def kmaj "${kmaj}" \
-        -o $(rt) rout=ATL_@(pr)@(rt)
+        -o $(rt) rout=ATL_@(pr)@(rt) -def cpUR "${cpUR}"
    @undef tg
 @endwhile
 @endwhile
@@ -3949,7 +3952,7 @@ cwrk3=0
            $(extC) -b $(mySRCdir)/micro-cpg.base -o c@(rt)tst.c pre=@(pre) \
            vec=NA -def rtnm ATL_blk2C rout=blk2C -def vl $(vlen) \
            -def TRI @(tri) -def mu $(mu) -def nu $(nu) \
-           -def cpvl $(cpvlen) -def beta 0 -def alpha 1 ; \
+           -def cpvl $(cpvlen) -def beta 0 -def alpha 1 -def cpUR $(cpUR) ; \
         else \
            echo "#define ATL_USERCPMM ATL_blk2C" > c@(rt)tst.c ; \
            cat $(blk2C) >> c@(rt)tst.c ; \
@@ -3982,7 +3985,7 @@ cwrk3=0
 	$(extC) -b $(mySRCdir)/micro-cpg.base -o c@(rt)tst.c pre=@(pre) \
            vec=NA -def rtnm ATL_blk2C rout=blk2C -def vl $(vlen) \
            -def TRI @(tri) -def mu $(mu) -def nu $(nu) \
-           -def cpvl $(cpvlen) -def beta 0 -def alpha 1
+           -def cpvl $(cpvlen) -def beta 0 -def alpha 1 -def cpUR $(cpUR)
 	$(extC) -def mu "${mu}" -def nu "${nu}" -def be "${beta}" \
                 -def M "${M}" -def N "${N}" -def K "${K}" -def kmaj "$(kmaj)" \
                 -def TRI @(tri) rout=cammmtst >> c@(rt)tst.c
@@ -4022,7 +4025,7 @@ cwrk3=0
            $(extC) -b $(mySRCdir)/micro-cpg.base -o @(rt)tst.c pre=@(pre) \
            vec=NA rout=blk2C -def vl $(vlen) -def mu $(mu) -def nu $(nu) \
            -def cpvl $(cpvlen) -def beta 0 -def alpha 1 -def rtnm ATL_blk2C \
-           -def TRI @(tri) ; \
+           -def TRI @(tri) -def cpUR $(cpUR) ; \
         else \
 @skip           echo "void ATL_blk2C(const size_t,const size_t,const SCALAR, const TYPE*, const SCALAR, TYPE*, const size_t);" > @(rt)tst.c ; \
            echo "#define ATL_USERCPMM ATL_blk2C" > @(rt)tst.c ; \
@@ -4036,7 +4039,7 @@ cwrk3=0
 	if test "$(C2blk)" = "def" ; then \
            $(extC) -b $(mySRCdir)/micro-cpg.base pre=@(pre) vec=NA \
                 rout=C2blk -def vl $(vlen) -def mu $(mu) -def nu $(nu) \
-                -def rtnm ATL_C2blk -def TRI @(tri) \
+                -def rtnm ATL_C2blk -def TRI @(tri) -def cpUR $(cpUR) \
                 -def cpvl $(cpvlen) -def beta 0 -def alpha 1 >> @(rt)tst.c ; \
         else \
            cat $(C2blk) >> @(rt)tst.c ; \
@@ -4075,10 +4078,10 @@ cwrk3=0
 	$(extC) -b $(mySRCdir)/micro-cpg.base -o @(rt)tst.c pre=@(pre) vec=NA \
                 rout=blk2C -def vl $(vlen) -def mu $(mu) -def nu $(nu) \
                 -def cpvl $(cpvlen) -def beta 0 -def alpha 1 \
-                -def rtnm ATL_blk2C -def TRI @(tri)
+                -def rtnm ATL_blk2C -def TRI @(tri) -def cpUR $(cpUR)
 	$(extC) -b $(mySRCdir)/micro-cpg.base pre=@(pre) vec=NA \
                 rout=C2blk -def vl $(vlen) -def mu $(mu) -def nu $(nu) \
-                -def rtnm ATL_C2blk -def TRI @(tri) \
+                -def rtnm ATL_C2blk -def TRI @(tri) -def cpUR $(cpUR) \
                 -def cpvl $(cpvlen) -def beta 0 -def alpha 1 >> @(rt)tst.c
 	$(extC) -def mu "${mu}" -def nu "${nu}" -def be "${beta}" \
                 -def M "${M}" -def N "${N}" -def K "${K}" -def dupB "${dupB}" \

--- a/AtlasBase/Clint/atlas-mmg.base
+++ b/AtlasBase/Clint/atlas-mmg.base
@@ -653,7 +653,7 @@ void ATL_USERCPMM       /* column- to access-major */
 @ROUT ATL_cm2am ammmtst
             *p = @(malp)rA[i];
 @ROUT ATL_am2cm
-            rA[i] = @(malp)*p;
+            rA[i] = @(malp)(*p);
 @ROUT ATL_am2cm ATL_cm2am ammmtst
          }
       @endiif
@@ -2200,7 +2200,7 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
 @ROUT ATL_rm2am ammmtst
             pp[ii] = @(malp)A[ii];
 @ROUT ATL_am2rm
-            A[ii] = @(malp)*pp[ii];
+            A[ii] = @(malp)pp[ii];
 @ROUT ATL_am2rm ATL_rm2am ammmtst
          }
       @endiif

--- a/AtlasBase/Clint/atlas-mmg.base
+++ b/AtlasBase/Clint/atlas-mmg.base
@@ -204,7 +204,7 @@
 @SKIP *** this proc handles one full block with KU unrolled 
 @BEGINPROC doBlockKu nu_
    @define k @dum@
-            unsigned int jj;
+            ATL_UINT jj;
             @(cnst)TYPE *rA = A0;
             @(cnstb)TYPE *p = b;
             for (jj=0; jj < @(nu_); jj++, rA += lda, p+=@(ku))
@@ -225,7 +225,7 @@
 @BEGINPROC doBlockNu ku_
    @define j @dum@
    @define ib @dum@
-            unsigned int ii;
+            ATL_UINT ii;
             for (ii=0; ii < @(ku_); ii++)
             {
       @iexp j 0 
@@ -244,12 +244,12 @@
 @ENDPROC
 @SKIP *** this proc handles one full block in both rolled 
 @BEGINPROC doBlockRolled nu_ ku_
-            unsigned int jj;
+            ATL_UINT jj;
             @(cnst)TYPE *rA = A0;
             @(cnstb)TYPE *p = b;
             for (jj=0; jj < @(nu_); jj++, rA += lda, p+=@(ku))
             {
-               unsigned int ii;
+               ATL_UINT ii;
                for (ii=0; ii < @(ku_); ii++)
                {
 @ROUT ATL_am2cm
@@ -280,7 +280,7 @@
 @SKIP *** this proc handles K-cleanup block 
 @BEGINPROC doKCuBlockRolled nu_
    @define k @dum@
-            unsigned int jj;
+            ATL_UINT jj;
             @(cnst)TYPE *rA = A0;
             @(cnstb)TYPE *p = b;
             for (jj=0; jj < @(nu_); jj++, rA += lda, p+=@(ku))
@@ -402,7 +402,7 @@ void ATL_USERCPMM       /* column- to access-major */
 @ROUT ATL_cm2am ammmtst
       /* zero padding the whole block first*/ 
    @iif CU_NUKU = 0
-         unsigned int ii, jj;
+         ATL_UINT ii, jj;
          TYPE *p = b; 
          for (jj=0; jj < @(nu); jj++, p+=@(ku))
             for (ii=0; ii < @(ku); ii++)
@@ -553,7 +553,7 @@ void ATL_USERCPMM       /* column- to access-major */
          @endiwhile
       @endiif
       @iif CU_KUR = 0
-            unsigned int ii;
+            ATL_UINT ii;
             for (ii=0; ii < @(ku); ii++)
                p[ii] = 0.0;
       @endiif
@@ -565,11 +565,11 @@ void ATL_USERCPMM       /* column- to access-major */
 @ROUT ATL_cm2am ammmtst
       /* zero padding the whole block first*/ 
       @SKIP @iif CU_NO ! 0
-         unsigned int jj;
+         ATL_UINT jj;
          TYPE *p = b; 
          for (jj=0; jj < @(nu); jj++, p+=@(ku))
          {
-            unsigned int ii;
+            ATL_UINT ii;
             for (ii=0; ii < @(ku); ii++)
             {
                p[ii] = 0.0;
@@ -636,7 +636,7 @@ void ATL_USERCPMM       /* column- to access-major */
 @ENDPROC
 @SKIP ***** handles rolled block copy 
 @BEGINPROC doBlockRolled nu_
-         unsigned int jj;
+         ATL_UINT jj;
          @(cnst)TYPE *rA = A0;
          @(cnstb)TYPE *p = b;
       @iif dupB = 1
@@ -653,7 +653,7 @@ void ATL_USERCPMM       /* column- to access-major */
          for (jj=0; jj < @(nu_); jj++, rA += lda, p+=@(dupB))
          {
 @ROUT ATL_cm2am ammmtst
-            unsigned int ii;
+            ATL_UINT ii;
             TYPE a0 = rA[i];
             for (ii=0; ii < @(dupB); ii++)
                p[ii] = @(malp)a0;
@@ -777,7 +777,7 @@ void ATL_USERCPMM       /* col-access matx to access-major blk */
    @endiif
    @iif ML_NUR = 0
       {
-         unsigned int jj;
+         ATL_UINT jj;
          for (jj=0; jj < @(nu); jj++)
             b[jj] = ATL_rzero;
       }
@@ -856,7 +856,7 @@ void ATL_USERCPMM       /* col-access matx to access-major blk */
    @iif ku > 1
       for (; i < KK; i++, b += @(incdup))
       {
-         unsigned int ii;
+         ATL_UINT ii;
          for (ii=0; ii < @(nu); ii++)
             b[ii] = ATL_rzero;
       }
@@ -956,7 +956,7 @@ void ATL_USERCPMM       /* col-access matx to access-major blk */
 @BEGINPROC doBlockKu nu_
    @define k @dum@
    @define k2 @dum@
-            unsigned int jj;
+            ATL_UINT jj;
             @(cnst)TYPE *pA0 = A0;
             @(cnstb)TYPE *pr = rA, *pi = iA;
             for (jj=0; jj < @(nu_); jj++, pA0 += lda2, pr+=@(ku), pi+=@(ku))
@@ -976,7 +976,7 @@ void ATL_USERCPMM       /* col-access matx to access-major blk */
 @BEGINPROC doBlockNu ku_
    @define j @dum@
    @define ib @dum@
-            unsigned int ii;
+            ATL_UINT ii;
             for (ii=0; ii < @(ku_); ii++)
             {
       @iexp j 0 
@@ -993,12 +993,12 @@ void ATL_USERCPMM       /* col-access matx to access-major blk */
 @ENDPROC
 @SKIP *** this proc handles one full block in both rolled 
 @BEGINPROC doBlockRolled nu_ ku_
-            unsigned int jj;
+            ATL_UINT jj;
             @(cnst)TYPE *pA0 = A0;
             @(cnstb)TYPE *pr = rA, *pi = iA;
             for (jj=0; jj < @(nu_); jj++, pA0 += lda2, pr+=@(ku), pi+=@(ku))
             {
-               unsigned int ii;
+               ATL_UINT ii;
                for (ii=0; ii < @(ku_); ii++)
                {
                   @SKIP rA[i+ii] = @(malp)p[ii];
@@ -1065,7 +1065,7 @@ void ATL_USERCPMM       /* col-access matx to access-major blk */
 @SKIP *** this proc handles K-cleanup block 
 @BEGINPROC doKCuBlockRolled nu_
    @define k @dum@
-            unsigned int jj;
+            ATL_UINT jj;
             @(cnst)TYPE *pA0 = A0;
             @(cnstb)TYPE *pr = rA, *pi = iA;
             for (jj=0; jj < @(nu_); jj++, pA0 += lda2, pr+=@(ku), pi+=@(ku))
@@ -1189,7 +1189,7 @@ void ATL_USERCPMM
       {
 @ROUT ATL_ccm2am cammmtst
    @iif CU_NUKU = 0
-         unsigned int ii, jj;
+         ATL_UINT ii, jj;
          TYPE *pr = rA, *pi = iA;
          for (jj=0; jj < @(nu); jj++, pr+=@(ku), pi+=@(ku))
             for (ii=0; ii < @(ku); ii++)
@@ -1410,7 +1410,7 @@ void ATL_USERCPMM
          @endiwhile
       @endiif
       @iif CU_KUR = 0
-            unsigned int ii;
+            ATL_UINT ii;
             for (ii=0; ii < @(ku); ii++)
                pr[ii] = pi[ii] = 0.0;
       @endiif
@@ -1422,7 +1422,7 @@ void ATL_USERCPMM
 @ROUT ATL_ccm2am cammmtst
       /* zero padding the whole block first*/ 
       @SKIP @iif CU_NO ! 0
-         unsigned int ii, jj;
+         ATL_UINT ii, jj;
          TYPE *pr = rA, *pi = iA; 
          for (jj=0; jj < @(nu); jj++, pr+=@(ku), pi+=@(ku))
             for (ii=0; ii < @(ku); ii++)
@@ -1514,7 +1514,7 @@ void ATL_USERCPMM
 @ENDPROC
 @SKIP *** handles one block rolled 
 @BEGINPROC doBlockRolled nu_
-         unsigned int jj;
+         ATL_UINT jj;
          @(cnst)TYPE *pA0 = A0;
          @(cnstb)TYPE *pr = rA, *pi = iA;
          for (jj=0; jj < @(nu_); jj++, pA0 += lda2, pr++, pi++)
@@ -1532,7 +1532,7 @@ void ATL_USERCPMM
 @BEGINPROC doKzeroPadRolled
       for (i=0; i < KR; i++, rA += @(nu), iA += @(nu))
       {
-         unsigned int ii; 
+         ATL_UINT ii; 
          for (ii=0; ii < @(nu); ii++)
             rA[ii] = iA[ii] = ATL_rzero;
       }
@@ -1788,7 +1788,7 @@ void ATL_cm2am
 @BEGINPROC doBlockMu ku_ 
    @define j @dum@
    @define ip @dum@
-         unsigned int jj;
+         ATL_UINT jj;
          @(cnst)TYPE *rA = A0;
          @(cnstb)TYPE *p = pp;
          for(jj=0; jj < @(ku_); jj++, rA +=lda, p++) 
@@ -1810,7 +1810,7 @@ void ATL_cm2am
 @SKIP **** handles full block unrolled KU  
 @BEGINPROC doBlockKu mu_ 
    @define j @dum@
-         unsigned int ii;
+         ATL_UINT ii;
          @(cnstb)TYPE *p = pp;
          for(ii=0; ii < @(mu_); ii++, p+=@(ku)) 
          {
@@ -1828,12 +1828,12 @@ void ATL_cm2am
 @ENDPROC
 @SKIP **** handles full block rolled 
 @BEGINPROC doBlockRolled mu_ ku_ 
-         unsigned int jj;
+         ATL_UINT jj;
          @(cnst)TYPE *rA = A0;
          @(cnstb)TYPE *p = pp;
          for(jj=0; jj < @(ku_); jj++, rA +=lda, p++)
          {
-            unsigned int ii;
+            ATL_UINT ii;
             @(cnstb)TYPE *w = p;
             for(ii=0; ii < @(mu_); ii++, w+=@(ku_)) 
             {
@@ -1847,12 +1847,12 @@ void ATL_cm2am
 @ENDPROC
 @SKIP ****** handles K-cleanup in rolled, without zero padding 
 @BEGINPROC doKCuBlockRolled mu_ ku_
-         unsigned int jj;
+         ATL_UINT jj;
          @(cnst)TYPE *rA = A0;
          @(cnstb)TYPE *p = pp;
          for(jj=0; jj < @(ku_); jj++, rA +=lda, p++)
          {
-            unsigned int ii;
+            ATL_UINT ii;
             @(cnstb)TYPE *w = p;
             for(ii=0; ii < @(mu_); ii++, w+=@(ku)) 
 @ROUT ATL_am2rm
@@ -1967,7 +1967,7 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
          @endiwhile
       @endiif
       @iif CU_KUR = 0
-            unsigned int jj;
+            ATL_UINT jj;
             @(cnst)TYPE *rA = A0;
             for (jj=0; jj < @(ku); jj++, rA+=lda)
                p[jj] = rA[i];
@@ -1987,7 +1987,7 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
          @endiwhile
       @endiif
       @iif CU_KUR = 0
-            unsigned int jj;
+            ATL_UINT jj;
             for (jj=0; jj < @(ku); jj++)
                p[jj] = 0.0;
       @endiif
@@ -2116,7 +2116,7 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
          @endiwhile
       @endiif
       @iif CU_NUR = 0
-            unsigned int ii;
+            ATL_UINT ii;
             TYPE *w = p;
             for (ii=0; ii < @(mu); ii++, w+=@(ku))
                *w = 0.0;
@@ -2129,7 +2129,7 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
          @(cnstb)TYPE *p = pp; 
          for ( ; i < M; i++, p+=@(ku))
          {
-            unsigned int jj;
+            ATL_UINT jj;
             @(cnst)TYPE *rA = A0;
             for (jj=0; jj < kr; jj++, rA+=lda)
 @ROUT ATL_rm2am ammmtst
@@ -2142,7 +2142,7 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
  */
          for (; i < MM; i++, p += @(ku))
          {
-            unsigned int jj;
+            ATL_UINT jj;
             for (jj=0; jj < @(ku); jj++)
                p[jj] = 0.0;
 @ROUT ATL_am2rm
@@ -2185,7 +2185,7 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
 @ENDPROC
 @SKIP *** handles block rolled
 @BEGINPROC doBlockRolled mu_
-         unsigned int ii;
+         ATL_UINT ii;
       @iif dupB = 1
          for (ii=0; ii < @(mu_); ii++)
          {
@@ -2201,7 +2201,7 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
          for (ii=0; ii < @(mu_); ii++, p+=@(dupB))
          {
 @ROUT ATL_rm2am ammmtst
-            unsigned int jj;
+            ATL_UINT jj;
             TYPE a0 = A[ii];
             for (jj=0; jj < @(dupB); jj++)
                p[jj] = @(malp)a0;
@@ -2333,7 +2333,7 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
          @(cnstb)TYPE *p = pp;
          for (; ii < @(mu); ii++, p+=@(dupB))
          {
-            unsigned int jj;
+            ATL_UINT jj;
             for (jj=0; jj < @(dupB); jj++)
                p[jj] = ATL_rzero;
          }
@@ -2362,7 +2362,7 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
       @endiif
       @iif CU_KUR = 0
          {
-            unsigned int ii;
+            ATL_UINT ii;
             for (ii=0; ii < @(mu); ii++)
                pp[ii] = ATL_rzero;
          }
@@ -2378,7 +2378,7 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
                  ATL_rzero;
       @endiif
       @iif CU_NUR = 0
-         unsigned int ii;
+         ATL_UINT ii;
          for (ii=0; ii < @(mu); ii++)
             b[ii] = ATL_rzero;
       @endiif
@@ -2464,7 +2464,7 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
    @define j @dum@
    @define i2 @dum@
    @define ip @dum@
-         unsigned int jj;
+         ATL_UINT jj;
          @(cnst)TYPE *pA0 = A0;
          @(cnstb)TYPE *pr0 = pr, *pi0 = pi;
          for(jj=0; jj < @(ku_); jj++, pA0 +=lda2, pr0++, pi0++) 
@@ -2485,7 +2485,7 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
 @BEGINPROC doBlockKu mu_ 
    @define j @dum@
    @define kk @dum@
-         unsigned int ii;
+         ATL_UINT ii;
          @(cnstb)TYPE *pr0 = pr, *pi0 = pi;
          @iexp kk @(mu_) @(mu_) +
          for(ii=0; ii < @(kk); ii+=2, pr0+=@(ku), pi0+=@(ku)) 
@@ -2503,12 +2503,12 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
 @SKIP **** handles full block rolled 
 @BEGINPROC doBlockRolled mu_ ku_ 
    @define kk @dum@
-         unsigned int jj;
+         ATL_UINT jj;
          @(cnst)TYPE *pA0 = A0;
          @(cnstb)TYPE *pr0 = pr, *pi0 = pi;
          for(jj=0; jj < @(ku_); jj++, pA0 +=lda2, pr0++, pi0++)
          {
-            unsigned int ii;
+            ATL_UINT ii;
             @(cnstb)TYPE *rw = pr0, *iw = pi0;
             @iexp kk @(mu_) @(mu_) +
             for(ii=0; ii < @(kk); ii+=2, rw+=@(ku), iw+=@(ku)) 
@@ -2564,7 +2564,7 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
    @define j @dum@
    @define i2 @dum@
    @define ip @dum@
-         unsigned int jj;
+         ATL_UINT jj;
          @(cnst)TYPE *pA0 = A0;
          @(cnstb)TYPE *pr0 = pr, *pi0 = pi;
          for(jj=0; jj < @(ku_); jj++, pA0 +=lda2, pr0++, pi0++) 
@@ -2584,12 +2584,12 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
 @SKIP **** handles K-cleanup block rolled FIXME: no diff with doBlockRolled!!! 
 @BEGINPROC doKCuBlockRolled mu_ ku_ 
    @define kk @dum@
-         unsigned int jj;
+         ATL_UINT jj;
          @(cnst)TYPE *pA0 = A0;
          @(cnstb)TYPE *pr0 = pr, *pi0 = pi;
          for(jj=0; jj < @(ku_); jj++, pA0 +=lda2, pr0++, pi0++)
          {
-            unsigned int ii;
+            ATL_UINT ii;
             @(cnstb)TYPE *rw = pr0, *iw = pi0;
             @iexp kk @(mu_) @(mu_) +
             for(ii=0; ii < @(kk); ii+=2, rw+=@(ku), iw+=@(ku)) 
@@ -2715,7 +2715,7 @@ void ATL_USERCPMM       /* row- to access-major */
          @endiwhile
       @endiif
       @iif CU_KUR = 0
-            unsigned int jj;
+            ATL_UINT jj;
             @(cnst)TYPE *pA0 = A0;
             for (jj=0; jj < @(ku); jj++, pA0+=lda2)
             {
@@ -2737,7 +2737,7 @@ void ATL_USERCPMM       /* row- to access-major */
          @endiwhile
       @endiif
       @iif CU_KUR = 0
-            unsigned int jj;
+            ATL_UINT jj;
             for (jj=0; jj < @(ku); jj++)
                ii[jj] = rr[jj] = 0.0;
       @endiif
@@ -2933,7 +2933,7 @@ void ATL_USERCPMM       /* row- to access-major */
          @endiwhile
       @endiif
       @iif CU_NUR = 0
-            unsigned int kk;
+            ATL_UINT kk;
             TYPE *rw = pr0, *iw = pi0;
             for (kk=0; kk < @(mu); kk++, rw+=@(ku), iw+=@(ku))
                *rw = *iw = 0.0;
@@ -2949,7 +2949,7 @@ void ATL_USERCPMM       /* row- to access-major */
  */
          for (rr=pr, ii=pi; i < M2; i += 2, rr += @(ku), ii += @(ku))
          {
-            unsigned int jj; 
+            ATL_UINT jj; 
             @(cnst)TYPE *pA0 = A0;
             for (jj=0; jj < kr; jj++, pA0+=lda2)
             {
@@ -2964,7 +2964,7 @@ void ATL_USERCPMM       /* row- to access-major */
  */
          for (i=M; i < MM; i++, rr+=@(ku), ii+=@(ku))
          {
-            unsigned int jj;
+            ATL_UINT jj;
             for (jj=0; jj < @(ku); jj++)
                rr[jj] = ii[jj] = 0.0;
          }
@@ -3036,7 +3036,7 @@ void ATL_USERCPMM       /* row- to access-major */
 @ENDPROC
 @SKIP *** handles single block unrolled 
 @BEGINPROC doBlockRolled mu_
-         unsigned int ii;
+         ATL_UINT ii;
          for (ii=0; ii < @(mu_); ii++)
          {
             @callproc doElement A (ii<<1) pr pi ii
@@ -3213,7 +3213,7 @@ void ATL_USERCPMM       /* row- to access-major */
          @endiif
          @iif CU_KUR = 0
          {
-            unsigned int ii;
+            ATL_UINT ii;
             for (ii=0; ii < @(mu); ii++)
                pr[ii] = pi[ii] = ATL_rzero;
          }
@@ -3229,7 +3229,7 @@ void ATL_USERCPMM       /* row- to access-major */
                          ATL_rzero;
          @endiif
          @iif CU_KUR = 0
-         unsigned int ii;
+            ATL_UINT ii;
             for (ii=0; ii < @(mu); ii++)
                rA[ii] = iA[ii] = ATL_rzero;
          @endiif

--- a/AtlasBase/Clint/atlas-mmg.base
+++ b/AtlasBase/Clint/atlas-mmg.base
@@ -10,6 +10,44 @@
 @iif kmaj = 1
    @iexp kmaj 0 0 +
 @endiif
+@SKIP ************ Adding new bitvectors to parameterized unrolling ************ 
+@BEGINSKIP
+   Now we created two flags: one for main loop and other for cleanup loop
+   bvML : bitvector, default 3, with following meanings:
+      0 : no unroll in any dimension
+      1 : unroll NU dimension
+      2 : unroll KU dimension
+      3 : unroll both dimension
+   bvCU : bitvector, default 0, with following meanings: 
+      0 : no unroll in any dimension
+      1 : unroll NU dimension
+      2 : unroll KU dimension
+      3 : unroll both dimension
+@ENDSKIP
+@SKIP **** made bvML=3 default case 
+@ifdef ! bvML
+   @iexp bvML 3  
+@endifdef
+@SKIP **** made bvCU=3 default case 
+@ifdef ! bvCU
+   @iexp bvCU 3 
+@endifdef
+@BEGINSKIP
+   to make code more readable, I create two flag to represent to each bits
+   ML_KUR, ML_NUR
+   CU_KUR, CU_NUR
+@ENDSKIP
+@iexp ML_NUR @(bvML) 1 &
+@iexp ML_KUR @(bvML) 2 &
+@iexp ML_NUKU @(bvML) 3 =
+@iexp ML_NO @(bvML) 0 = 
+@print ML_NUR=@(ML_NUR) ML_KUR=@(ML_KUR) ML_NUKU=@(ML_NUKU) 
+@iexp CU_NUR @(bvCU) 1 &
+@iexp CU_KUR @(bvCU) 2 &
+@iexp CU_NUKU @(bvCU) 3 =
+@iexp CU_NO @(bvCU) 0 = 
+@SKIP @print CU_NUR = @(CU_NUR) CU_KUR = @(CU_KUR)
+@SKIP **************************************************************************
 @ROUT ATL_cam2amb ATL_ram2amb ATL_muxnu2mat
 #include "atlas_misc.h"
 @beginskip
@@ -137,6 +175,141 @@
 @endifdef
 @iif kmaj ! 0
    @define ku @@(kmaj)@
+@SKIP *** this proc handles one full block
+@BEGINPROC doBlockNuKu
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define ib @dum@
+      @iexp j 0 0 +
+      @iwhile j < @(nu)
+         @iexp k 0 0 +
+         @iwhile k < @(ku)
+            @iexp ib @(j) @(ku) *
+            @iexp ib @(ib) @(k) +
+@ROUT ATL_am2cm
+            A@(j)[i+@(k)] = @(malp)b[@(ib)];
+@ROUT ATL_cm2am ammmtst
+            b[@(ib)] = @(malp)A@(j)[i+@(k)];
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+            @iexp k @(k) 1 +
+         @endiwhile
+         @iexp j @(j) 1 +
+      @endiwhile
+   @undef ib
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP *** this proc handles one full block with KU unrolled 
+@BEGINPROC doBlockKu nu_
+   @define k @dum@
+            unsigned int jj;
+            @(cnst)TYPE *rA = A0;
+            @(cnstb)TYPE *p = b;
+            for (jj=0; jj < @(nu_); jj++, rA += lda, p+=@(ku))
+            {
+      @iexp k 0 
+      @iwhile k < @(ku)
+@ROUT ATL_am2cm
+               rA[i+@(k)] = @(malp)p[@(k)];
+@ROUT ATL_cm2am ammmtst
+               p[@(k)] = @(malp)rA[i+@(k)];
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+         @iexp k @(k) 1 +
+      @endiwhile
+            }
+   @undef k
+@ENDPROC
+@SKIP *** this proc handles one full block with NU unrolled 
+@BEGINPROC doBlockNu ku_
+   @define j @dum@
+   @define ib @dum@
+            unsigned int ii;
+            for (ii=0; ii < @(ku_); ii++)
+            {
+      @iexp j 0 
+      @iwhile j < @(nu)
+            @iexp ib @(j) @(ku) *
+@ROUT ATL_am2cm
+               A@(j)[i+ii] = @(malp)b[@(ib)+ii];
+@ROUT ATL_cm2am ammmtst
+               b[@(ib)+ii] = @(malp)A@(j)[i+ii];
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+         @iexp j @(j) 1 +
+      @endiwhile
+            }
+   @undef j
+   @undef ib
+@ENDPROC
+@SKIP *** this proc handles one full block in both rolled 
+@BEGINPROC doBlockRolled nu_ ku_
+            unsigned int jj;
+            @(cnst)TYPE *rA = A0;
+            @(cnstb)TYPE *p = b;
+            for (jj=0; jj < @(nu_); jj++, rA += lda, p+=@(ku))
+            {
+               unsigned int ii;
+               for (ii=0; ii < @(ku_); ii++)
+               {
+@ROUT ATL_am2cm
+                  rA[i+ii] = @(malp)p[ii];
+@ROUT ATL_cm2am ammmtst
+                  p[ii] = @(malp)rA[i+ii];
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+               }
+            }
+@ENDPROC
+@SKIP *** this proc handles K-cleanup block 
+@BEGINPROC doKCuBlockNuKu
+   @define j @dum@
+   @define ib @dum@
+      @iexp j 0 0 +
+      @iwhile j < @(nu)
+         @iexp ib @(j) @(ku) *
+@ROUT ATL_am2cm
+            A@(j)[i] = @(malp)b[@(ib)];
+@ROUT ATL_cm2am ammmtst
+            b[@(ib)] = @(malp)A@(j)[i];
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+         @iexp j @(j) 1 +
+      @endiwhile
+   @undef ib
+   @undef j
+@ENDPROC
+@SKIP *** this proc handles K-cleanup block 
+@BEGINPROC doKCuBlockRolled nu_
+   @define k @dum@
+            unsigned int jj;
+            @(cnst)TYPE *rA = A0;
+            @(cnstb)TYPE *p = b;
+            for (jj=0; jj < @(nu_); jj++, rA += lda, p+=@(ku))
+            {
+@ROUT ATL_am2cm
+               rA[i] = @(malp)p[0];
+@ROUT ATL_cm2am ammmtst
+               p[0] = @(malp)rA[i];
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+            }
+   @undef k
+@ENDPROC 
+@SKIP *** this proc handles K-cleanup block 
+@BEGINPROC doKCuBlockNu nu_
+   @define j @dum@
+   @define ib @dum@
+      @iexp j 0 
+      @iwhile j < @(nu_)
+         @iexp ib @(j) @(ku) *
+@ROUT ATL_am2cm
+            A@(j)[i] = @(malp)b[@(ib)];
+@ROUT ATL_cm2am ammmtst
+            b[@(ib)] = @(malp)A@(j)[i];
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+         @iexp j @(j) 1 +
+      @endiwhile
+   @undef ib
+   @undef j
+@ENDPROC 
 @ROUT ATL_am2cm
 /* 
  * This routine copies from k-vectorized access-major block b to column-major
@@ -185,6 +358,11 @@ void ATL_USERCPMM       /* column- to access-major */
    ATL_CSZT n = (N/@(nu))*@(nu), k = (K/@(ku))*@(ku), incA = lda*@(nu), nr=N-n;
    ATL_CSZT KK = ((K+@(ku)-1)/@(ku))*@(ku);
    ATL_SZT i, j;
+@iexp NA1 1
+@iif @iexp 0 @(ML_NUR) ! 0 @(CU_NUR) ! |
+   @iexp NA1 0
+@endiif 
+@iif NA1 = 0
    @declare "   @(cnst)TYPE " n n ";"
       *A0=A
       @define j @1@
@@ -194,31 +372,43 @@ void ATL_USERCPMM       /* column- to access-major */
          @iexp j @(j) 1 +
       @endiwhile
    @enddeclare
+@endiif
+@iif NA1 ! 0
+   @(cnst)TYPE *A0=A;
+@endiif
    @iexp binc @(nu) @(ku) *
-
+   /* Main loop */
    for (j=0; j < n; j += @(nu))
    {
       for (i=0; i < k; i += @(ku), b += @(binc))
       {
-      @iexp j 0 0 +
-      @iwhile j < @(nu)
-         @iexp k 0 0 +
-         @iwhile k < @(ku)
-            @iexp ib @(j) @(ku) *
-            @iexp ib @(ib) @(k) +
-@ROUT ATL_am2cm
-            A@(j)[i+@(k)] = @(malp)b[@(ib)];
-@ROUT ATL_cm2am ammmtst
-            b[@(ib)] = @(malp)A@(j)[i+@(k)];
-@ROUT ATL_am2cm ATL_cm2am ammmtst
-            @iexp k @(k) 1 +
-         @endiwhile
-         @iexp j @(j) 1 +
-      @endiwhile
+         @iif ML_NUKU ! 0 
+            @callproc doBlockNuKu
+         @endiif
+         @iif ML_NUKU = 0
+            @iif ML_KUR ! 0
+               @callproc doBlockKu @(nu)
+            @endiif
+            @iif ML_NUR ! 0
+               @callproc doBlockNu @(ku)
+            @endiif
+            @iif ML_NO ! 0
+               @callproc doBlockRolled @(nu) @(ku)
+            @endiif
+         @endiif
       }
-      if (k != KK)
+      if (k != KK) /* K-cleanup */
       {
 @ROUT ATL_cm2am ammmtst
+      /* zero padding the whole block first*/ 
+   @iif CU_NUKU = 0
+         unsigned int ii, jj;
+         TYPE *p = b; 
+         for (jj=0; jj < @(nu); jj++, p+=@(ku))
+            for (ii=0; ii < @(ku); ii++)
+               p[ii] = 0.0;
+   @endiif
+   @iif CU_NUKU ! 0
       @iexp j 0 0 +
       @iwhile j < @(nu)
          @iexp k 0 0 +
@@ -231,29 +421,37 @@ void ATL_USERCPMM       /* column- to access-major */
          @iexp j @(j) 1 +
                     0.0;
       @endiwhile
+   @endiif
 @ROUT ATL_am2cm ATL_cm2am ammmtst
          for (; i < K; i++, b++)
          {
-      @iexp j 0 0 +
-      @iwhile j < @(nu)
-         @iexp ib @(j) @(ku) *
-@ROUT ATL_am2cm
-            A@(j)[i] = @(malp)b[@(ib)];
-@ROUT ATL_cm2am ammmtst
-            b[@(ib)] = @(malp)A@(j)[i];
-@ROUT ATL_am2cm ATL_cm2am ammmtst
-         @iexp j @(j) 1 +
-      @endiwhile
+            @iif CU_NUKU ! 0
+               @callproc doKCuBlockNuKu
+            @endiif
+            @iif CU_NUKU = 0
+               @iif CU_NUR ! 0
+                  @callproc doKCuBlockNu @(nu)
+               @endiif
+               @iif CU_NUR = 0
+                  @callproc doKCuBlockRolled @(nu)
+               @endiif
+            @endiif
          }
          b += @(binc) - K + k;
       }
+   @iif NA1 = 0
       @iexp j 0 0 +
       @iwhile j < @(nu)
       A@(j) += incA;
       @iexp j @(j) 1 +
       @endiwhile
+   @endiif
+   @iif NA1 ! 0
+      A0 += incA;
+   @endiif
    }
-   switch(nr)
+@iif CU_NUKU ! 0 
+   switch(nr) /* N-cleanup */
    {
    @iexp n 1 0 +
    @iwhile n < @(nu)
@@ -331,10 +529,140 @@ void ATL_USERCPMM       /* column- to access-major */
    @endiwhile
    default:;
    }
+@endiif
+@iif CU_NUKU = 0
+   if (nr) /* N-cleanup */
+   {
+      for (i=0; i < k; i += @(ku), b += @(binc))
+      {
+      @iif CU_KUR ! 0
+         @callproc doBlockKu nr
+      @endiif
+      @iif CU_KUR = 0
+         @callproc doBlockRolled nr @(ku)
+      @endiif
+@ROUT ATL_cm2am ammmtst
+         /* zero padding */
+         for (; jj < @(nu); jj++, p+=@(ku))
+         {
+      @iif CU_KUR ! 0
+         @iexp j 0 
+         @iwhile j < @(ku)
+            p[@(j)] = 0.0;
+            @iexp j @(j) 1 +
+         @endiwhile
+      @endiif
+      @iif CU_KUR = 0
+            unsigned int ii;
+            for (ii=0; ii < @(ku); ii++)
+               p[ii] = 0.0;
+      @endiif
+         }
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+      }
+      if (k != KK)
+      {
+@ROUT ATL_cm2am ammmtst
+      /* zero padding the whole block first*/ 
+      @SKIP @iif CU_NO ! 0
+         unsigned int jj;
+         TYPE *p = b; 
+         for (jj=0; jj < @(nu); jj++, p+=@(ku))
+         {
+            unsigned int ii;
+            for (ii=0; ii < @(ku); ii++)
+            {
+               p[ii] = 0.0;
+            }
+         }
+      @SKIP @endiif
+      @BEGINSKIP ****skipping unrolling the zero padding when not fully unrolled     
+      @iif CU_NO = 0
+         @iexp j 0 0 +
+         @iwhile j < @(nu)
+            @iexp k 0 0 +
+            @iwhile k < @(ku)
+               @iexp ib @(j) @(ku) *
+               @iexp ib @(ib) @(k) +
+               b[@(ib)] = 
+               @iexp k @(k) 1 +
+            @endiwhile
+            @iexp j @(j) 1 +
+                    0.0;
+         @endiwhile
+      @endiif
+      @ENDSKIP 
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+         for (; i < K; i++, b++)
+         {
+            @callproc doKCuBlockRolled nr 
+@ROUT ATL_cm2am ammmtst
+            /* zero padding */
+            for (; jj < @(nu); jj++, p+=@(ku))
+               p[0] = 0.0;
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+         }
+         b += @(binc) - K + k;
+      }
+   }
+@endiif
 }
 @ROUT ammmtst `#endif`
 @endiif
 @iif kmaj = 0
+@SKIP ****** handles unrolled block copy
+@BEGINPROC doBlockNu nu_
+   @define j @dum@
+   @define k @dum@
+   @define jk @dum@
+      @iexp j 0 0 +
+      @iwhile j < @(nu_)
+         @iexp jk @(dupB) @(j) *
+         @iexp k @(dupB) -1 +
+@ROUT ATL_cm2am ammmtst
+         @iwhile k > 0
+         b[@(jk)+@(k)] =
+            @iexp k @(k) -1 +
+         @endiwhile
+         b[@(jk)] = @(malp)A@(j)[i];
+@ROUT ATL_am2cm
+         A@(j)[i] = @(malp)b[@(jk)];
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+      @iexp j @(j) 1 +
+      @endiwhile
+   @undef jk
+   @undef k
+   @undef j
+@ENDPROC
+@SKIP ***** handles rolled block copy 
+@BEGINPROC doBlockRolled nu_
+         unsigned int jj;
+         @(cnst)TYPE *rA = A0;
+         @(cnstb)TYPE *p = b;
+      @iif dupB = 1
+         for (jj=0; jj < @(nu_); jj++, rA += lda, p++)
+         {
+@ROUT ATL_cm2am ammmtst
+            *p = @(malp)rA[i];
+@ROUT ATL_am2cm
+            rA[i] = @(malp)*p;
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+         }
+      @endiif
+      @iif dupB > 1
+         for (jj=0; jj < @(nu_); jj++, rA += lda, p+=@(dupB))
+         {
+@ROUT ATL_cm2am ammmtst
+            unsigned int ii;
+            TYPE a0 = rA[i];
+            for (ii=0; ii < @(dupB); ii++)
+               p[ii] = @(malp)a0;
+@ROUT ATL_am2cm
+            rA[i] = @(malp)p[0];
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+         }
+      @endiif
+@ENDPROC
 @ROUT ATL_am2cm
 /*
  * Copies from (M-vectorized) access-major storage block b back to column-
@@ -390,6 +718,14 @@ void ATL_USERCPMM       /* col-access matx to access-major blk */
       @define KB @K@
    @endiif
    ATL_SZT i, j;
+   @iif CU_NUR = 0
+   ATL_CSZT nr = N-n;
+   @endiif
+@iexp NA1 1
+@iif @iexp 0 @(ML_NUR) ! 0 @(CU_NUR) ! |
+   @iexp NA1 0
+@endiif 
+   @iif NA1 = 0
    @declare "   @(cnst)TYPE " n n ";"
       *A0=A
       @define j @1@
@@ -399,48 +735,58 @@ void ATL_USERCPMM       /* col-access matx to access-major blk */
          @iexp j @(j) 1 +
       @endiwhile
    @enddeclare
-   @undef cnst
+   @endiif
+   @iif NA1 ! 0
+   @(cnst)TYPE *A0 = A;
+   @endiif
+   @SKIP @undef cnst
 
    for (j=0; j < n; j += @(nu))
    {
       for (i=0; i < K; i++, b += @(incdup))
       {
-      @iexp j 0 0 +
-      @iwhile j < @(nu)
-         @iexp jk @(dupB) @(j) *
-         @iexp k @(dupB) -1 +
-@ROUT ATL_cm2am ammmtst
-         @iwhile k > 0
-         b[@(jk)+@(k)] =
-            @iexp k @(k) -1 +
-         @endiwhile
-         b[@(jk)] = @(malp)A@(j)[i];
-@ROUT ATL_am2cm
-         A@(j)[i] = @(malp)b[@(jk)];
-@ROUT ATL_am2cm ATL_cm2am ammmtst
-      @iexp j @(j) 1 +
-      @endiwhile
+         @iif ML_NUR ! 0
+            @callproc doBlockNu @(nu)
+         @endiif
+         @iif ML_NUR = 0
+            @callproc doBlockRolled @(nu)
+         @endiif
       }
+   @iif NA1 = 0
       @iexp j 0 0 +
       @iwhile j < @(nu)
       A@(j) += incA;
       @iexp j @(j) 1 +
       @endiwhile
+   @endiif
+   @iif NA1 ! 0
+      A0 += incA;
+   @endiif
    @iif ku > 1
 @ROUT ATL_am2cm
       b += ZSKIP;
 @ROUT ATL_cm2am ammmtst
       for (;i < KK; i++, b += @(incdup))
+   @iif ML_NUR ! 0
       @iexp j 0
       @iwhile j < @(nu)
          b[@(j)] =
          @iexp j @(j) 1 +
       @endiwhile
                 ATL_rzero;
+   @endiif
+   @iif ML_NUR = 0
+      {
+         unsigned int jj;
+         for (jj=0; jj < @(nu); jj++)
+            b[jj] = ATL_rzero;
+      }
+   @endiif
 @ROUT ATL_am2cm ATL_cm2am ammmtst
    @endiif
    }
    @mif nu ! "1
+      @iif CU_NUR ! 0
    switch(N-n)
    {
    @iexp n 1 0 +
@@ -493,6 +839,31 @@ void ATL_USERCPMM       /* col-access matx to access-major blk */
    @endiwhile
    default:;
    }
+      @endiif
+      @SKIP **** rolled cleanup **** 
+      @iif CU_NUR = 0
+   if (nr)
+   {
+      for (i=0; i < K; i++, b += @(incdup))
+      {
+         @callproc doBlockRolled nr 
+@ROUT ATL_cm2am ammmtst
+         for (; jj < @(nu); jj++, p++)
+            *p = ATL_rzero;
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+      }
+@ROUT ATL_cm2am ammmtst
+   @iif ku > 1
+      for (; i < KK; i++, b += @(incdup))
+      {
+         unsigned int ii;
+         for (ii=0; ii < @(nu); ii++)
+            b[ii] = ATL_rzero;
+      }
+   @endiif
+@ROUT ATL_am2cm ATL_cm2am ammmtst
+   }
+      @endiif
    @endmif
 }
 @ROUT ammmtst `#endif`
@@ -517,6 +888,207 @@ void ATL_USERCPMM       /* col-access matx to access-major blk */
 @endifdef
 @iif kmaj ! 0
    @iexp ku2 @(ku) @(ku) +
+@SKIP *** handles element
+@BEGINPROC doElement A_ j_ k2_ rA_ iA_ ib_
+            @mif nalp ! "X
+@ROUT ATL_cam2cm
+                  @(A_)@(j_)[i+@(k2_)] = @(malp)@(rA_)[@(ib_)];
+               #ifdef Conj_
+                  @(A_)@(j_)[i+@(k2_)+1] = @(calp)@(iA_)[@(ib_)];
+               #else
+                  @(A_)@(j_)[i+@(k2_)+1] = @(malp)@(iA_)[@(ib_)];
+               #endif
+@ROUT ATL_ccm2am cammmtst
+               @(rA_)[@(ib_)] = @(malp)@(A_)@(j_)[i+@(k2_)];
+               #ifdef Conj_
+                  @(iA_)[@(ib_)] = @(calp)@(A_)@(j_)[i+@(k2_)+1];
+               #else
+                  @(iA_)[@(ib_)] = @(malp)@(A_)@(j_)[i+@(k2_)+1];
+               #endif
+@ROUT ATL_cam2cm ATL_ccm2am cammmtst
+            @endmif
+            @mif nalp = "X
+@ROUT ATL_cam2cm
+               rv = @(rA_)[@(ib_)];
+               #ifdef Conj_
+                  iv = @(iA_)[@(ib_)];
+               #else
+                  iv = -@(iA_)[@(ib_)];
+               #endif
+               @(A_)@(j_)[i+@(k2_)] = rv*ra - iv*ia;
+               @(A_)@(j_)[i+@(k2_)+1] = rv*ia + iv*ra;
+@ROUT ATL_ccm2am cammmtst
+               rv = @(A_)@(j_)[i+@(k2_)];
+               #ifdef Conj_
+                  iv = -@(A_)@(j_)[i+@(k2_)+1];
+               #else
+                  iv = @(A_)@(j_)[i+@(k2_)+1];
+               #endif
+               @(rA_)[@(ib_)] = rv*ra - iv*ia;
+               @(iA_)[@(ib_)] = rv*ia + iv*ra;
+@ROUT ATL_cam2cm ATL_ccm2am cammmtst
+            @endmif
+@ENDPROC
+@SKIP *** this proc handles one full block
+@BEGINPROC doBlockNuKu
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define ib @dum@
+      @iexp j 0 0 +
+      @iwhile j < @(nu)
+         @iexp k 0 0 +
+         @iwhile k < @(ku)
+            @iexp k2 @(k) @(k) +
+            @iexp ib @(j) @(ku) *
+            @iexp ib @(ib) @(k) +
+               @callproc doElement A @(j) @(k2) rA iA @(ib) 
+            @iexp k @(k) 1 +
+         @endiwhile
+         @iexp j @(j) 1 +
+      @endiwhile
+   @undef ib
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP *** this proc handles one full block with KU unrolled 
+@BEGINPROC doBlockKu nu_
+   @define k @dum@
+   @define k2 @dum@
+            unsigned int jj;
+            @(cnst)TYPE *pA0 = A0;
+            @(cnstb)TYPE *pr = rA, *pi = iA;
+            for (jj=0; jj < @(nu_); jj++, pA0 += lda2, pr+=@(ku), pi+=@(ku))
+            {
+      @iexp k 0 
+      @iwhile k < @(ku)
+         @iexp k2 @(k) @(k) +
+               @SKIP rA[i+@(k)] = @(malp)p[@(k)];
+               @callproc doElement pA 0 @(k2) pr pi @(k) 
+         @iexp k @(k) 1 +
+      @endiwhile
+            }
+   @undef k2
+   @undef k
+@ENDPROC
+@SKIP *** this proc handles one full block with NU unrolled 
+@BEGINPROC doBlockNu ku_
+   @define j @dum@
+   @define ib @dum@
+            unsigned int ii;
+            for (ii=0; ii < @(ku_); ii++)
+            {
+      @iexp j 0 
+      @iwhile j < @(nu)
+            @iexp ib @(j) @(ku) *
+               @SKIP ** real case : A@(j)[i+ii] = @(malp)b[@(ib)+ii];
+               @SKIP @callproc doElement A @(j) ii*2 rA iA @(ib)+ii 
+               @callproc doElement A @(j) (ii<<1) rA iA @(ib)+ii 
+         @iexp j @(j) 1 +
+      @endiwhile
+            }
+   @undef j
+   @undef ib
+@ENDPROC
+@SKIP *** this proc handles one full block in both rolled 
+@BEGINPROC doBlockRolled nu_ ku_
+            unsigned int jj;
+            @(cnst)TYPE *pA0 = A0;
+            @(cnstb)TYPE *pr = rA, *pi = iA;
+            for (jj=0; jj < @(nu_); jj++, pA0 += lda2, pr+=@(ku), pi+=@(ku))
+            {
+               unsigned int ii;
+               for (ii=0; ii < @(ku_); ii++)
+               {
+                  @SKIP rA[i+ii] = @(malp)p[ii];
+                  @SKIP @callproc doElement pA 0 (ii<<1) pr pi ii
+                  @callproc doElement pA 0 ii*2 pr pi ii
+               }
+            }
+@ENDPROC
+@SKIP *** handles single element for cleanup
+@SKIP *** NOTE: **** FIXME: call doElement with k2=0
+@BEGINPROC doCuElement A_ j_ rA_ iA_ ib_ 
+            @mif nalp ! "X
+@ROUT ATL_ccm2am cammmtst
+            @(rA_)[@(ib_)] = @(malp)@(A_)@(j_)[i];
+            #ifdef Conj_
+               @(iA_)[@(ib_)] = @(calp)@(A_)@(j_)[i+1];
+            #else
+               @(iA_)[@(ib_)] = @(malp)@(A_)@(j_)[i+1];
+            #endif
+@ROUT ATL_cam2cm
+            @(A_)@(j_)[i] = @(malp)@(rA_)[@(ib_)];
+            #ifdef Conj_
+               @(A_)@(j_)[i+1] = @(calp)@(iA_)[@(ib_)];
+            #else
+               @(A_)@(j_)[i+1] = @(malp)@(iA_)[@(ib_)];
+            #endif
+@ROUT ATL_cam2cm ATL_ccm2am cammmtst
+            @endmif
+            @mif nalp = "X
+@ROUT ATL_ccm2am cammmtst
+            rv = @(A_)@(j_)[i];
+            #ifdef Conj_
+               iv = -@(A_)@(j_)[i+1];
+            #else
+               iv = @(A_)@(j_)[i+1];
+            #endif
+            @(rA_)[@(ib_)] = rv*ra - iv*ia;
+            @(iA_)[@(ib_)] = rv*ia + iv*ra;
+@ROUT ATL_cam2cm
+            rv = @(rA_)[@(ib_)];
+            #ifdef Conj_
+               iv = -@(iA_)[@(ib_)];
+            #else
+               iv = @(iA_)[@(ib_)];
+            #endif
+            @(A_)@(j_)[i] = rv*ra - iv*ia;
+            @(A_)@(j_)[i+1] = rv*ia + iv*ra;
+@ROUT ATL_cam2cm ATL_ccm2am cammmtst
+            @endmif
+@ENDPROC
+@SKIP *** this proc handles K-cleanup block 
+@BEGINPROC doKCuBlockNuKu
+   @define j @dum@
+   @define ib @dum@
+      @iexp j 0 0 +
+      @iwhile j < @(nu)
+         @iexp ib @(j) @(ku) *
+            @callproc doCuElement A @(j) rA iA @(ib) 
+         @iexp j @(j) 1 +
+      @endiwhile
+   @undef ib
+   @undef j
+@ENDPROC
+@SKIP *** this proc handles K-cleanup block 
+@BEGINPROC doKCuBlockRolled nu_
+   @define k @dum@
+            unsigned int jj;
+            @(cnst)TYPE *pA0 = A0;
+            @(cnstb)TYPE *pr = rA, *pi = iA;
+            for (jj=0; jj < @(nu_); jj++, pA0 += lda2, pr+=@(ku), pi+=@(ku))
+            {
+               @SKIP rA[i] = @(malp)p[0];
+               @callproc doCuElement pA 0 pr pi 0 
+            }
+   @undef k
+@ENDPROC 
+@SKIP *** this proc handles K-cleanup block 
+@BEGINPROC doKCuBlockNu nu_
+   @define j @dum@
+   @define ib @dum@
+      @iexp j 0 
+      @iwhile j < @(nu_)
+         @iexp ib @(j) @(ku) *
+            @SKIP A@(j)[i] = @(malp)b[@(ib)];
+            @callproc doCuElement A @(j) rA iA @(ib)
+         @iexp j @(j) 1 +
+      @endiwhile
+   @undef ib
+   @undef j
+@ENDPROC 
 @ROUT ATL_cam2cm
 void ATL_USERCPMM
 (
@@ -574,6 +1146,11 @@ void ATL_USERCPMM
    const register TYPE ra=(*alpha), ia=alpha[1];
    register TYPE rv, iv;
    @endmif
+@iexp NA1 1
+@iif @iexp 0 @(ML_NUR) ! 0 @(CU_NUR) ! |
+   @iexp NA1 0
+@endiif 
+@iif NA1 = 0
    @declare "   @(cnst)TYPE " n n ";"
       *A0=A
       @define j @1@
@@ -583,65 +1160,42 @@ void ATL_USERCPMM
          @iexp j @(j) 1 +
       @endiwhile
    @enddeclare
+@endiif
+@iif NA1 ! 0
+   @(cnst)TYPE *A0=A;
+@endiif
    @iexp binc @(nu) @(ku) *
 
    for (j=0; j < n; j += @(nu))
    {
       for (i=0; i < k2; i += @(ku2), rA += @(binc), iA += @(binc))
       {
-      @iexp j 0 0 +
-      @iwhile j < @(nu)
-         @iexp k 0 0 +
-         @iwhile k < @(ku)
-            @iexp k2 @(k) @(k) +
-            @iexp ib @(j) @(ku) *
-            @iexp ib @(ib) @(k) +
-            @mif nalp ! "X
-@ROUT ATL_cam2cm
-         A@(j)[i+@(k2)] = @(malp)rA[@(ib)];
-         #ifdef Conj_
-            A@(j)[i+@(k2)+1] = @(calp)iA[@(ib)];
-         #else
-            A@(j)[i+@(k2)+1] = @(malp)iA[@(ib)];
-         #endif
-@ROUT ATL_ccm2am cammmtst
-         rA[@(ib)] = @(malp)A@(j)[i+@(k2)];
-         #ifdef Conj_
-            iA[@(ib)] = @(calp)A@(j)[i+@(k2)+1];
-         #else
-            iA[@(ib)] = @(malp)A@(j)[i+@(k2)+1];
-         #endif
-@ROUT ATL_cam2cm ATL_ccm2am cammmtst
-            @endmif
-            @mif nalp = "X
-@ROUT ATL_cam2cm
-         rv = rA[@(ib)];
-         #ifdef Conj_
-            iv = iA[@(ib)];
-         #else
-            iv = -iA[@(ib)];
-         #endif
-         A@(j)[i+@(k2)] = rv*ra - iv*ia;
-         A@(j)[i+@(k2)+1] = rv*ia + iv*ra;
-@ROUT ATL_ccm2am cammmtst
-         rv = A@(j)[i+@(k2)];
-         #ifdef Conj_
-            iv = -A@(j)[i+@(k2)+1];
-         #else
-            iv = A@(j)[i+@(k2)+1];
-         #endif
-         rA[@(ib)] = rv*ra - iv*ia;
-         iA[@(ib)] = rv*ia + iv*ra;
-@ROUT ATL_cam2cm ATL_ccm2am cammmtst
-            @endmif
-            @iexp k @(k) 1 +
-         @endiwhile
-         @iexp j @(j) 1 +
-      @endiwhile
+      @iif ML_NUKU ! 0
+         @callproc doBlockNuKu 
+      @endiif
+      @iif ML_NUKU = 0
+         @iif ML_KUR ! 0
+            @callproc doBlockKu @(nu) 
+         @endiif
+         @iif ML_NUR ! 0
+            @callproc doBlockNu @(ku) 
+         @endiif
+         @iif ML_NO ! 0
+            @callproc doBlockRolled @(nu) @(ku) 
+         @endiif
+      @endiif
       }
       if (k != KK)
       {
 @ROUT ATL_ccm2am cammmtst
+   @iif CU_NUKU = 0
+         unsigned int ii, jj;
+         TYPE *pr = rA, *pi = iA;
+         for (jj=0; jj < @(nu); jj++, pr+=@(ku), pi+=@(ku))
+            for (ii=0; ii < @(ku); ii++)
+               pr[ii] = pi[ii] = 0.0;
+   @endiif
+   @iif CU_NUKU ! 0
       @iexp j 0 0 +
       @iwhile j < @(nu)
          @iexp k 0 0 +
@@ -654,62 +1208,37 @@ void ATL_USERCPMM
          @iexp j @(j) 1 +
                     0.0;
       @endiwhile
+   @endiif
 @ROUT ATL_cam2cm ATL_ccm2am cammmtst
          for (; i < K2; i += 2, rA++, iA++)
          {
-      @iexp j 0 0 +
-      @iwhile j < @(nu)
-         @iexp ib @(j) @(ku) *
-            @mif nalp ! "X
-@ROUT ATL_ccm2am cammmtst
-            rA[@(ib)] = @(malp)A@(j)[i];
-            #ifdef Conj_
-               iA[@(ib)] = @(calp)A@(j)[i+1];
-            #else
-               iA[@(ib)] = @(malp)A@(j)[i+1];
-            #endif
-@ROUT ATL_cam2cm
-            A@(j)[i] = @(malp)rA[@(ib)];
-            #ifdef Conj_
-               A@(j)[i+1] = @(calp)iA[@(ib)];
-            #else
-               A@(j)[i+1] = @(malp)iA[@(ib)];
-            #endif
-@ROUT ATL_cam2cm ATL_ccm2am cammmtst
-            @endmif
-            @mif nalp = "X
-@ROUT ATL_ccm2am cammmtst
-            rv = A@(j)[i];
-            #ifdef Conj_
-               iv = -A@(j)[i+1];
-            #else
-               iv = A@(j)[i+1];
-            #endif
-            rA[@(ib)] = rv*ra - iv*ia;
-            iA[@(ib)] = rv*ia + iv*ra;
-@ROUT ATL_cam2cm
-            rv = rA[@(ib)];
-            #ifdef Conj_
-               iv = -iA[@(ib)];
-            #else
-               iv = iA[@(ib)];
-            #endif
-            A@(j)[i] = rv*ra - iv*ia;
-            A@(j)[i+1] = rv*ia + iv*ra;
-@ROUT ATL_cam2cm ATL_ccm2am cammmtst
-            @endmif
-         @iexp j @(j) 1 +
-      @endiwhile
+            @iif CU_NUKU ! 0
+               @callproc doKCuBlockNuKu 
+            @endiif
+            @iif CU_NUKU = 0
+               @iif CU_NUR ! 0
+                  @callproc doKCuBlockNu @(nu)
+               @endiif
+               @iif CU_NUR = 0
+                  @callproc doKCuBlockRolled @(nu)
+               @endiif
+            @endiif
          }
          rA += @(binc) - K + k;
          iA += @(binc) - K + k;
       }
+   @iif NA1 = 0
       @iexp j 0 0 +
       @iwhile j < @(nu)
       A@(j) += incA;
       @iexp j @(j) 1 +
       @endiwhile
+   @endiif
+   @iif NA1 ! 0
+      A0 += incA;
+   @endiif
    }
+@iif CU_NUKU ! 0 
    switch(nr)
    {
    @iexp n 1 0 +
@@ -857,10 +1386,157 @@ void ATL_USERCPMM
    @endiwhile
    default:;
    }
+@endiif
+@iif CU_NUKU = 0
+   if (nr) /* N-cleanup */
+   {
+      for (i=0; i < k2; i += @(ku2), rA += @(binc), iA += @(binc))
+      {
+      @iif CU_KUR ! 0
+         @callproc doBlockKu nr
+      @endiif
+      @iif CU_KUR = 0
+         @callproc doBlockRolled nr @(ku)
+      @endiif
+@ROUT ATL_ccm2am cammmtst
+         /* zero padding */
+         for (; jj < @(nu); jj++, pr+=@(ku), pi+=@(ku))
+         {
+      @iif CU_KUR ! 0
+         @iexp j 0 
+         @iwhile j < @(ku)
+            pr[@(j)] = pi[@(j)] = 0.0;
+            @iexp j @(j) 1 +
+         @endiwhile
+      @endiif
+      @iif CU_KUR = 0
+            unsigned int ii;
+            for (ii=0; ii < @(ku); ii++)
+               pr[ii] = pi[ii] = 0.0;
+      @endiif
+         }
+@ROUT ATL_cam2cm ATL_ccm2am cammmtst
+      }
+      if (k != KK)
+      {
+@ROUT ATL_ccm2am cammmtst
+      /* zero padding the whole block first*/ 
+      @SKIP @iif CU_NO ! 0
+         unsigned int ii, jj;
+         TYPE *pr = rA, *pi = iA; 
+         for (jj=0; jj < @(nu); jj++, pr+=@(ku), pi+=@(ku))
+            for (ii=0; ii < @(ku); ii++)
+               pi[ii] = pr[ii] = 0.0;
+      @SKIP @endiif
+      @BEGINSKIP ***skipping unrolling the zero padding when not fully unrolled     
+      @iif CU_NO = 0
+         @iexp j 0 0 +
+         @iwhile j < @(nu)
+            @iexp k 0 0 +
+            @iwhile k < @(ku)
+               @iexp ib @(j) @(ku) *
+               @iexp ib @(ib) @(k) +
+               iA[@(ib)] = rA[@(ib)] =
+               @iexp k @(k) 1 +
+            @endiwhile
+            @iexp j @(j) 1 +
+                    0.0;
+         @endiwhile
+      @endiif
+      @ENDSKIP 
+@ROUT ATL_cam2cm ATL_ccm2am cammmtst
+         for (; i < K2; i+=2, rA++, iA++)
+         {
+            @callproc doKCuBlockRolled nr 
+@ROUT ATL_ccm2am cammmtst
+            /* zero padding */
+            for (; jj < @(nu); jj++, pr+=@(ku), pi+=@(ku))
+               pr[0] = pi[0] = 0.0;
+@ROUT ATL_cam2cm ATL_ccm2am cammmtst
+         }
+         rA += @(binc) - K + k;
+         iA += @(binc) - K + k;
+      }
+   }
+@endiif
 }
 @ROUT cammmtst `#endif`
 @endiif
 @iif kmaj = 0
+@SKIP *** handles single cell
+@BEGINPROC doElement A_ j_ rA_ iA_  
+         @mif nalp = "X
+@ROUT ATL_ccm2am cammmtst
+            rv = @(A_)@(j_)[i];
+            #ifdef Conj_
+               iv = -@(A_)@(j_)[i+1];
+            #else
+               iv = @(A_)@(j_)[i+1];
+            #endif
+            @(rA_)[@(j_)] = rv*ra - iv*ia;
+            @(iA_)[@(j_)] = rv*ia + iv*ra;
+@ROUT ATL_cam2cm
+            rv = @(rA_)[@(j_)];
+            #ifdef Conj_
+               iv = -@(iA_)[@(j_)];
+            #else
+               iv = @(iA_)[@(j_)];
+            #endif
+            @(A_)@(j_)[i] = rv*ra - iv*ia;
+            @(A_)@(j_)[i+1] = rv*ia + iv*ra;
+@ROUT ATL_cam2cm ATL_ccm2am cammmtst
+         @endmif
+         @mif nalp ! "X
+@ROUT ATL_ccm2am cammmtst
+            @(rA_)[@(j_)] = @(malp)@(A_)@(j_)[i];
+            #ifdef Conj_
+               @(iA_)[@(j_)] = @(calp)@(A_)@(j_)[i+1];
+            #else
+               @(iA_)[@(j_)] = @(malp)@(A_)@(j_)[i+1];
+            #endif
+@ROUT ATL_cam2cm
+            @(A_)@(j_)[i] = @(malp)@(rA_)[@(j_)];
+            #ifdef Conj_
+               @(A_)@(j_)[i+1] = @(calp)@(iA_)[@(j_)];
+            #else
+               @(A_)@(j_)[i+1] = @(malp)@(iA_)[@(j_)];
+            #endif
+@ROUT ATL_cam2cm ATL_ccm2am cammmtst
+         @endmif
+@ENDPROC
+@SKIP *** handles block unrolled 
+@BEGINPROC doBlockNu nu_
+      @iexp j 0 0 +
+      @iwhile j < @(nu_)
+         @callproc doElement A @(j) rA iA  
+      @iexp j @(j) 1 +
+      @endiwhile
+@ENDPROC
+@SKIP *** handles one block rolled 
+@BEGINPROC doBlockRolled nu_
+         unsigned int jj;
+         @(cnst)TYPE *pA0 = A0;
+         @(cnstb)TYPE *pr = rA, *pi = iA;
+         for (jj=0; jj < @(nu_); jj++, pA0 += lda2, pr++, pi++)
+         {
+            @callproc doElement pA 0 pr pi 
+         }
+@ENDPROC
+@SKIP *** Handles cleanup rolled block only 
+@BEGINPROC doCuBlockRolled 
+         @callproc doBlockRolled nr
+         for (; jj < @(nu); jj++, pr++, pi++)
+            pr[0] = pi[0] = ATL_rzero;
+@ENDPROC
+@SKIP *** zero padding on K dimension
+@BEGINPROC doKzeroPadRolled
+      for (i=0; i < KR; i++, rA += @(nu), iA += @(nu))
+      {
+         unsigned int ii; 
+         for (ii=0; ii < @(nu); ii++)
+            rA[ii] = iA[ii] = ATL_rzero;
+      }
+@ENDPROC
 @ROUT ATL_cam2cm
 @beginskip
 #ifdef Conj_
@@ -917,6 +1593,7 @@ void ATL_cm2am
 @ROUT ATL_cam2cm ATL_ccm2am cammmtst
 {
    ATL_CSZT K2=K+K, lda2=lda+lda, n = (N/@(nu))*@(nu), incA = lda2*@(nu);
+   ATL_CSZT nr = N-n;
    @iif ku > 1
    ATL_CSZT KK = ((K+@(ku)-1)/@(ku))*@(ku), KR=KK-K;
 @ROUT ATL_cam2cm  `   ATL_CINT ZINC = KR*@(nu)`
@@ -927,6 +1604,11 @@ void ATL_cm2am
    register TYPE rv, iv;
    @endmif
    @iexp nu2 @(nu) @(nu) +
+@iexp NA1 1
+@iif @iexp 0 @(ML_NUR) ! 0 @(CU_NUR) ! |
+   @iexp NA1 0
+@endiif 
+   @iif NA1 = 0
    @declare "   @(cnst)TYPE " n n ";"
       *A0=A
       @define j @1@
@@ -936,59 +1618,27 @@ void ATL_cm2am
          @iexp j @(j) 1 +
       @endiwhile
    @enddeclare
-
+   @endiif
+   @iif NA1 ! 0
+   @(cnst)TYPE *A0 = A;
+   @endiif
    for (j=0; j < n; j += @(nu))
    {
       for (i=0; i < K2; i += 2, rA += @(nu), iA += @(nu))
       {
-      @iexp j 0 0 +
-      @iwhile j < @(nu)
-         @mif nalp = "X
-@ROUT ATL_ccm2am cammmtst
-         rv = A@(j)[i];
-         #ifdef Conj_
-            iv = -A@(j)[i+1];
-         #else
-            iv = A@(j)[i+1];
-         #endif
-         rA[@(j)] = rv*ra - iv*ia;
-         iA[@(j)] = rv*ia + iv*ra;
-@ROUT ATL_cam2cm
-         rv = rA[@(j)];
-         #ifdef Conj_
-            iv = -iA[@(j)];
-         #else
-            iv = iA[@(j)];
-         #endif
-         A@(j)[i] = rv*ra - iv*ia;
-         A@(j)[i+1] = rv*ia + iv*ra;
-@ROUT ATL_cam2cm ATL_ccm2am cammmtst
-         @endmif
-         @mif nalp ! "X
-@ROUT ATL_ccm2am cammmtst
-         rA[@(j)] = @(malp)A@(j)[i];
-         #ifdef Conj_
-            iA[@(j)] = @(calp)A@(j)[i+1];
-         #else
-            iA[@(j)] = @(malp)A@(j)[i+1];
-         #endif
-@ROUT ATL_cam2cm
-         A@(j)[i] = @(malp)rA[@(j)];
-         #ifdef Conj_
-            A@(j)[i+1] = @(calp)iA[@(j)];
-         #else
-            A@(j)[i+1] = @(malp)iA[@(j)];
-         #endif
-@ROUT ATL_cam2cm ATL_ccm2am cammmtst
-         @endmif
-      @iexp j @(j) 1 +
-      @endiwhile
+         @iif ML_NUR ! 0
+            @callproc doBlockNu @(nu)
+         @endiif
+         @iif ML_NUR = 0
+            @callproc doBlockRolled @(nu)
+         @endiif
       }
    @iif ku > 1
 @ROUT ATL_cam2cm
       rA += ZINC;
       iA += ZINC;
 @ROUT ATL_ccm2am cammmtst
+   @iif ML_NUR ! 0
       for (i=0; i < KR; i++, rA += @(nu), iA += @(nu))
       @iexp j 0
       @iwhile j < @(nu)
@@ -996,15 +1646,25 @@ void ATL_cm2am
       @iexp j @(j) 1 +
       @endiwhile
                          ATL_rzero;
+   @endiif
+   @iif ML_NUR = 0
+      @callproc doKzeroPadRolled
+   @endiif
 @ROUT ATL_cam2cm ATL_ccm2am cammmtst
    @endiif
+   @iif NA1 = 0
       @iexp j 0 0 +
       @iwhile j < @(nu)
       A@(j) += incA;
       @iexp j @(j) 1 +
       @endiwhile
+   @endiif
+   @iif NA1 ! 0
+      A0 += incA;
+   @endiif
    }
    @mif nu ! "1
+@iif CU_NUR ! 0
    switch(N-n)
    {
    @iexp n 1 0 +
@@ -1078,6 +1738,21 @@ void ATL_cm2am
    @endiwhile
    default:;
    }
+@endiif
+@iif CU_NUR = 0
+   if (nr)
+   {
+      for (i=0; i < K2; i += 2, rA += @(nu), iA += @(nu))
+      {
+         @callproc doCuBlockRolled 
+      }
+@ROUT ATL_ccm2am cammmtst
+   @iif ku > 1
+      @callproc doKzeroPadRolled 
+   @endiif
+@ROUT ATL_cam2cm ATL_ccm2am cammmtst
+   }
+@endiif
    @endmif
 }
 @ROUT cammmtst `#endif`
@@ -1085,6 +1760,108 @@ void ATL_cm2am
 @ROUT ATL_am2rm ATL_rm2am ammmtst
 @iif kmaj ! 0
    @define ku @@(kmaj)@
+@SKIP **** handles full block fully unrolled 
+@BEGINPROC doBlockMuKu mu_ ku_
+   @define i @dum@
+   @define j @dum@
+   @define ip @dum@
+   @iexp i 0 0 +
+   @iwhile i < @(mu_)
+      @iexp j 0 0 +
+      @iwhile j < @(ku_)
+         @iexp ip @(i) @(ku_) *
+         @iexp ip @(ip) @(j) +
+@ROUT ATL_am2rm
+         A@(j)[i+@(i)] = @(malp)pp[@(ip)];
+@ROUT ATL_rm2am ammmtst
+         pp[@(ip)] = @(malp)A@(j)[i+@(i)];
+@ROUT ATL_am2rm ATL_rm2am ammmtst
+         @iexp j @(j) 1 +
+      @endiwhile
+      @iexp i @(i) 1 +
+   @endiwhile
+   @undef ip
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP **** handles full block unrolled MU  
+@BEGINPROC doBlockMu ku_ 
+   @define j @dum@
+   @define ip @dum@
+         unsigned int jj;
+         @(cnst)TYPE *rA = A0;
+         @(cnstb)TYPE *p = pp;
+         for(jj=0; jj < @(ku_); jj++, rA +=lda, p++) 
+         {
+      @iexp j 0 
+      @iwhile j < @(mu)
+         @iexp ip @(j) @(ku) *
+@ROUT ATL_am2rm
+            rA[i+@(j)] = @(malp)p[@(ip)];
+@ROUT ATL_rm2am ammmtst
+            p[@(ip)] = @(malp)rA[i+@(j)];
+@ROUT ATL_am2rm ATL_rm2am ammmtst
+         @iexp j @(j) 1 +
+      @endiwhile
+         }
+   @undef ip
+   @undef j
+@ENDPROC
+@SKIP **** handles full block unrolled KU  
+@BEGINPROC doBlockKu mu_ 
+   @define j @dum@
+         unsigned int ii;
+         @(cnstb)TYPE *p = pp;
+         for(ii=0; ii < @(mu_); ii++, p+=@(ku)) 
+         {
+      @iexp j 0 0 +
+      @iwhile j < @(ku)
+@ROUT ATL_am2rm
+            A@(j)[i+ii] = @(malp)p[@(j)];
+@ROUT ATL_rm2am ammmtst
+            p[@(j)] = @(malp)A@(j)[i+ii];
+@ROUT ATL_am2rm ATL_rm2am ammmtst
+         @iexp j @(j) 1 +
+      @endiwhile
+         }
+   @undef j
+@ENDPROC
+@SKIP **** handles full block rolled 
+@BEGINPROC doBlockRolled mu_ ku_ 
+         unsigned int jj;
+         @(cnst)TYPE *rA = A0;
+         @(cnstb)TYPE *p = pp;
+         for(jj=0; jj < @(ku_); jj++, rA +=lda, p++)
+         {
+            unsigned int ii;
+            @(cnstb)TYPE *w = p;
+            for(ii=0; ii < @(mu_); ii++, w+=@(ku_)) 
+            {
+@ROUT ATL_am2rm
+               rA[i+ii] = @(malp)(*w);
+@ROUT ATL_rm2am ammmtst
+               *w = @(malp)rA[i+ii];
+@ROUT ATL_am2rm ATL_rm2am ammmtst
+            }
+         }
+@ENDPROC
+@SKIP ****** handles K-cleanup in rolled, without zero padding 
+@BEGINPROC doKCuBlockRolled mu_ ku_
+         unsigned int jj;
+         @(cnst)TYPE *rA = A0;
+         @(cnstb)TYPE *p = pp;
+         for(jj=0; jj < @(ku_); jj++, rA +=lda, p++)
+         {
+            unsigned int ii;
+            @(cnstb)TYPE *w = p;
+            for(ii=0; ii < @(mu_); ii++, w+=@(ku)) 
+@ROUT ATL_am2rm
+               rA[i+ii] = @(malp)(*w);
+@ROUT ATL_rm2am ammmtst
+               *w = @(malp)rA[i+ii];
+@ROUT ATL_am2rm ATL_rm2am ammmtst
+         }
+@ENDPROC
 @ROUT ATL_am2rm
 void ATL_USERCPMM       /* access-major blk to row-major matrix */
 (
@@ -1127,8 +1904,13 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
 {
    ATL_CSZT MM = ((M+@(mu)-1)/@(mu))*@(mu), KK = ((K+@(ku)-1)/@(ku))*@(ku);
    ATL_CSZT pansz = @(mu)*KK, m = M/@(mu)*@(mu), mr = M-m, incA = @(ku)*lda;
-   ATL_CSZT k = (K/@(ku))*@(ku);
+   ATL_CSZT k = (K/@(ku))*@(ku), kr = K-k;
    ATL_SZT i, j;
+@iexp NA1 1
+@iif @iexp 0 @(ML_KUR) ! 0 @(CU_KUR) ! |
+   @iexp NA1 0
+@endiif 
+@iif NA1 = 0
    @declare "   @(cnst)TYPE " n n ";"
       *A0=A
       @iexp j 0 1 +
@@ -1138,6 +1920,10 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
          @iexp j @(j) 1 +
       @endiwhile
    @enddeclare
+@endiif
+@iif NA1 ! 0
+   @(cnst)TYPE *A0=A;
+@endiif
    @iexp incb @(ku) @(mu) *
 
    for (j=0; j < k; j += @(ku), b += @(incb))
@@ -1146,23 +1932,22 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
 
       for (i=0; i < m; i += @(mu), pp += pansz)
       {
-   @iexp i 0 0 +
-   @iwhile i < @(mu)
-      @iexp j 0 0 +
-      @iwhile j < @(ku)
-         @iexp ip @(i) @(ku) *
-         @iexp ip @(ip) @(j) +
-@ROUT ATL_am2rm
-         A@(j)[i+@(i)] = @(malp)pp[@(ip)];
-@ROUT ATL_rm2am ammmtst
-         pp[@(ip)] = @(malp)A@(j)[i+@(i)];
-@ROUT ATL_am2rm ATL_rm2am ammmtst
-         @iexp j @(j) 1 +
-      @endiwhile
-      @iexp i @(i) 1 +
-   @endiwhile
+         @iif ML_NUKU ! 0
+            @callproc doBlockMuKu @(mu) @(ku)
+         @endiif
+         @iif ML_NUKU = 0
+            @iif ML_NUR ! 0 
+               @callproc doBlockMu @(ku)
+            @endiif
+            @iif ML_KUR ! 0 
+               @callproc doBlockKu @(mu)
+            @endiif
+            @iif ML_NO ! 0
+               @callproc doBlockRolled @(mu) @(ku)
+            @endiif
+         @endiif
       }
-      if (m != M)
+      if (m != M) /* M cleanup */
       {
          @(cnstb)TYPE *p;
 /*
@@ -1170,15 +1955,23 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
  */
          for (p=pp; i < M; i++, p += @(ku))
          {
-   @iexp j 0 0 +
-   @iwhile j < @(ku)
+      @iif CU_KUR ! 0
+         @iexp j 0 0 +
+         @iwhile j < @(ku)
 @ROUT ATL_rm2am ammmtst
             p[@(j)] = @(malp)A@(j)[i];
 @ROUT ATL_am2rm
             A@(j)[i] = @(malp)p[@(j)];
 @ROUT ATL_am2rm ATL_rm2am ammmtst
-      @iexp j @(j) 1 +
-   @endiwhile
+            @iexp j @(j) 1 +
+         @endiwhile
+      @endiif
+      @iif CU_KUR = 0
+            unsigned int jj;
+            @(cnst)TYPE *rA = A0;
+            for (jj=0; jj < @(ku); jj++, rA+=lda)
+               p[jj] = rA[i];
+      @endiif
          }
 @ROUT ATL_rm2am ammmtst
 /*
@@ -1186,14 +1979,22 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
  */
          for (; i < MM; i++, p += @(ku))
          {
-   @iexp j 0 0 +
-   @iwhile j < @(ku)
+      @iif CU_KUR ! 0
+         @iexp j 0 0 +
+         @iwhile j < @(ku)
             p[@(j)] = 0.0;
-      @iexp j @(j) 1 +
-   @endiwhile
+            @iexp j @(j) 1 +
+         @endiwhile
+      @endiif
+      @iif CU_KUR = 0
+            unsigned int jj;
+            for (jj=0; jj < @(ku); jj++)
+               p[jj] = 0.0;
+      @endiif
          }
 @ROUT ATL_am2rm ATL_rm2am ammmtst
       }
+@iif NA1 = 0
 /*
  * Update column-ptrs from A
  */
@@ -1202,10 +2003,15 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
       A@(j) += incA;
       @iexp j @(j) 1 +
    @endiwhile
+@endiif
+@iif NA1 ! 0
+      A0 += incA;
+@endiif
    }
 /*
  * Check for final, partial K-panel that needs to be padded wt zeros
  */
+@iif CU_NUKU ! 0
    switch(K-k)
    {
    @iexp r @(ku) -1 +
@@ -1284,6 +2090,68 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
    @endiwhile
    default:;
    }
+@endiif
+@iif CU_NUKU = 0
+   if (kr)
+   {
+      @(cnstb)TYPE *pp = b;   /* panel ptr */
+      for (i=0; i < m; i += @(mu), pp += pansz)
+      {
+         @iif CU_NUR ! 0
+            @callproc doBlockMu kr
+         @endiif
+         @iif CU_NUR = 0
+            @callproc doKCuBlockRolled @(mu) kr
+         @endiif
+@ROUT ATL_rm2am ammmtst
+         /* zero padding */
+         for (; jj < @(ku); jj++, p++)
+         {
+      @iif CU_NUR ! 0
+         @iexp j 0 0 +
+         @iwhile j < @(mu)
+            @iexp ip @(j) @(ku) *
+            p[@(ip)] = 0.0;
+            @iexp j @(j) 1 +
+         @endiwhile
+      @endiif
+      @iif CU_NUR = 0
+            unsigned int ii;
+            TYPE *w = p;
+            for (ii=0; ii < @(mu); ii++, w+=@(ku))
+               *w = 0.0;
+      @endiif
+         }
+@ROUT ATL_am2rm ATL_rm2am ammmtst
+      }
+      if (m != M)
+      {
+         @(cnstb)TYPE *p = pp; 
+         for ( ; i < M; i++, p+=@(ku))
+         {
+            unsigned int jj;
+            @(cnst)TYPE *rA = A0;
+            for (jj=0; jj < kr; jj++, rA+=lda)
+@ROUT ATL_rm2am ammmtst
+               p[jj] = @(malp)rA[i];
+            for ( ; jj < @(ku); jj++)
+               p[jj] = 0.0;
+         }
+/*
+ *       Zero rest of M remainder subblock
+ */
+         for (; i < MM; i++, p += @(ku))
+         {
+            unsigned int jj;
+            for (jj=0; jj < @(ku); jj++)
+               p[jj] = 0.0;
+@ROUT ATL_am2rm
+               rA[i] = @(malp)p[jj];
+@ROUT ATL_am2rm ATL_rm2am ammmtst
+         }
+      }
+   }
+@endiif
 }
 @ROUT ammmtst `#endif`
 @endiif
@@ -1291,6 +2159,58 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
    @define dupB @1@
 @ROUT ATL_am2rm ATL_rm2am ammmtst
 @iif kmaj = 0
+@SKIP *** handles block unrolled 
+@BEGINPROC doBlockMU mu_
+   @define i @dum@
+   @define k @dum@
+   @define ik @dum@
+      @iexp i 0 0 +
+      @iwhile i < @(mu_)
+         @iexp ik @(dupB) @(i) *
+@ROUT ATL_rm2am ammmtst
+         @iexp k @(dupB) -1 +
+         @iwhile k > 0
+         pp[@(ik)+@(k)] =
+            @iexp k @(k) -1 +
+         @endiwhile
+         pp[@(ik)] = @(malp)A[@(i)];
+@ROUT ATL_am2rm
+         A[@(i)] = @(malp)pp[@(ik)];
+@ROUT ATL_am2rm ATL_rm2am ammmtst
+      @iexp i @(i) 1 +
+      @endiwhile
+   @undef ik 
+   @undef k 
+   @undef i 
+@ENDPROC
+@SKIP *** handles block rolled
+@BEGINPROC doBlockRolled mu_
+         unsigned int ii;
+      @iif dupB = 1
+         for (ii=0; ii < @(mu_); ii++)
+         {
+@ROUT ATL_rm2am ammmtst
+            pp[ii] = @(malp)A[ii];
+@ROUT ATL_am2rm
+            A[ii] = @(malp)*pp[ii];
+@ROUT ATL_am2rm ATL_rm2am ammmtst
+         }
+      @endiif
+      @iif dupB > 1
+         @(cnstb)TYPE *p = pp;
+         for (ii=0; ii < @(mu_); ii++, p+=@(dupB))
+         {
+@ROUT ATL_rm2am ammmtst
+            unsigned int jj;
+            TYPE a0 = A[ii];
+            for (jj=0; jj < @(dupB); jj++)
+               p[jj] = @(malp)a0;
+@ROUT ATL_am2rm
+            A[ii] = @(malp)p[0];
+@ROUT ATL_am2rm ATL_rm2am ammmtst
+         }
+      @endiif
+@ENDPROC
 @ROUT ATL_am2rm
 @beginskip
 @iif dupB > 1
@@ -1353,23 +2273,15 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
       @(cnstb)TYPE *pp = b;  /* panel ptr */
       for (i=0; i < m; i += @(mu), pp += pansz, A += @(mu))
       {
-      @iexp i 0 0 +
-      @iwhile i < @(mu)
-         @iexp ik @(dupB) @(i) *
-@ROUT ATL_rm2am ammmtst
-         @iexp k @(dupB) -1 +
-         @iwhile k > 0
-         pp[@(ik)+@(k)] =
-            @iexp k @(k) -1 +
-         @endiwhile
-         pp[@(ik)] = @(malp)A[@(i)];
-@ROUT ATL_am2rm
-         A[@(i)] = @(malp)pp[@(ik)];
-@ROUT ATL_am2rm ATL_rm2am ammmtst
-      @iexp i @(i) 1 +
-      @endiwhile
+      @iif ML_NUR ! 0
+         @callproc doBlockMU @(mu)
+      @endiif 
+      @iif ML_NUR = 0
+         @callproc doBlockRolled @(mu) 
+      @endiif
       }
       @mif mu ! "1
+         @iif CU_NUR ! 0
       switch(mr)
       {
       @iexp n 1 0 +
@@ -1407,6 +2319,28 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
       @endiwhile
       default:;
       }
+         @endiif
+         @iif CU_NUR = 0
+      if (mr)
+      {
+            @callproc doBlockRolled mr 
+@ROUT ATL_rm2am ammmtst
+      @iif dupB = 1
+         for (; ii < @(mu); ii++)
+            pp[ii] = ATL_rzero;
+      @endiif
+      @iif dupB > 1
+         @(cnstb)TYPE *p = pp;
+         for (; ii < @(mu); ii++, p+=@(dupB))
+         {
+            unsigned int jj;
+            for (jj=0; jj < @(dupB); jj++)
+               p[jj] = ATL_rzero;
+         }
+      @endiif
+@ROUT ATL_am2rm ATL_rm2am ammmtst
+      }
+         @endiif
       @endmif
    }
 @ROUT ATL_rm2am ammmtst
@@ -1418,6 +2352,7 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
       @iif ku > 2
          TYPE *pp = b;
          for (j=0; j < KR; j++, pp += @(mu)) /* zero KR*mu block */
+      @iif CU_KUR ! 0
          @iexp i 0
          @iwhile i < @(mu)
             pp[@(i)] =
@@ -1425,13 +2360,28 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
          @endiwhile
                     ATL_rzero;
       @endiif
+      @iif CU_KUR = 0
+         {
+            unsigned int ii;
+            for (ii=0; ii < @(mu); ii++)
+               pp[ii] = ATL_rzero;
+         }
+      @endiif
+      @endiif
       @iif ku == 2
+      @iif CU_NUR ! 0
          @iexp i 0
          @iwhile i < @(mu)
          b[@(i)] =
          @iexp i @(i) 1 +
          @endiwhile
                  ATL_rzero;
+      @endiif
+      @iif CU_NUR = 0
+         unsigned int ii;
+         for (ii=0; ii < @(mu); ii++)
+            b[ii] = ATL_rzero;
+      @endiif
       @endiif
       }
    }
@@ -1445,6 +2395,210 @@ void ATL_USERCPMM       /* row-access matrix to access-major block */
 @ROUT ATL_cam2rm ATL_crm2am cammmtst
 @iif kmaj ! 0
    @define ku @@(kmaj)@
+@SKIP ***** handles single element 
+@BEGINPROC doElement A_ j_ i2_ pr_ pi_ ib_
+         @mif nalp ! "X
+@ROUT ATL_crm2am cammmtst
+               @(pr_)[@(ib_)] = @(malp)@(A_)@(j_)[i+@(i2_)];
+               #ifdef Conj_
+                  @(pi_)[@(ib_)] = @(calp)@(A_)@(j_)[i+@(i2_)+1];
+               #else
+                  @(pi_)[@(ib_)] = @(malp)@(A_)@(j_)[i+@(i2_)+1];
+               #endif
+@ROUT ATL_cam2rm
+               @(A_)@(j_)[i+@(i2_)] = @(malp)@(pr_)[@(ib_)];
+               #ifdef Conj_
+                  @(A_)@(j_)[i+@(i2_)+1] = @(calp)@(pi_)[@(ib_)];
+               #else
+                  @(A_)@(j_)[i+@(i2_)+1] = @(malp)@(pi_)[@(ib_)];
+               #endif
+@ROUT ATL_cam2rm ATL_crm2am cammmtst
+         @endmif
+         @mif nalp = "X
+@ROUT ATL_crm2am cammmtst
+               rv = @(A_)@(j_)[i+@(i2_)];
+               #ifdef Conj_
+                  iv = -@(A_)@(j_)[i+@(i2_)+1];
+               #else
+                  iv = @(A_)@(j_)[i+@(i2_)+1];
+               #endif
+               @(pr_)[@(ib_)] = rv*ra - iv*ia;
+               @(pi_)[@(ib_)] = rv*ia + iv*ra;
+@ROUT ATL_cam2rm
+               rv = @(pr_)[@(ib_)];
+               #ifdef Conj_
+                  iv = -@(pi_)[@(ib_)];
+               #else
+                  iv = @(pi_)[@(ib_)];
+               #endif
+               @(A_)@(j_)[i+@(i2_)] = rv*ra - iv*ia;
+               @(A_)@(j_)[i+@(i2_)+1] = rv*ia + iv*ra;
+@ROUT ATL_cam2rm ATL_crm2am cammmtst
+         @endmif
+@ENDPROC
+@SKIP handles block 
+@BEGINPROC doBlockMuKu mu_ ku_ 
+   @define i @dum@
+   @define i2 @dum@
+   @define j @dum@
+   @define ip @dum@
+   @iexp i 0 0 +
+   @iwhile i < @(mu_)
+      @iexp i2 @(i) @(i) +
+      @iexp j 0 0 +
+      @iwhile j < @(ku_)
+         @iexp ip @(i) @(ku_) *
+         @iexp ip @(ip) @(j) +
+            @callproc doElement A @(j) @(i2) pr pi @(ip) 
+         @iexp j @(j) 1 +
+      @endiwhile
+      @iexp i @(i) 1 +
+   @endiwhile
+   @undef ip
+   @undef j
+   @undef i2
+   @undef i
+@ENDPROC
+@SKIP **** handles full block unrolled MU  
+@BEGINPROC doBlockMu ku_ 
+   @define j @dum@
+   @define i2 @dum@
+   @define ip @dum@
+         unsigned int jj;
+         @(cnst)TYPE *pA0 = A0;
+         @(cnstb)TYPE *pr0 = pr, *pi0 = pi;
+         for(jj=0; jj < @(ku_); jj++, pA0 +=lda2, pr0++, pi0++) 
+         {
+      @iexp j 0 
+      @iwhile j < @(mu)
+         @iexp i2 @(j) @(j) +
+         @iexp ip @(j) @(ku) *
+            @callproc doElement pA 0 @(i2) pr0 pi0 @(ip) 
+         @iexp j @(j) 1 +
+      @endiwhile
+         }
+   @undef ip
+   @undef i2
+   @undef j
+@ENDPROC
+@SKIP **** handles full block unrolled KU  
+@BEGINPROC doBlockKu mu_ 
+   @define j @dum@
+   @define kk @dum@
+         unsigned int ii;
+         @(cnstb)TYPE *pr0 = pr, *pi0 = pi;
+         @iexp kk @(mu_) @(mu_) +
+         for(ii=0; ii < @(kk); ii+=2, pr0+=@(ku), pi0+=@(ku)) 
+         {
+      @iexp j 0 0 +
+      @iwhile j < @(ku)
+            @SKIP A@(j)[i+ii] = @(malp)p[@(j)];
+         @callproc doElement A @(j) ii pr0 pi0 @(j) 
+         @iexp j @(j) 1 +
+      @endiwhile
+         }
+   @undef kk
+   @undef j
+@ENDPROC
+@SKIP **** handles full block rolled 
+@BEGINPROC doBlockRolled mu_ ku_ 
+   @define kk @dum@
+         unsigned int jj;
+         @(cnst)TYPE *pA0 = A0;
+         @(cnstb)TYPE *pr0 = pr, *pi0 = pi;
+         for(jj=0; jj < @(ku_); jj++, pA0 +=lda2, pr0++, pi0++)
+         {
+            unsigned int ii;
+            @(cnstb)TYPE *rw = pr0, *iw = pi0;
+            @iexp kk @(mu_) @(mu_) +
+            for(ii=0; ii < @(kk); ii+=2, rw+=@(ku), iw+=@(ku)) 
+            {
+               @callproc doElement pA 0 ii rw iw 0 
+            }
+         }
+   @undef kk
+@ENDPROC
+@SKIP *** FIXME: modify doElement with work with 
+@BEGINPROC doCuElement A_ j_ rr_ ii_ ip_ 
+      @mif nalp ! "X
+@ROUT ATL_crm2am cammmtst
+               @(rr_)[@(ip_)] = @(malp)@(A_)@(j_)[i];
+               #ifdef Conj_
+                  @(ii_)[@(ip_)] = @(calp)@(A_)@(j_)[i+1];
+               #else
+                  @(ii_)[@(ip_)] = @(malp)@(A_)@(j_)[i+1];
+               #endif
+@ROUT ATL_cam2rm
+               @(A_)@(j_)[i] = @(malp)@(rr_)[@(ip_)];
+               #ifdef Conj_
+                  @(A_)@(j_)[i+1] = @(calp)@(ii_)[@(ip_)];
+               #else
+                  @(A_)@(j_)[i+1] = @(malp)@(ii_)[@(ip_)];
+               #endif
+@ROUT ATL_cam2rm ATL_crm2am cammmtst
+      @endmif
+      @mif nalp = "X
+@ROUT ATL_crm2am cammmtst
+               rv = @(A_)@(j_)[i];
+               #ifdef Conj_
+                  iv = -@(A_)@(j_)[i+1];
+               #else
+                  iv = @(A_)@(j_)[i+1];
+               #endif
+               @(rr_)[@(ip_)] = rv*ra - iv*ia;
+               @(ii_)[@(ip_)] = rv*ia + iv*ra;
+@ROUT ATL_cam2rm
+               rv = @(rr_)[@(ip_)];
+               #ifdef Conj_
+                  iv = -@(ii_)[@(ip_)];
+               #else
+                  iv = @(ii_)[@(ip_)];
+               #endif
+               @(A_)@(j_)[i] = rv*ra - iv*ia;
+               @(A_)@(j_)[i+1] = rv*ia + iv*ra;
+@ROUT ATL_cam2rm ATL_crm2am cammmtst
+      @endmif
+@ENDPROC 
+@SKIP **** handles full block unrolled MU  
+@BEGINPROC doCuBlockMu ku_ 
+   @define j @dum@
+   @define i2 @dum@
+   @define ip @dum@
+         unsigned int jj;
+         @(cnst)TYPE *pA0 = A0;
+         @(cnstb)TYPE *pr0 = pr, *pi0 = pi;
+         for(jj=0; jj < @(ku_); jj++, pA0 +=lda2, pr0++, pi0++) 
+         {
+      @iexp j 0 
+      @iwhile j < @(mu)
+         @iexp i2 @(j) @(j) +
+         @iexp ip @(j) @(ku) *
+            @callproc doElement pA 0 @(i2) pr0 pi0 @(ip) 
+         @iexp j @(j) 1 +
+      @endiwhile
+         }
+   @undef ip
+   @undef i2
+   @undef j
+@ENDPROC
+@SKIP **** handles K-cleanup block rolled FIXME: no diff with doBlockRolled!!! 
+@BEGINPROC doKCuBlockRolled mu_ ku_ 
+   @define kk @dum@
+         unsigned int jj;
+         @(cnst)TYPE *pA0 = A0;
+         @(cnstb)TYPE *pr0 = pr, *pi0 = pi;
+         for(jj=0; jj < @(ku_); jj++, pA0 +=lda2, pr0++, pi0++)
+         {
+            unsigned int ii;
+            @(cnstb)TYPE *rw = pr0, *iw = pi0;
+            @iexp kk @(mu_) @(mu_) +
+            for(ii=0; ii < @(kk); ii+=2, rw+=@(ku), iw+=@(ku)) 
+            {
+               @callproc doElement pA 0 ii rw iw 0 
+            }
+         }
+   @undef kk 
+@ENDPROC
 @ROUT ATL_cam2rm
 void ATL_USERCPMM       /* access- to row-major */
 (
@@ -1498,11 +2652,17 @@ void ATL_USERCPMM       /* row- to access-major */
    ATL_CSZT MM = ((M+@(mu)-1)/@(mu))*@(mu), KK = ((K+@(ku)-1)/@(ku))*@(ku);
    ATL_CSZT pansz = @(mu)*KK, m = M/@(mu)*@(mu), mr = M-m, k = (K/@(ku))*@(ku);
    ATL_CSZT K2=K+K, m2 = m+m, lda2=lda+lda, M2 = M+M, incA = @(ku)*lda2;
+   ATL_CSZT kr = K-k;
    ATL_SZT i, j;
    @mif nalp = "X
    const register TYPE ra=(*alpha), ia=alpha[1];
    register TYPE rv, iv;
    @endmif
+@iexp NA1 1
+@iif @iexp 0 @(ML_KUR) ! 0 @(CU_KUR) ! |
+   @iexp NA1 0
+@endiif 
+@iif NA1 = 0
    @declare "   @(cnst)TYPE " n n ";"
       *A0=A
       @iexp j 0 1 +
@@ -1512,6 +2672,10 @@ void ATL_USERCPMM       /* row- to access-major */
          @iexp j @(j) 1 +
       @endiwhile
    @enddeclare
+@endiif
+@iif NA1 ! 0
+   @(cnst)TYPE *A0=A;
+@endiif
    @iexp incb @(ku) @(mu) *
 
    for (j=0; j < k; j += @(ku), rA += @(incb), iA += @(incb))
@@ -1520,55 +2684,20 @@ void ATL_USERCPMM       /* row- to access-major */
 
       for (i=0; i < m2; i += @(mu2), pr += pansz, pi += pansz)
       {
-   @iexp i 0 0 +
-   @iwhile i < @(mu)
-      @iexp i2 @(i) @(i) +
-      @iexp j 0 0 +
-      @iwhile j < @(ku)
-         @iexp ip @(i) @(ku) *
-         @iexp ip @(ip) @(j) +
-         @mif nalp ! "X
-@ROUT ATL_crm2am cammmtst
-         pr[@(ip)] = @(malp)A@(j)[i+@(i2)];
-         #ifdef Conj_
-            pi[@(ip)] = @(calp)A@(j)[i+@(i2)+1];
-         #else
-            pi[@(ip)] = @(malp)A@(j)[i+@(i2)+1];
-         #endif
-@ROUT ATL_cam2rm
-         A@(j)[i+@(i2)] = @(malp)pr[@(ip)];
-         #ifdef Conj_
-            A@(j)[i+@(i2)+1] = @(calp)pi[@(ip)];
-         #else
-            A@(j)[i+@(i2)+1] = @(malp)pi[@(ip)];
-         #endif
-@ROUT ATL_cam2rm ATL_crm2am cammmtst
-         @endmif
-         @mif nalp = "X
-@ROUT ATL_crm2am cammmtst
-         rv = A@(j)[i+@(i2)];
-         #ifdef Conj_
-            iv = -A@(j)[i+@(i2)+1];
-         #else
-            iv = A@(j)[i+@(i2)+1];
-         #endif
-         pr[@(ip)] = rv*ra - iv*ia;
-         pi[@(ip)] = rv*ia + iv*ra;
-@ROUT ATL_cam2rm
-         rv = pr[@(ip)];
-         #ifdef Conj_
-            iv = -pi[@(ip)];
-         #else
-            iv = pi[@(ip)];
-         #endif
-         A@(j)[i+@(i2)] = rv*ra - iv*ia;
-         A@(j)[i+@(i2)+1] = rv*ia + iv*ra;
-@ROUT ATL_cam2rm ATL_crm2am cammmtst
-         @endmif
-         @iexp j @(j) 1 +
-      @endiwhile
-      @iexp i @(i) 1 +
-   @endiwhile
+         @iif ML_NUKU ! 0
+            @callproc doBlockMuKu @(mu) @(ku) 
+         @endiif 
+         @iif ML_NUKU = 0
+            @iif ML_NUR ! 0 
+               @callproc doBlockMu @(ku)
+            @endiif
+            @iif ML_KUR ! 0 
+               @callproc doBlockKu @(mu)
+            @endiif
+            @iif ML_NO ! 0
+               @callproc doBlockRolled @(mu) @(ku)
+            @endiif
+         @endiif
       }
       if (m != M)
       {
@@ -1578,48 +2707,21 @@ void ATL_USERCPMM       /* row- to access-major */
  */
          for (rr=pr, ii=pi; i < M2; i += 2, rr += @(ku), ii += @(ku))
          {
-   @iexp j 0 0 +
-   @iwhile j < @(ku)
-      @mif nalp ! "X
-@ROUT ATL_crm2am cammmtst
-            rr[@(j)] = @(malp)A@(j)[i];
-            #ifdef Conj_
-               ii[@(j)] = @(calp)A@(j)[i+1];
-            #else
-               ii[@(j)] = @(malp)A@(j)[i+1];
-            #endif
-@ROUT ATL_cam2rm
-            A@(j)[i] = @(malp)rr[@(j)];
-            #ifdef Conj_
-               A@(j)[i+1] = @(calp)ii[@(j)];
-            #else
-               A@(j)[i+1] = @(malp)ii[@(j)];
-            #endif
-@ROUT ATL_cam2rm ATL_crm2am cammmtst
-      @endmif
-      @mif nalp = "X
-@ROUT ATL_crm2am cammmtst
-         rv = A@(j)[i];
-         #ifdef Conj_
-            iv = -A@(j)[i+1];
-         #else
-            iv = A@(j)[i+1];
-         #endif
-         rr[@(j)] = rv*ra - iv*ia;
-         ii[@(j)] = rv*ia + iv*ra;
-@ROUT ATL_cam2rm
-         rv = rr[@(j)];
-         #ifdef Conj_
-            iv = -ii[@(j)];
-         #else
-            iv = ii[@(j)];
-         #endif
-         A@(j)[i] = rv*ra - iv*ia;
-         A@(j)[i+1] = rv*ia + iv*ra;
-@ROUT ATL_cam2rm ATL_crm2am cammmtst
-      @endmif
-      @iexp j @(j) 1 +
-   @endiwhile
+      @iif CU_KUR ! 0
+         @iexp j 0 0 +
+         @iwhile j < @(ku)
+            @callproc doCuElement A @(j) rr ii @(j) 
+            @iexp j @(j) 1 +
+         @endiwhile
+      @endiif
+      @iif CU_KUR = 0
+            unsigned int jj;
+            @(cnst)TYPE *pA0 = A0;
+            for (jj=0; jj < @(ku); jj++, pA0+=lda2)
+            {
+               @callproc doCuElement pA 0 rr ii jj 
+            }
+      @endiif
          }
 @ROUT ATL_crm2am cammmtst
 /*
@@ -1627,14 +2729,22 @@ void ATL_USERCPMM       /* row- to access-major */
  */
          for (i=M; i < MM; i++, rr += @(ku), ii += @(ku))
          {
-   @iexp j 0 0 +
-   @iwhile j < @(ku)
+      @iif CU_KUR ! 0
+         @iexp j 0 0 +
+         @iwhile j < @(ku)
             ii[@(j)] = rr[@(j)] = 0.0;
-      @iexp j @(j) 1 +
-   @endiwhile
+            @iexp j @(j) 1 +
+         @endiwhile
+      @endiif
+      @iif CU_KUR = 0
+            unsigned int jj;
+            for (jj=0; jj < @(ku); jj++)
+               ii[jj] = rr[jj] = 0.0;
+      @endiif
          }
 @ROUT ATL_cam2rm ATL_crm2am cammmtst
       }
+@iif NA1 = 0
 /*
  * Update column-ptrs from A
  */
@@ -1643,10 +2753,15 @@ void ATL_USERCPMM       /* row- to access-major */
       A@(j) += incA;
       @iexp j @(j) 1 +
    @endiwhile
+@endiif
+@iif NA1 ! 0
+      A0 += incA;
+@endiif
    }
 /*
  * Check for final, partial K-panel that needs to be padded wt zeros
  */
+@iif CU_NUKU ! 0
    switch(K-k)
    {
    @iexp r @(ku) -1 +
@@ -1792,10 +2907,147 @@ void ATL_USERCPMM       /* row- to access-major */
    @endiwhile
    default:;
    }
+@endiif
+@iif CU_NUKU = 0
+   if (kr)
+   {
+      @(cnstb)TYPE *pr = rA, *pi = iA;   /* panel ptrs */
+      for (i=0; i < m2; i += @(mu2), pr += pansz, pi += pansz)
+      {
+         @iif CU_NUR ! 0
+            @callproc doCuBlockMu kr
+         @endiif
+         @iif CU_NUR = 0
+         @callproc doKCuBlockRolled @(mu) kr
+         @endiif
+@ROUT ATL_crm2am cammmtst
+         /* zero padding */
+         for(; jj < @(ku); jj++, pr0++, pi0++) 
+         {
+      @iif CU_NUR ! 0
+         @iexp j 0 0 +
+         @iwhile j < @(mu)
+            @iexp ip @(j) @(ku) *
+            pi0[@(ip)] = pr0[@(ip)] = 0.0;
+            @iexp j @(j) 1 +
+         @endiwhile
+      @endiif
+      @iif CU_NUR = 0
+            unsigned int kk;
+            TYPE *rw = pr0, *iw = pi0;
+            for (kk=0; kk < @(mu); kk++, rw+=@(ku), iw+=@(ku))
+               *rw = *iw = 0.0;
+      @endiif 
+         }
+@ROUT ATL_cam2rm ATL_crm2am cammmtst
+      }
+      if (m != M)
+      {
+         @(cnstb)TYPE *rr, *ii;
+/*
+ *       Copy partial M remainder subblock
+ */
+         for (rr=pr, ii=pi; i < M2; i += 2, rr += @(ku), ii += @(ku))
+         {
+            unsigned int jj; 
+            @(cnst)TYPE *pA0 = A0;
+            for (jj=0; jj < kr; jj++, pA0+=lda2)
+            {
+@ROUT ATL_crm2am cammmtst
+               @callproc doCuElement pA 0 rr ii jj 
+            }
+            for (; jj < @(ku); jj++)
+               rr[jj] = ii[jj] = 0.0;
+         }
+/*
+ *       zero rest of M remainder subblock 
+ */
+         for (i=M; i < MM; i++, rr+=@(ku), ii+=@(ku))
+         {
+            unsigned int jj;
+            for (jj=0; jj < @(ku); jj++)
+               rr[jj] = ii[jj] = 0.0;
+         }
+@ROUT ATL_cam2rm 
+               @callproc doCuElement pA 0 rr ii jj 
+            }
+         }
+@ROUT ATL_cam2rm ATL_crm2am cammmtst
+      }
+   }
+@endiif
 }
 @ROUT cammmtst `#endif`
 @endiif
 @iif kmaj = 0
+@SKIP *** handles single cell 
+@BEGINPROC doElement A_ i2_ pr_ pi_ i_
+         @mif nalp = "X
+@ROUT ATL_crm2am cammmtst
+            rv = @(A_)[@(i2_)];
+            #ifdef Conj_
+               iv = -@(A_)[@(i2_)+1];
+            #else
+               iv = @(A_)[@(i2_)+1];
+            #endif
+            @(pr_)[@(i_)] = rv*ra - iv*ia;
+            @(pi_)[@(i_)] = rv*ia + iv*ra;
+@ROUT ATL_cam2rm
+            rv = @(pr_)[@(i_)];
+            #ifdef Conj_
+               iv = -@(pi_)[@(i_)];
+            #else
+               iv = @(pi_)[@(i_)];
+            #endif
+            @(A_)[@(i2_)] = rv*ra - iv*ia;
+            @(A_)[@(i2_)+1] = rv*ia + iv*ra;
+@ROUT ATL_cam2rm ATL_crm2am cammmtst
+         @endmif
+         @mif nalp ! "X
+@ROUT ATL_crm2am cammmtst
+            @(pr_)[@(i_)] = @(malp)@(A_)[@(i2_)];
+            #ifdef Conj_
+               @(pi_)[@(i_)] = @(calp)@(A_)[@(i2_)+1];
+            #else
+               @(pi_)[@(i_)] = @(malp)@(A_)[@(i2_)+1];
+            #endif
+@ROUT ATL_cam2rm
+            @(A_)[@(i2_)] = @(malp)@(pr_)[@(i_)];
+            #ifdef Conj_
+               @(A_)[@(i2_)+1] = @(calp)@(pi_)[@(i_)];
+            #else
+               @(A_)[@(i2_)+1] = @(malp)@(pi_)[@(i_)];
+            #endif
+@ROUT ATL_cam2rm ATL_crm2am cammmtst
+         @endmif
+@ENDPROC
+@SKIP *** handles single block unrolled 
+@BEGINPROC doBlockMu
+   @define i @dum@
+   @define i2 @dum@
+      @iexp i 0 0 +
+      @iwhile i < @(mu)
+         @iexp i2 @(i) @(i) +
+         @callproc doElement A @(i2) pr pi @(i)
+      @iexp i @(i) 1 +
+      @endiwhile
+   @undef i2
+   @undef i
+@ENDPROC
+@SKIP *** handles single block unrolled 
+@BEGINPROC doBlockRolled mu_
+         unsigned int ii;
+         for (ii=0; ii < @(mu_); ii++)
+         {
+            @callproc doElement A (ii<<1) pr pi ii
+         }
+@ENDPROC
+@SKIP *** handles single cleanup block unrolled 
+@BEGINPROC doCuBlockRolled mu_
+         @callproc doBlockRolled @(mu_)
+         for (; ii < @(mu); ii++)
+            pr[ii] = pi[ii] = ATL_rzero;
+@ENDPROC
 @ROUT ATL_cam2rm
 @beginskip
 #ifdef Conj_
@@ -1865,51 +3117,15 @@ void ATL_USERCPMM       /* row- to access-major */
       @(cnstb)TYPE *pr = rA, *pi = iA;  /* panel ptrs */
       for (i=0; i < m2; i += @(mu2), pr += pansz, pi += pansz, A += @(mu2))
       {
-      @iexp i 0 0 +
-      @iwhile i < @(mu)
-         @iexp i2 @(i) @(i) +
-         @mif nalp = "X
-@ROUT ATL_crm2am cammmtst
-         rv = A[@(i2)];
-         #ifdef Conj_
-            iv = -A[@(i2)+1];
-         #else
-            iv = A[@(i2)+1];
-         #endif
-         pr[@(i)] = rv*ra - iv*ia;
-         pi[@(i)] = rv*ia + iv*ra;
-@ROUT ATL_cam2rm
-         rv = pr[@(i)];
-         #ifdef Conj_
-            iv = -pi[@(i)];
-         #else
-            iv = pi[@(i)];
-         #endif
-         A[@(i2)] = rv*ra - iv*ia;
-         A[@(i2)+1] = rv*ia + iv*ra;
-@ROUT ATL_cam2rm ATL_crm2am cammmtst
-         @endmif
-         @mif nalp ! "X
-@ROUT ATL_crm2am cammmtst
-         pr[@(i)] = @(malp)A[@(i2)];
-         #ifdef Conj_
-            pi[@(i)] = @(calp)A[@(i2)+1];
-         #else
-            pi[@(i)] = @(malp)A[@(i2)+1];
-         #endif
-@ROUT ATL_cam2rm
-         A[@(i2)] = @(malp)pr[@(i)];
-         #ifdef Conj_
-            A[@(i2)+1] = @(calp)pi[@(i)];
-         #else
-            A[@(i2)+1] = @(malp)pi[@(i)];
-         #endif
-@ROUT ATL_cam2rm ATL_crm2am cammmtst
-         @endmif
-      @iexp i @(i) 1 +
-      @endiwhile
+      @iif ML_NUR ! 0
+         @callproc doBlockMu
+      @endiif
+      @iif ML_NUR = 0
+         @callproc doBlockRolled @(mu)
+      @endiif
       }
       @mif mu ! "1
+   @iif CU_NUR ! 0
       switch(mr)
       {
       @iexp n 1 0 +
@@ -1969,6 +3185,13 @@ void ATL_USERCPMM       /* row- to access-major */
       @endiwhile
       default:;
       }
+   @endiif
+   @iif CU_NUR = 0
+      if (mr)
+      {
+         @callproc doCuBlockRolled mr
+      }
+   @endiif
       @endmif
    }
 @ROUT ATL_crm2am cammmtst
@@ -1980,20 +3203,36 @@ void ATL_USERCPMM       /* row- to access-major */
       @iif ku > 2
          TYPE *pr = rA, *pi = iA;
          for (j=0; j < KR; j++, pr += @(mu), pi += @(mu)) /* zero KR*mu block */
+         @iif CU_KUR ! 0
          @iexp i 0
          @iwhile i < @(mu)
             pr[@(i)] = pi[@(i)] =
          @iexp i @(i) 1 +
          @endiwhile
                             ATL_rzero;
+         @endiif
+         @iif CU_KUR = 0
+         {
+            unsigned int ii;
+            for (ii=0; ii < @(mu); ii++)
+               pr[ii] = pi[ii] = ATL_rzero;
+         }
+         @endiif
       @endiif
       @iif ku == 2
+         @iif CU_KUR ! 0
          @iexp i 0
          @iwhile i < @(mu)
          rA[@(i)] = iA[@(i)] =
          @iexp i @(i) 1 +
          @endiwhile
                          ATL_rzero;
+         @endiif
+         @iif CU_KUR = 0
+         unsigned int ii;
+            for (ii=0; ii < @(mu); ii++)
+               rA[ii] = iA[ii] = ATL_rzero;
+         @endiif
       @endiif
       }
    }

--- a/AtlasBase/Clint/atlas-mmg.base
+++ b/AtlasBase/Clint/atlas-mmg.base
@@ -12,26 +12,34 @@
 @endiif
 @SKIP ************ Adding new bitvectors to parameterized unrolling ************ 
 @BEGINSKIP
-   Now we created two flags: one for main loop and other for cleanup loop
-   bvML : bitvector, default 3, with following meanings:
-      0 : no unroll in any dimension
-      1 : unroll NU dimension
-      2 : unroll KU dimension
-      3 : unroll both dimension
-   bvCU : bitvector, default 0, with following meanings: 
-      0 : no unroll in any dimension
-      1 : unroll NU dimension
-      2 : unroll KU dimension
-      3 : unroll both dimension
+   NOTE: cpUR bit location meanings: 
+      0/1   : Main Loop, Unroll in NU/MU dimension
+      1/2   : Main Loop, Unroll in KU dimension
+      2/4   : Cleanup Loop, Unroll in MU/NU dimension
+      3/8   : Cleanup Loop, Unroll in KU dimension
 @ENDSKIP
-@SKIP **** made bvML=3 default case 
-@ifdef ! bvML
-   @iexp bvML 3  
+@SKIP **** made fully unroll default for both main loop and cleanup loop
+@ifdef ! cpUR
+   @iexp cpUR 15
 @endifdef
-@SKIP **** made bvCU=3 default case 
-@ifdef ! bvCU
-   @iexp bvCU 3 
-@endifdef
+@BEGINSKIP
+   We are splitting two bits each for main loop and cleanup and creating two 
+   seperate bitvectors: bvML and bvCU
+   Now we created two flags: one for main loop and other for cleanup loop
+   bvML : bitvector with following meanings:
+      0 : no unroll in any dimension
+      1 : unroll NU/MU dimension (no-transpose/transpose)
+      2 : unroll KU dimension
+      3 : unroll both dimension
+   bvCU : bitvector with following meanings: 
+      0 : no unroll in any dimension
+      1 : unroll NU/MU dimension (no-transpose/transpose)
+      2 : unroll KU dimension
+      3 : unroll both dimension
+   NOTE: Unlike C-copy, A copy does support all 16 cases
+@ENDSKIP
+@iexp bvML @(cpUR) 3 &
+@iexp bvCU 2 @(cpUR) r
 @BEGINSKIP
    to make code more readable, I create two flag to represent to each bits
    ML_KUR, ML_NUR

--- a/AtlasBase/Clint/atlas-mmg.base
+++ b/AtlasBase/Clint/atlas-mmg.base
@@ -1978,7 +1978,11 @@ void ATL_USERCPMM       /* row-major matrix to access-major block */
             ATL_UINT jj;
             @(cnst)TYPE *rA = A0;
             for (jj=0; jj < @(ku); jj++, rA+=lda)
-               p[jj] = rA[i];
+@ROUT ATL_rm2am ammmtst
+               p[jj] = @(malp)rA[i];
+@ROUT ATL_am2rm
+               rA[i] = @(malp)p[jj];
+@ROUT ATL_am2rm ATL_rm2am ammmtst
       @endiif
          }
 @ROUT ATL_rm2am ammmtst

--- a/AtlasBase/Clint/fko_atlas-mmkg.base
+++ b/AtlasBase/Clint/fko_atlas-mmkg.base
@@ -1,3 +1,11 @@
+@BEGINSKIP
+================================================================================
+*** NOTE: FKO doesn't support multiline comments yet, like: \* ... *\
+***       Only use single line comment style, like: \\       
+***       Using multiline comments in FKO input may cause the parser freak out
+***       We will add the support of multiline comments later
+================================================================================
+@ENDSKIP 
 @ROUT !
    @define pre @@(@pre)@
    @PRE S C
@@ -387,7 +395,7 @@ During tuning, think about several regions for prefetch:
          cases.  1-D handles this with special code; to create a hole for 2x2
          we therefore don't count the last B load as memory load.  We do:
             IF (vmu != 2 || nu != 2 || i_ == nu-1)
-               mo++  /* mo is count of memory ops done with last MAC */
+               mo++  // mo is count of memory ops done with last MAC 
          but this the same as
             mo = mo + 1*(vmu != 2 || nu != 2 || i_ == nu-1)
          which was obvious to you from the line below, of course.
@@ -806,8 +814,8 @@ ASSUMES DEFINED: ldB, incBk, bmul, incAk, vmu, vnu, vl
          @callproc ldB 6 rB@(jl) @(jl)
       @endiif
       @ifdef lb
-         @skip ATL_vld(vB@(lb), pB+@(ib));  /* A01 */
-         vB@(lb) = pB[@(ib)];  /* A01 */
+         @skip ATL_vld(vB@(lb), pB+@(ib));  // A01 
+         vB@(lb) = pB[@(ib)];  // A01 
          @undef lb
          @iexp ib @(ib) @(vl) +
       @endifdef
@@ -832,8 +840,8 @@ ASSUMES DEFINED: ldB, incBk, bmul, incAk, vmu, vnu, vl
             @endiif
             @iif mo = 0
                @ifdef lb
-            @skip ATL_vld(vB@(lb), pB+@(ib));  /* A02 i=@(i) j=@(j) */
-            vB@(lb) = pB[@(ib)];  /* A02 i=@(i) j=@(j) */
+            @skip ATL_vld(vB@(lb), pB+@(ib));  // A02 i=@(i) j=@(j) 
+            vB@(lb) = pB[@(ib)];  // A02 i=@(i) j=@(j) 
                   @undef lb
                   @iexp mo @(mo) 1 +
                   @iexp ib @(ib) @(vl) +
@@ -1224,7 +1232,7 @@ ASSUMES DEFINED: ldB, incBk, bmul, incAk, vmu, vnu, vl
             @iif mo = 0
                @ifdef lb
                   @iexp kk @(lb) @(vl) *
-               @skip ATL_vld(vB@(lb), pB+@(kk)); /*di0_01: lb=@(lb) jl=@(jl) */
+               @skip ATL_vld(vB@(lb), pB+@(kk)); // di0_01: lb=@(lb) jl=@(jl) 
                vB@(lb) = pB[@(kk)]; 
                   @iexp kk @(kk) @(vl) +
                   @iif kk = incBk
@@ -1389,27 +1397,27 @@ void ATL_USERMM
    ATL_CSZT nmus,
    ATL_CSZT nnus,
    ATL_CSZT K,
-   const @(typ) *pA, /* @(mu)*KB*nmus-length access-major array of A */
-   const @(typ) *pB, /* @(nu)*KB*nnus-length access-major array of B */
-   @(typ) *pC,   /* @(mu)*@(nu)*nnus*nmus-length access-major array of C */
-   const @(typ) *pAn, /* next block of A */
-   const @(typ) *pBn, /* next block of B */
-   const @(typ) *pCn  /* next block of C */
+   const @(typ) *pA, // @(mu)*KB*nmus-length access-major array of A 
+   const @(typ) *pB, // @(nu)*KB*nnus-length access-major array of B 
+   @(typ) *pC,   // @(mu)*@(nu)*nnus*nmus-length access-major array of C 
+   const @(typ) *pAn, // next block of A 
+   const @(typ) *pBn, // next block of B 
+   const @(typ) *pCn  // next block of C 
 )
 @endskip
 ROUTINE ATL_USERMM;
    PARAMS :: nmus, nnus, K, pA, pB, pC, pAn, pBn, pCn;
    INT :: nmus, nnus, K;
    @(typ)_PTR :: pA, pB, pC, pAn, pBn, pCn;
-/*
- * Performs a GEMM with M,N,K unrolling (& jam) of (@(mu),@(nu),@(ku)).
-@VEC KDIM ` * Vectorization of VLEN=@(vl) along K dim, vec unroll=(@(vmu),@(vnu),@(vku)).`
-@VEC MDIM ` * Vectorization of VLEN=@(vl) along M dim, vec unroll=(@(vmu),@(vnu),@(vku)).`
-@VEC NO   ` * Code is not vectorized (VLEN=@(vl)).`
+//
+//  Performs a GEMM with M,N,K unrolling (& jam) of (@(mu),@(nu),@(ku)).
+@VEC KDIM ` // Vectorization of VLEN=@(vl) along K dim, vec unroll=(@(vmu),@(vnu),@(vku)).`
+@VEC MDIM ` // Vectorization of VLEN=@(vl) along M dim, vec unroll=(@(vmu),@(vnu),@(vku)).`
+@VEC NO   ` // Code is not vectorized (VLEN=@(vl)).`
 @iif kb = 0
- * You may set compile-time constant K dim by defining ATL_MM_KB.
+//  You may set compile-time constant K dim by defining ATL_MM_KB.
 @endiif
- */
+//
 @skip {
 ROUT_LOCALS
    @declare "   @(typ) :: " y n ";"
@@ -1606,8 +1614,8 @@ LB_PB_EQ:
       @endiif
       NLOOP:
    @endiif
-         @skip /* Peel K=0 iteration to avoid zero of rCxx and extra add  */
-         /* Peel K=0 iteration to avoid zero of rCxx and extra add */
+         @skip // Peel K=0 iteration to avoid zero of rCxx and extra add  
+         // Peel K=0 iteration to avoid zero of rCxx and extra add 
    @skip *********************************************************
    @iif NOKLOOP ! 0
       @iexp IN_K 0 0 +
@@ -1615,7 +1623,7 @@ LB_PB_EQ:
       @iexp incK 1 0 +
       @iexp k 0 @(incK) +
       @iwhile ipf < npf
-            /* Peel K=@(k) iteration for prefetch */
+            // Peel K=@(k) iteration for prefetch 
          @CALLPROC DoIter
          @iexp k @(k) @(incK) +
       @endiwhile
@@ -1636,7 +1644,7 @@ LB_PB_EQ:
       @iexp npeel 1 0 +
       @CALLPROC DoIter0
       @iwhile ipf < npf
-        /* Peel K=@(npeel) it to allow prefetch of C or next blocks of A&B */
+        // Peel K=@(npeel) it to allow prefetch of C or next blocks of A&B 
          @iexp kk @(npeel) 0 +
          IF (K == @(kk)) GOTO KDONE;
             @CALLPROC DoIter
@@ -1748,7 +1756,7 @@ ROUT_END
 @PRE S D
 @SKIP blksz = ((mu*nu+vlen-1)/vlen)*vlen
 @iexp bs @(vl) @(mu) @(nu) * @(vl) + -1 + / @(vl) *
-/* HERE vl=@(vl), mu=@(mu), nu=@(nu) bs=@(bs) */
+// HERE vl=@(vl), mu=@(mu), nu=@(nu) bs=@(bs) 
 @SKIP IN: mu, nu, beta, alpha
 @BEGINPROC doDiBlock n_
    @define i @dum@

--- a/AtlasBase/Clint/l3micro.base
+++ b/AtlasBase/Clint/l3micro.base
@@ -2602,27 +2602,15 @@ int syrk_amm
    }
    #endif
 /*
- * Will eventually need syrk timed for all square blocks to select best case.
- * For now, just pretend syrk time doesn't matter
- */
-/*
- * We may need to decide between sqsyrk and ursyrk based on the pref data from 
- * amm_syrkPerf.h. For now, we are always applying ursyrk  
+ * new unrestricted syrk (ursyrk) supports all cases
+ * NOTE: ursyrk currently uses fixed syrk C-copy from /auxil/kernel/
  */
    Mjoin(PATL,ipmenInfo)(&ipmen, TA,TB, N,N,K, lda,lda,ldc, alpha,beta);
-   #if 1
-      #ifdef Conj_
-         ierr = ursyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
-      #else
-         ierr = ursyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
-      #endif
+   #ifdef Conj_
+      ierr = ursyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
    #else
-      #ifdef Conj_
-         ierr = sqsyrk(&ipmen, Uplo, TA, N, K, ralpha, A, lda, rbeta, C, ldc);
-      #else
-         ierr = sqsyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
-      #endif
-   #endif  
+      ierr = ursyrk(&ipmen, Uplo, TA, N, K, alpha, A, lda, beta, C, ldc);
+   #endif
    return(ierr);
 }
 

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -19,7 +19,6 @@
 @endifdef
 @SKIP TRI = 1 means lower triangular C (SYRK)
 @iif TRI = 1
-   @define SYRKU @0@ 
    @define ma @1@
    @define na @1@
    @iif mu ! nu
@@ -28,8 +27,6 @@
          @iexp mma @(ma) @(nu) *
          @iif mu ! mma
            @abort "mu (@(mu)) must be multiple of nu (@(nu))" 
-           @SKIP Now unrestricted SYRK is supported 
-           @iexp SYKRU 1 
          @endiif
          @skip @print ************ma = @(ma)
       @endiif
@@ -38,8 +35,6 @@
          @iexp nna @(na) @(mu) *
          @iif nu ! nna
            @abort "nu (@(nu)) must be multiple of mu (@(mu))"  
-           @SKIP Now unrestricted SYRK is supported 
-           @iexp SYKRU 1 
          @endiif
          @skip @print ************na = @(na)
       @endiif
@@ -81,12 +76,12 @@
 @iexp ML_NUR @(bvML) 2 &
 @iexp ML_MUNU @(bvML) 3 =
 @iexp ML_NO @(bvML) 0 = 
-@print ML_MUR=@(ML_MUR) ML_NUR=@(ML_NUR) ML_MUNU=@(ML_MUNU) 
+@SKIP @print ML_MUR=@(ML_MUR) ML_NUR=@(ML_NUR) ML_MUNU=@(ML_MUNU) 
 @iexp CU_MUR @(bvCU) 1 &
 @iexp CU_NUR @(bvCU) 2 &
 @iexp CU_MUNU @(bvCU) 3 =
 @iexp CU_NO @(bvCU) 0 = 
-@print CU_MUR = @(CU_MUR) CU_NUR = @(CU_NUR)
+@SKIP @print CU_MUR = @(CU_MUR) CU_NUR = @(CU_NUR)
 @SKIP **************************************************************************
 @ROUT blk2C C2blk
 #include <stddef.h>
@@ -114,66 +109,8 @@
 @iexp bs @(vl) @(mu) @(nu) * @(vl) + -1 + / @(vl) *
 /* HERE vl=@(vl), mu=@(mu), nu=@(nu) bs=@(bs) */
 @SKIP this proc handles only one element
-@SKIP IN : alpha, beta, C, p 
-@BEGINPROC doElement r c k
-         @iif alpha = 1
-            @iif beta = 0
-@ROUT blk2C `            C@(c)[@(r)] = p[@(k)];`
-@ROUT C2blk `            p[@(k)] = C@(c)[@(r)];`
-            @endiif
-            @iif beta = 1
-@ROUT blk2C `            C@(c)[@(r)] += p[@(k)];`
-@ROUT C2blk `            p[@(k)] += C@(c)[@(r)];`
-            @endiif
-            @iif beta = -1
-@ROUT blk2C `            C@(c)[@(r)] = p[@(k)] - C@(c)[@(r)];`
-@ROUT C2blk `            p[@(k)] = C@(c)[@(r)] - p[@(k)];`
-            @endiif
-            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
-@ROUT blk2C `            C@(c)[@(r)] = beta*C@(c)[@(r)] + p[@(k)];`
-@ROUT C2blk `            p[@(k)] = beta*p[@(k)] + C@(c)[@(r)];`
-            @endiif
-         @endiif
-         @iif alpha = -1
-            @iif beta = 0
-@ROUT blk2C `            C@(c)[@(r)] = -p[@(k)];`
-@ROUT C2blk `            p[@(k)] = -C@(c)[@(r)];`
-            @endiif
-            @iif beta = 1
-@ROUT blk2C `            C@(c)[@(r)] -= p[@(k)];`
-@ROUT C2blk `            p[@(k)] -= C@(c)[@(r)];`
-            @endiif
-            @iif beta = -1
-@ROUT blk2C `            C@(c)[@(r)] = -C@(c)[@(r)] - p[@(k)];`
-@ROUT C2blk `            p[@(k)] = -C@(c)[@(r)] - p[@(k)];`
-            @endiif
-            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
-@ROUT blk2C `            C@(c)[@(r)] = beta*C@(c)[@(r)] - p[@(k)];`
-@ROUT C2blk `            p[@(k)] = beta*p[@(k)] - C@(c)[@(r)];`
-            @endiif
-         @endiif
-         @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
-            @iif beta = 0
-@ROUT blk2C `            C@(c)[@(r)] = alpha*p[@(k)];`
-@ROUT C2blk `            p[@(k)] = alpha*C@(c)[@(r)];`
-            @endiif
-            @iif beta = 1
-@ROUT blk2C `            C@(c)[@(r)] += alpha*p[@(k)];`
-@ROUT C2blk `            p[@(k)] += alpha*C@(c)[@(r)];`
-            @endiif
-            @iif beta = -1
-@ROUT blk2C `            C@(c)[@(r)] = alpha*p[@(k)] - C@(c)[@(r)];`
-@ROUT C2blk `            p[@(k)] = alpha*C@(c)[@(r)] - p[@(k)];`
-            @endiif
-            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
-@ROUT blk2C `            C@(c)[@(r)] = beta*C@(c)[@(r)] + alpha*p[@(k)];`
-@ROUT C2blk `            p[@(k)] = beta*p[@(k)] + alpha*C@(c)[@(r)];`
-            @endiif
-         @endiif
-@ENDPROC
-@SKIP this proc handles only one element
 @SKIP IN : alpha, beta 
-@BEGINPROC doElementUR r c C_ k p_
+@BEGINPROC doElement r c C_ k p_
          @iif alpha = 1
             @iif beta = 0
 @ROUT blk2C `                  @(C_)@(c)[@(r)] = @(p_)[@(k)];`
@@ -229,235 +166,6 @@
             @endiif
          @endiif
 @ENDPROC
-@SKIP handles diagonal blocks when mu = nu 
-@SKIP IN: mu, nu, beta, alpha
-@BEGINPROC doDiBlock n_
-   @define i @dum@
-   @define j @dum@
-   @define k @dum@
-   @define c @dum@
-   @define r @dum@
-   @iexp j 0
-   @iwhile j < @(n_)
-      @iexp i 0
-      @iwhile i < @(n_)
-         @iexp k @(j) @(mu) * @(i) +
-@ROUT blk2C
-         @iexp r @(i)
-         @iexp c @(j)
-         @iif j { i
-@ROUT C2blk
-         @iif j > i
-            @iexp r @(j)
-            @iexp c @(i)
-         @endiif
-         @iif j { i
-            @iexp r @(i)
-            @iexp c @(j)
-         @endiif
-@ROUT blk2C C2blk
-      @callproc doElement @(r) @(c) @(k)  
-@ROUT blk2C 
-         @endiif
-@ROUT blk2C C2blk
-         @iexp i @(i) 1 +
-      @endiwhile
-      @iif n_ = mu
-            C@(j) += @(mu);
-      @endiif
-      @iexp j @(j) 1 +
-   @endiwhile
-   @undef r
-   @undef c
-   @undef k
-   @undef j
-   @undef i
-@ENDPROC
-@SKIP handles diagonal subblocks when mu=ma*nu
-@SKIP IN: mu, nu, beta, alpha
-@BEGINPROC doDiBlockmn m_ n_ ma_
-   @define i @dum@
-   @define j @dum@
-   @define jj @dum@
-   @define k @dum@
-   @define t @dum@
-   @define sc @dum@
-      switch (j%@(ma_))
-      {
-      @iexp sc 0
-      @iwhile sc < @(ma_)
-      case @(sc):
-         @iexp j 0
-         @iwhile j < @(n_)  
-            @iexp i 0
-            @iwhile i < @(m_) 
-               @iexp k @(j) @(mu) * @(i) +
-               @iexp t @(nu) @(sc) *
-               @iexp t @(t) @(j) +
-               @iif i < @(t) 
-@ROUT C2blk    
-               @iexp jj @(m_) -1 +    
-               @callproc doElement @(jj) @(j) @(k) 
-@ROUT C2blk blk2C
-               @endiif
-               @iif i } @(t)
-               @callproc doElement @(i) @(j) @(k)
-               @endiif
-               @iexp i @(i) 1 +
-            @endiwhile
-         C@(j) += @(m_);
-            @iexp j @(j) 1 +
-         @endiwhile
-         break;
-         @iexp sc @(sc) 1 +
-      @endiwhile
-      default:;
-      }
-   @undef sc
-   @undef t
-   @undef k
-   @undef jj
-   @undef j
-   @undef i
-@ENDPROC
-@SKIP cleanup diagonal subblocks when mu!=nu 
-@SKIP IN: mu, nu, beta, alpha,
-@BEGINPROC doCuDiBlockmn m_ n_ ma_
-   @define i @dum@
-   @define j @dum@
-   @define jj @dum@
-   @define k @dum@
-   @define t @dum@
-   @define sc @dum@
-   @define m @dum@
-      unsigned int kk;
-      switch (j%@(ma_))
-      {
-      @iexp m @(ma_) -1 +
-      @iexp sc 0
-      @iwhile sc < @(m)
-      case @(sc):
-         @iexp j 0
-         @iwhile j < @(n_)  
-            @iexp i 0 
-            @iwhile i < @(m_) 
-               @iexp k @(j) @(mu) * @(i) +
-               @iexp t @(nu) @(sc) *
-               @iexp t @(t) @(j) +
-@ROUT C2blk    
-               @iif i < @(t) 
-               @iexp jj @(i) 1 +    
-            p[@(k)] = 0.0;
-               @endiif
-@ROUT C2blk blk2C
-               @iif i } @(t)
-                  @skip "upper limit"
-                  @iexp t @(sc) 1 +
-                  @iexp t @(t) @(nu) *
-                  @iif i < @(t)
-            @callproc doElement @(i) @(j) @(k)
-                  @endiif
-               @endiif
-               @iexp i @(i) 1 +
-            @endiwhile
-            @iexp j @(j) 1 +
-         @endiwhile
-            @skip "now from nu to mu "
-            @iexp jj @(sc) 1 +
-            @iexp jj @(jj) @(n_) *
-         for (kk=@(jj); kk < mr; kk++ )
-         {
-               @iexp jj 0
-               @iwhile jj < @(n_)
-                  @iexp t @(jj) @(m_) * 
-                  @callproc doElement kk @(jj) @(t)+kk
-                  @iexp jj @(jj) 1 +
-               @endiwhile
-         }
-         break;
-         @iexp sc @(sc) 1 +
-      @endiwhile
-      default:;
-      }
-   @undef m
-   @undef sc
-   @undef t
-   @undef k
-   @undef jj
-   @undef j
-   @undef i
-@ENDPROC
-@SKIP diagonal block when nu > mu and nu = na * mu
-@BEGINPROC doDikkBlockna n_ mul_
-   @define i @dum@
-   @define j @dum@
-   @define k @dum@
-   @define c @dum@
-   @define r @dum@
-   @define m @dum@
-   @iexp j 0
-   @iwhile j < @(n_)
-      @iexp i 0
-      @iwhile i < @(n_)
-         @iexp k @(j) @(mu) * @(i) +
-@ROUT blk2C
-         @iexp r @(i)
-         @iexp c @(j)
-         @iif j { i
-@ROUT C2blk
-         @iif j > i
-            @iexp r @(j)
-            @iexp c @(i)
-         @endiif
-         @iif j { i
-            @iexp r @(i)
-            @iexp c @(j)
-         @endiif
-@ROUT blk2C C2blk
-         @skip @iexp m @(n_) @(n_) *
-         @callproc doElement @(r) @(c) @(k)+kk*@(mul_) 
-@ROUT blk2C
-         @endiif
-@ROUT blk2C C2blk
-         @iexp i @(i) 1 +
-      @endiwhile
-      @iif n_ = mu
-            C@(j) += @(mu);
-      @endiif
-      @iexp j @(j) 1 +
-   @endiwhile
-   @undef m
-   @undef r
-   @undef c
-   @undef k
-   @undef j
-   @undef i
-@ENDPROC
-@SKIP full blocks with multiplication 
-@BEGINPROC donaBlock m_ n_ mn_
-   @define i @dum@
-   @define j @dum@
-   @define k @dum@
-   @define m @dum@
-   @iexp j 0
-   @iwhile j < @(n_)
-      @iexp i 0
-      @iwhile i < @(m_)
-         @iexp k @(j) @(mu) * @(i) +
-         @callproc doElement @(i) @(j) @(k)+kk*@(mn_) 
-         @iexp i @(i) 1 +
-      @endiwhile
-      @iif m_ = mu
-            C@(j) += @(mu);
-      @endiif
-      @iexp j @(j) 1 +
-   @endiwhile
-   @undef m
-   @undef k
-   @undef j
-   @undef i
-@ENDPROC
-@SKIP ******** parameterized GEMM implementation ************** 
 @SKIP handles square blocks 
 @BEGINPROC doBlock m_ n_ p_
    @define i @dum@
@@ -468,7 +176,7 @@
       @iexp i 0
       @iwhile i < @(m_)
          @iexp k @(j) @(mu) * @(i) +
-         @callproc doElementUR @(i) @(j) C @(k) @(p_) 
+         @callproc doElement @(i) @(j) C @(k) @(p_) 
          @iexp i @(i) 1 +
       @endiwhile
       @iif m_ = mu
@@ -492,7 +200,7 @@
             {
                for (ii=0; ii < @(mu_); ii++)
                {
-                  @callproc doElementUR ii 0 rC ii pr 
+                  @callproc doElement ii 0 rC ii pr 
                }
             }
       @iif cinc_ ! 0
@@ -508,7 +216,7 @@
          {
       @iexp i 0
       @iwhile i < @(m_)
-         @callproc doElementUR @(i) 0 C @(i) p0 
+         @callproc doElement @(i) 0 C @(i) p0 
          @iexp i @(i) 1 +
       @endiwhile
          }
@@ -524,146 +232,14 @@
          {
             @iexp j 0
             @iwhile j < @(nu_)
-               @callproc doElementUR ii @(j) C @(mu)*@(j)+ii p
+               @callproc doElement ii @(j) C @(mu)*@(j)+ii p
                @iexp j @(j) 1 +
             @endiwhile
          }
    @undef j
 @ENDPROC
-@SKIP ******** parameterized unrestricted SYRK implementation ************** 
-@SKIP handles rolled rectangual blocks, used for cleanup as well
-@SKIP we are skipping the i-loop to make it work with cleanup 
-@BEGINPROC doTrBlocksRolled mu_ nu_ tstmu_
-         unsigned int mu=N-i, ii, jj, nblks;
-@ROUT C2BLK `         const @(typ) *C0 = C + i; `          
-@ROUT BLK2C `         @(typ) *C0 = C + i; `          
-@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
-@ROUT BLK2C `         const @(typ) *p = rw + cinc; `     
-   @iif tstmu_ = 1
-         mu = (mu >= @(mu)) ? @(mu) : mu;
-   @endiif
-         in = i + mu;
-         for (jj=0; jj < @(nu_); jj++, C0 += ldc, p += @(mu))
-         {
-            for (ii=0; ii < @(mu_); ii++)
-            {
-               @callproc doElementUR ii 0 C ii p 
-            }
-         }
-         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
-         rwpan = nblks*@(bs);
-         rw += rwpan;
-@ENDPROC
-@SKIP handles unrolled rectangual blocks, used for cleanup as well
-@BEGINPROC doTrBlocksUR 
-      for (; (i+@(mu)) < N; i = in)
-      {
-         unsigned int nblks;
-@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
-@ROUT BLK2C `         const @(typ) *p = rw + cinc; `          
-@ROUT blk2C `        @declare "         @(typ) " n n ";"`
-@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
-         *C0=C+i
-         @define j @1@
-         @iwhile j < @(nu)
-            @iexp i @(j) -1 +
-            *C@(j)=C@(i)+ldc
-            @iexp j @(j) 1 +
-         @endiwhile
-      @enddeclare
-         in = i + @(mu);
-         @callproc doBlock @(mu) @(nu) p 
-         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
-         rwpan = nblks*@(bs);
-         rw += rwpan;
-      }
-@ENDPROC
-@BEGINPROC doTrBlocksMuUR mu_ nu_
-         for (; (i+@(mu)) < N; i = in)
-         {
-            unsigned int jj, nblks;
-@ROUT C2BLK `            const @(typ) *C0 = C + i; `          
-@ROUT BLK2C `            @(typ) *C0 = C + i; `          
-@ROUT C2BLK `            @(typ) *p = rw + cinc; `          
-@ROUT BLK2C `            const @(typ) *p = rw + cinc; `          
-            in = i + @(mu);
-            for (jj=0; jj < @(nu_); jj++, C0 += ldc, p += @(mu))
-            {
-            @iexp i 0
-            @iwhile i < @(mu_)
-               @callproc doElementUR @(i) 0 C @(i) p 
-               @iexp i @(i) 1 +
-            @endiwhile
-            } 
-            nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
-            rwpan = nblks*@(bs);
-            rw += rwpan;
-         }
-@ENDPROC
-@BEGINPROC doTrBlocksNuUR mu_ nu_ 
-      for (; i < N; i = in)
-      {
-         unsigned int ii, nblks, mu=N-i;
-@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
-@ROUT BLK2C `         const @(typ) *p = rw + cinc; `          
-@ROUT blk2C `        @declare "         @(typ) " n n ";"`
-@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
-         *C0=C+i
-         @define j @1@
-         @iwhile j < @(nu)
-            @iexp i @(j) -1 +
-            *C@(j)=C@(i)+ldc
-            @iexp j @(j) 1 +
-         @endiwhile
-      @enddeclare
-         mu = (mu >= @(mu)) ? @(mu) : mu;
-         in = i + mu;
-         for (ii=0; ii < @(mu_); ii++)
-         {
-            @iexp j 0
-            @iwhile j < @(nu_)
-               @callproc doElementUR ii @(j) C @(mu)*@(j)+ii p
-               @iexp j @(j) 1 +
-            @endiwhile
-         }
-         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
-         rwpan = nblks*@(bs);
-         rw += rwpan;
-      }
-@ENDPROC
-@SKIP handles diagonal crossing blocks, implement rolled version first
-@BEGINPROC doDiagBlock mu_ nu_
-/*
- *    Handling of diagonal blocks for this colpan 
- */
-      for (; i < jn; i = in)
-      {
-         unsigned int mu=N-i, ii, jj, nblks;
-@ROUT C2BLK `         const @(typ) *C0 = C + i; `          
-@ROUT BLK2C `         @(typ) *C0 = C + i; `          
-@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
-@ROUT BLK2C `         const @(typ) *p = rw + cinc; `          
-         mu = (mu >= @(mu)) ? @(mu) : mu;
-         in = i + mu;
-@SKIP /* based on full/cleanup, nu can be const or var */
-         for (jj=0; jj < @(nu_); jj++, C0 += ldc, p += @(mu)) 
-         {
-            const unsigned int J=j+jj;
-            for (ii=0; ii < mu; ii++)
-            {
-               const unsigned int I=i+ii;
-               if (I >= J)
-               {
-                  @callproc doElementUR ii 0 C ii p 
-               }
-            }
-         }
-         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
-         rwpan = nblks*@(bs);
-         rw += rwpan; /* finished all blocks in rowpanel */
-         rW = (in <= jn) ? rw : rW;
-      }
-@ENDPROC
+@iif TRI = 0
+@SKIP ********************** GEMM copy: real type ******************************
 /*
  * Main Loop:
  @iif bvML = 0
@@ -702,8 +278,6 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
                          @(typ) *C, ATL_CSZT ldc)
 @endiif
 {
-@SKIP ********************** GEMM copy: real type ******************************
-@iif TRI = 0
    unsigned int i, j;
    const unsigned int mf = M/@(mu), nf = N/@(nu);
    const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
@@ -891,10 +465,264 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @endiif
       @endiif
    @endiif
+}
 @endiif
-@SKIP ******************** SYRK copy: real type ********************************
+@SKIP ******************** Restricted SYRK copy: real type *********************
 @iif TRI = 1
-@iif SYRKU = 0
+@SKIP handles diagonal blocks when mu = nu 
+@SKIP IN: mu, nu, beta, alpha
+@BEGINPROC doDiBlock n_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define c @dum@
+   @define r @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+         @iexp k @(j) @(mu) * @(i) +
+@ROUT blk2C
+         @iexp r @(i)
+         @iexp c @(j)
+         @iif j { i
+@ROUT C2blk
+         @iif j > i
+            @iexp r @(j)
+            @iexp c @(i)
+         @endiif
+         @iif j { i
+            @iexp r @(i)
+            @iexp c @(j)
+         @endiif
+@ROUT blk2C C2blk
+      @callproc doElement @(r) @(c) C @(k) p  
+@ROUT blk2C 
+         @endiif
+@ROUT blk2C C2blk
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif n_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef r
+   @undef c
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP handles diagonal subblocks when mu=ma*nu
+@SKIP IN: mu, nu, beta, alpha
+@BEGINPROC doDiBlockmn m_ n_ ma_
+   @define i @dum@
+   @define j @dum@
+   @define jj @dum@
+   @define k @dum@
+   @define t @dum@
+   @define sc @dum@
+      switch (j%@(ma_))
+      {
+      @iexp sc 0
+      @iwhile sc < @(ma_)
+      case @(sc):
+         @iexp j 0
+         @iwhile j < @(n_)  
+            @iexp i 0
+            @iwhile i < @(m_) 
+               @iexp k @(j) @(mu) * @(i) +
+               @iexp t @(nu) @(sc) *
+               @iexp t @(t) @(j) +
+               @iif i < @(t) 
+@ROUT C2blk    
+               @iexp jj @(m_) -1 +    
+               @callproc doElement @(jj) @(j) C @(k) p 
+@ROUT C2blk blk2C
+               @endiif
+               @iif i } @(t)
+               @callproc doElement @(i) @(j) C @(k) p
+               @endiif
+               @iexp i @(i) 1 +
+            @endiwhile
+         C@(j) += @(m_);
+            @iexp j @(j) 1 +
+         @endiwhile
+         break;
+         @iexp sc @(sc) 1 +
+      @endiwhile
+      default:;
+      }
+   @undef sc
+   @undef t
+   @undef k
+   @undef jj
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP cleanup diagonal subblocks when mu!=nu 
+@SKIP IN: mu, nu, beta, alpha,
+@BEGINPROC doCuDiBlockmn m_ n_ ma_
+   @define i @dum@
+   @define j @dum@
+   @define jj @dum@
+   @define k @dum@
+   @define t @dum@
+   @define sc @dum@
+   @define m @dum@
+      unsigned int kk;
+      switch (j%@(ma_))
+      {
+      @iexp m @(ma_) -1 +
+      @iexp sc 0
+      @iwhile sc < @(m)
+      case @(sc):
+         @iexp j 0
+         @iwhile j < @(n_)  
+            @iexp i 0 
+            @iwhile i < @(m_) 
+               @iexp k @(j) @(mu) * @(i) +
+               @iexp t @(nu) @(sc) *
+               @iexp t @(t) @(j) +
+@ROUT C2blk    
+               @iif i < @(t) 
+               @iexp jj @(i) 1 +    
+            p[@(k)] = 0.0;
+               @endiif
+@ROUT C2blk blk2C
+               @iif i } @(t)
+                  @skip "upper limit"
+                  @iexp t @(sc) 1 +
+                  @iexp t @(t) @(nu) *
+                  @iif i < @(t)
+            @callproc doElement @(i) @(j) C @(k) p
+                  @endiif
+               @endiif
+               @iexp i @(i) 1 +
+            @endiwhile
+            @iexp j @(j) 1 +
+         @endiwhile
+            @skip "now from nu to mu "
+            @iexp jj @(sc) 1 +
+            @iexp jj @(jj) @(n_) *
+         for (kk=@(jj); kk < mr; kk++ )
+         {
+               @iexp jj 0
+               @iwhile jj < @(n_)
+                  @iexp t @(jj) @(m_) * 
+                  @callproc doElement kk @(jj) C @(t)+kk p
+                  @iexp jj @(jj) 1 +
+               @endiwhile
+         }
+         break;
+         @iexp sc @(sc) 1 +
+      @endiwhile
+      default:;
+      }
+   @undef m
+   @undef sc
+   @undef t
+   @undef k
+   @undef jj
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP diagonal block when nu > mu and nu = na * mu
+@BEGINPROC doDikkBlockna n_ mul_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define c @dum@
+   @define r @dum@
+   @define m @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+         @iexp k @(j) @(mu) * @(i) +
+@ROUT blk2C
+         @iexp r @(i)
+         @iexp c @(j)
+         @iif j { i
+@ROUT C2blk
+         @iif j > i
+            @iexp r @(j)
+            @iexp c @(i)
+         @endiif
+         @iif j { i
+            @iexp r @(i)
+            @iexp c @(j)
+         @endiif
+@ROUT blk2C C2blk
+         @skip @iexp m @(n_) @(n_) *
+         @callproc doElement @(r) @(c) C @(k)+kk*@(mul_) p 
+@ROUT blk2C
+         @endiif
+@ROUT blk2C C2blk
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif n_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef m
+   @undef r
+   @undef c
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP full blocks with multiplication 
+@BEGINPROC donaBlock m_ n_ mn_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define m @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp k @(j) @(mu) * @(i) +
+         @callproc doElement @(i) @(j) C @(k)+kk*@(mn_) p 
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif m_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef m
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@iif cpvl = 1
+void @(rtnm)
+(
+   const size_t M,      /* number of rows in A */
+   const size_t N,      /* number of columns in A */
+   @ROUT blk2C
+   const @(typ) alpha,  /* scalar for b */
+   const @(typ) *b,     /* matrix stored in @(mu)x@(nu)-major order */
+   const @(typ) beta,   /* scalar for C */
+   @(typ) *C,           /* matrix to be copied to access-major format */
+   const size_t ldc     /* stride between row elements */
+   @ROUT C2blk
+   const @(typ) alpha,  /* scalar for C */
+   const @(typ) *C,     /* matrix to be copied to access-major format */
+   const size_t ldc,    /* stride between row elements */
+   const @(typ) beta,   /* scalar for b */
+   @(typ) *b            /* matrix stored in @(mu)x@(nu)-major order */
+   @ROUT C2blk blk2C
+)
+@endiif
+@iif cpvl > 1
+static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha, 
+                         const @(typ) *b, const SCALAR beta, 
+                         @(typ) *C, ATL_CSZT ldc)
+@endiif
+{
    const unsigned int mf = M/@(mu), nf = N/@(nu);
    const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
    @iif mEn = 1
@@ -1109,120 +937,8 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    }
 @endiif
 @endiif
-@endiif
-@iif SYRKU ! 0
-@SKIP ***************** unrestricted syrk implementation **********************
-   int j, jn, cinc, rwpan;
-   unsigned int pansz = @(bs);
-   const size_t incC = ldc*@(nu);
-@ROUT C2BLK `   @(typ) *rW=b, *rw; `
-@ROUT BLK2C `   const @(typ) *rW=b, *rw; `
-/*
- * NOTE: we assume N=M, always square for syrk 
- */
-   @iif ML_NO = 0 
-      @iif ML_NUR ! 0
-   const unsigned int nf = N/@(nu);
-   const unsigned int n = nf*@(nu), nr = N-n;
-      @endiif
-/*
- * NU colpan: Full panel, without cleanup (N direction)
- */
-      @iif ML_NUR ! 0 
-   for (cinc=j=0; j < n; j = jn, C += incC, cinc += @(bs))
-      @endiif
-   @SKIP ***** Nu rolled, no need of Nu cleanup 
-      @iif ML_NUR = 0
-   for (cinc=j=0; j < N; j = jn, C += incC, cinc += @(bs))
-      @endiif
-   {
-      unsigned int i, in, nd;
-      @iif ML_NUR = 0
-      unsigned int nu = N-j;
-      nu = (nu >= @(nu)) ? @(nu) : nu;
-      jn = j + nu;      /* main loop, full NU block */
-      @endiif
-      @iif ML_NUR ! 0
-      jn = j + @(nu);      /* main loop, full NU block */
-      @endiif
-      i = (j/@(mu))*@(mu);
-      rw = rW;
-/*
- *    handle the diagonal-crossing blocks first
- *    NOTE: this can be full-MU block or partial----> no unrolling right now 
- */
-      @iif ML_NUR ! 0
-         @callproc doDiagBlock mu @(nu)
-      @endiif
-      @iif ML_NUR = 0
-         @callproc doDiagBlock mu nu
-      @endiif
-/*
- *    Full block after diagonal crossing, n=m  
- */
-      @iif ML_MUNU = 1
-         @callproc doTrBlocksUR
-      @endiif
-      @SKIP only MU unrolling.. ML_MU true for both MU and MUNU
-      @iif ML_NUR = 0
-         @callproc doTrBlocksMuUR @(mu) nu
-      @endiif
-      @iif ML_MUR = 0 
-         @callproc doTrBlocksNuUR mu @(nu)
-      @endiif
-      @iif ML_MUR = 1 
-/*
- *    MU cleanup 
- */   
-      if (i < N)
-      {
-         @iif ML_MUNU = 1
-            @callproc doTrBlocksRolled mu @(nu) 0
-         @endiif
-         @iif ML_MUR = 1
-            @callproc doTrBlocksRolled mu nu 0
-         @endiif 
-      }
-      @endiif 
-   }
-   @endiif
-@BEGINSKIP
-*
-*  Following codes execute for three cases: 
-*     NU unrolled, both unrolled and no unroll 
-*     So, condition: if ML_MUR = 0 || ML_MUNU = 1 
-@ENDSKIP
-   @iif @iexp 1 @(ML_MUNU) = 0 @(ML_MUR) = |
-      @iif ML_NO = 0
-/*
- * cleanup in N dimension
- */
-   if (j < N)
-      @endiif
-      @iif ML_NO = 1
-   for (cinc=j=0; j < N; j = jn, C += incC, cinc += @(bs)) 
-      @endiif 
-   {
-      unsigned int  i, in, nu = N-j, nd, nblks;
-      jn = j + nu;
-      i = (j/@(mu))*@(mu);
-      rw = rW;
-      @callproc doDiagBlock mu nu 
-/*
- *    full blocks before diagonal 
- */
-      for (; i < N; i = in)
-      {
-         @callproc doTrBlocksRolled mu nu 1
-      }
-   }
-   @endiif 
-@endiif
-@SKIP ********** END of SYRK copy: real type ***********************************
-@endiif
 }
 @SKIP ********** SYRK L2UT copy: real type *************************************
-@iif TRI = 1
 @SKIP this proc handles single element
 @SKIP IN : alpha, beta, C, b 
 @BEGINPROC doElementT r_ c_ k_
@@ -1721,227 +1437,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
 @iexp bs @(vl) @(mu) @(nu) * @(vl) + -1 + / @(vl) *
 /* HERE vl=@(vl), mu=@(mu), nu=@(nu) bs=@(bs)*/
 @SKIP handles single element 
-@BEGINPROC doElement c_ ir_ ii_ k_
-         @iif alpha = 1
-            @iif beta = 0
-@ROUT blk2C 
-            C@(c_)[@(ir_)] = pr[@(k_)];
-            C@(c_)[@(ii_)] = pi[@(k_)];
-@ROUT C2blk 
-            pr[@(k_)] = C@(c_)[@(ir_)];
-            pi[@(k_)] = C@(c_)[@(ii_)];
-@ROUT blk2C C2blk
-            @endiif
-            @iif beta = 1
-@ROUT blk2C 
-            C@(c_)[@(ir_)] += pr[@(k_)];
-            C@(c_)[@(ii_)] += pi[@(k_)];
-@ROUT C2blk 
-            pr[@(k_)] += C@(c_)[@(ir_)];
-@ROUT blk2C C2blk
-            @endiif
-            @iif beta = -1
-@ROUT blk2C 
-            C@(c_)[@(ir_)] = pr[@(k_)] - C@(c_)[@(ir_)];
-            C@(c_)[@(ii_)] = pi[@(k_)] - C@(c_)[@(ii_)];
-@ROUT C2blk 
-            pr[@(k_)] = C@(c_)[@(ir_)] - pr[@(k_)];
-            pi[@(k_)] = C@(c_)[@(ii_)] - pi[@(k_)];
-@ROUT blk2C C2blk
-            @endiif
-            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
-@ROUT blk2C 
-            { 
-               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
-               register @(typ) rr=pr[@(k_)], ir=pi[@(k_)];
-               rr += rc * rb;
-               ir += ic * rb;
-               rr -= ic * ib;
-               ir += rc * ib;
-               C@(c_)[@(ir_)] = rr;
-               C@(c_)[@(ii_)] = ir;
-            }
-@ROUT C2blk 
-            { 
-               const register @(typ) rc=pr[@(k_)], ic=pi[@(k_)];
-               register @(typ) rr=C@(c_)[@(ir_)], ir=C@(c_)[@(ii_)];
-               rr += rc * rb;
-               ir += ic * rb;
-               rr -= ic * ib;
-               ir += rc * ib;
-               pr[@(k_)] = rr;
-               pi[@(k_)] = ic;
-            }
-@ROUT blk2C C2blk
-            @endiif
-         @endiif
-         @iif alpha = -1
-            @iif beta = 0
-@ROUT blk2C 
-            C@(c_)[@(ir_)] = -pr[@(k_)];
-            C@(c_)[@(ii_)] = -pi[@(k_)];
-@ROUT C2blk 
-            pr[@(k_)] = -C@(c_)[@(ir_)];
-            pi[@(k_)] = -C@(c_)[@(ii_)];
-@ROUT blk2C C2blk
-            @endiif
-            @iif beta = 1
-@ROUT blk2C 
-            C@(c_)[@(ir_)] -= pr[@(k_)];
-            C@(c_)[@(ii_)] -= pi[@(k_)];
-@ROUT C2blk 
-            pr[@(k_)] -= C@(c_)[@(ir_)];
-            pi[@(k_)] -= C@(c_)[@(ii_)];
-@ROUT blk2C C2blk
-            @endiif
-            @iif beta = -1
-@ROUT blk2C 
-            C@(c_)[@(ir_)] = -C@(c_)[@(ir_)] - pr[@(k_)];
-            C@(c_)[@(ii_)] = -C@(c_)[@(ii_)] - pi[@(k_)];
-@ROUT C2blk 
-            pr[@(k_)] = -C@(c_)[@(ir_)] - pr[@(k_)];
-            pi[@(k_)] = -C@(c_)[@(ii_)] - pi[@(k_)];
-@ROUT blk2C C2blk
-            @endiif
-            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
-@ROUT blk2C 
-            { 
-               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
-               register @(typ) rr = -pr[@(k_)], ir = -pi[@(k_)];
-               rr += rc * rb;
-               ir += ic * rb;
-               rr -= ic * ib;
-               ir += rc * ib;
-               C@(c_)[@(ir_)] = rr;
-               C@(c_)[@(ii_)] = ir;
-            }
-@ROUT C2blk 
-            { 
-               const register @(typ) rc=pr[@(k_)], ic=pi[@(k_)];
-               register @(typ) rr = -C@(c_)[@(ir_)], ir = -C@(c_)[@(ii_)];
-               rr += rc * rb;
-               ir += ic * rb;
-               rr -= ic * ib;
-               ir += rc * ib;
-               pr[@(k_)] = rr;
-               pi[@(k_)] = ic;
-            }
-@ROUT blk2C C2blk
-            @endiif
-         @endiif
-         @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
-            @iif beta = 0
-@ROUT blk2C 
-            { 
-               const register @(typ) rc=pr[@(k_)], ic=pi[@(k_)];
-               register @(typ) rr, ir;
-               rr = rc * ra;
-               ir = ic * ra;
-               rr -= ic * ia;
-               ir += rc * ia;
-               C@(c_)[@(ir_)] = rr;
-               C@(c_)[@(ii_)] = ir;
-            }
-@ROUT C2blk 
-            { 
-               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
-               register @(typ) rr, ir;
-               rr  = rc * ra;
-               ir  = ic * ra;
-               rr -= ic * ia;
-               ir += rc * ia;
-               pr[@(k_)] = rr;
-               pi[@(k_)] = ir;
-            }
-@ROUT blk2C C2blk
-            @endiif
-            @iif beta = 1
-@ROUT blk2C 
-            { 
-               const register @(typ) rc=pr[@(k_)], ic=pi[@(k_)];
-               register @(typ) rr=C@(c_)[@(ir_)], ir=C@(c_)[@(ii_)];
-               rr += rc * ra;
-               ir += ic * ra;
-               rr -= ic * ia;
-               ir += rc * ia;
-               C@(c_)[@(ir_)] = rr;
-               C@(c_)[@(ii_)] = ir;
-            }
-@ROUT C2blk 
-            { 
-               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
-               register @(typ) rr=pr[@(k_)], ir=pi[@(k_)];
-               rr += rc * ra;
-               ir += ic * ra;
-               rr -= ic * ia;
-               ir += rc * ia;
-               pr[@(k_)] = rr;
-               pi[@(k_)] = ir;
-            }
-@ROUT blk2C C2blk
-            @endiif
-            @iif beta = -1
-@ROUT blk2C 
-            { 
-               const register @(typ) rc=pr[@(k_)], ic=pi[@(k_)];
-               register @(typ) rr = -C@(c_)[@(ir_)], ir = -C@(c_)[@(ii_)];
-               rr += rc * ra;
-               ir += ic * ra;
-               rr -= ic * ia;
-               ir += rc * ia;
-               C@(c_)[@(ir_)] = rr;
-               C@(c_)[@(ii_)] = ir;
-            }
-@ROUT C2blk 
-            { 
-               const register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
-               register @(typ) rr = -pr[@(k_)], ir = -pi[@(k_)];
-               rr += rc * ra;
-               ir += ic * ra;
-               rr -= ic * ia;
-               ir += rc * ia;
-               pr[@(k_)] = rr;
-               pi[@(k_)] = ir;
-            }
-@ROUT blk2C C2blk
-            @endiif
-            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
-@ROUT blk2C 
-            {
-               register @(typ) rc=C@(c_)[@(ir_)], ic=C@(c_)[@(ii_)];
-               register @(typ) rB=pr[@(k_)], iB=pi[@(k_)], r0, i0, r1, i1;
-               r0  = rb * rc;
-               r1  = ra * rB;
-               i0  = rb * ic;
-               i1  = ra * iB;
-               r0 -= ib * ic;
-               i1 += ib * rc;
-               r1 -= ia * iB;
-               i1 += ia * rB;
-               C@(c_)[@(ir_)] = r0 + r1;
-               C@(c_)[@(ii_)] = i0 + i1;
-            }
-@ROUT C2blk 
-            {
-               register @(typ) rB=C@(c_)[@(ir_)], iB=C@(c_)[@(ii_)];
-               register @(typ) rc=pr[@(k_)], ic=pi[@(k_)], r0, i0, r1, i1;
-               r0  = rb * rc;
-               r1  = ra * rB;
-               i0  = rb * ic;
-               i1  = ra * iB;
-               r0 -= ib * ic;
-               i1 += ib * rc;
-               r1 -= ia * iB;
-               i1 += ia * rB;
-               pr[@(k_)] = r0 + r1;
-               pi[@(k_)] = i0 + i1;
-            }
-@ROUT blk2C C2blk
-            @endiif
-         @endiif
-@ENDPROC
-@SKIP handles single element 
-@BEGINPROC doElementUR c_ ir_ ii_ C_ k_ pr_ pi_
+@BEGINPROC doElement c_ ir_ ii_ C_ k_ pr_ pi_
          @iif alpha = 1
             @iif beta = 0
 @ROUT blk2C 
@@ -2169,6 +1665,532 @@ void Mjoin(ATL_USERCPMM,_L2UT)
             @endiif
          @endiif
 @ENDPROC
+@SKIP handles full block
+@BEGINPROC doBlock m_ n_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp ir @(i) @(i) +
+         @iexp ii @(ir) 1 +
+         @iexp k @(j) @(mu) * @(i) +
+         @callproc doElement @(j) @(ir) @(ii) C @(k) pr pi 
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iexp i @(mu) @(mu) +
+      @iif m_ = mu
+            C@(j) += @(i);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef ii
+   @undef ir
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP handles block Mu unrolled 
+@BEGINPROC doBlockMuUR m_ cinc_
+   @define i @dum@
+         C0 = C; pr0 = pr; pi0 = pi;  
+         for (jj=0; jj < nu; jj++, C0 += ldc2, pr0 += @(mu), pi0 += @(mu))
+         {
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp ir @(i) @(i) +
+         @iexp ii @(ir) 1 +
+         @callproc doElement 0 @(ir) @(ii) C @(i) pr0 pi0 
+         @iexp i @(i) 1 +
+      @endiwhile
+         }
+      @iif cinc_ ! 0
+         @iexp i @(mu) @(mu) +
+         C += @(i);
+      @endiif
+   @undef i
+@ENDPROC
+@SKIP handles block Nu unrolled, m_=0 means NU cleanup rolled 
+@BEGINPROC doBlockNuUR nu_
+   @define j @dum@
+         for (ii=0; ii < mu; ii++)
+         {
+            @iexp j 0
+            @iwhile j < @(nu_)
+               @callproc doElement @(j) 2*ii 2*ii+1 C @(mu)*@(j)+ii pr pi
+               @iexp j @(j) 1 +
+            @endiwhile
+         }
+   @undef j
+@ENDPROC
+@SKIP handles rolled blocks only   
+@BEGINPROC doBlockRolled C_ mu_ nu_ cinc_  
+   @define i @dum@
+         { /* rolled block copy */
+            unsigned int ii, jj; 
+@ROUT blk2C `            @(typ) *rC0 = @(C_);`
+@ROUT C2blk `            const @(typ) *rC0 = @(C_);`
+@ROUT blk2C `            const @(typ) *rw = pr, *iw = pi;`
+@ROUT C2blk `            @(typ) *rw = pr, *iw = pi;`
+            for (jj=0; jj < @(nu_); jj++, rC0 += ldc2, rw += @(mu), iw += @(mu))
+            {
+               for (ii=0; ii < @(mu_); ii++)
+               {
+                  @callproc doElement 0 2*ii 2*ii+1 rC ii rw iw 
+               }
+            }
+      @iif cinc_ ! 0
+         @iexp i @(mu) @(mu) +
+            @(C_) += @(i);
+      @endiif
+         }
+   @undef i
+@ENDPROC
+@SKIP handles diagonal subblocks when mu=ma*nu
+@SKIP IN: mu, nu, beta, alpha
+@BEGINPROC doDiBlockmn m_ n_ ma_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define t @dum@
+   @define sc @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @define jj @dum@
+      switch (j%@(ma_))
+      {
+      @iexp sc 0
+      @iwhile sc < @(ma_)
+      case @(sc):
+         @iexp j 0
+         @iwhile j < @(n_)  
+            @iexp i 0
+            @iwhile i < @(m_) 
+               @iexp k @(j) @(mu) * @(i) +
+               @iexp t @(nu) @(sc) *
+               @iexp t @(t) @(j) +
+               @iif i < @(t) 
+@ROUT C2blk    
+                  @iexp jj @(m_) -1 +    
+                  @iexp ir @(jj) @(jj) + 
+                  @iexp ii @(ir) 1 + 
+                  @callproc doElement @(j) @(ir) @(ii) C @(k) pr pi 
+@ROUT C2blk blk2C
+               @endiif
+               @iif i } @(t)
+                  @iexp ir @(i) @(i) + 
+                  @iexp ii @(ir) 1 + 
+                  @callproc doElement @(j) @(ir) @(ii) C @(k) pr pi
+               @endiif
+               @iexp i @(i) 1 +
+            @endiwhile
+         @iexp ir @(m_) @(m_) +
+         @skip C@(j) += @(m_);
+         C@(j) += @(ir);
+            @iexp j @(j) 1 +
+         @endiwhile
+         break;
+         @iexp sc @(sc) 1 +
+      @endiwhile
+      default:;
+      }
+   @undef jj
+   @undef ii 
+   @undef ir 
+   @undef sc
+   @undef t
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP diagonal block when nu > mu and nu = na * mu
+@BEGINPROC doDikkBlockna n_ mul_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define c @dum@
+   @define r @dum@
+   @define m @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(n_)
+         @iexp k @(j) @(mu) * @(i) +
+@ROUT blk2C
+         @iexp r @(i)
+         @iexp c @(j)
+         @iif j { i
+@ROUT C2blk
+         @iif j > i
+            @iexp r @(j)
+            @iexp c @(i)
+         @endiif
+         @iif j { i
+            @iexp r @(i)
+            @iexp c @(j)
+         @endiif
+@ROUT blk2C C2blk
+         @iexp ir @(r) @(r) + 
+         @iexp ii @(ir) 1 + 
+         @callproc doElement @(c) @(ir) @(ii) C @(k)+kk*@(mul_) pr pi 
+@ROUT blk2C
+         @endiif
+@ROUT blk2C C2blk
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif n_ = mu
+            @iexp ir @(mu) @(mu) +
+            @skip C@(j) += @(mu);
+            C@(j) += @(ir);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef ii
+   @undef ir
+   @undef m
+   @undef r
+   @undef c
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP full blocks with multiplication 
+@BEGINPROC donaBlock m_ n_ mn_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define m @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp k @(j) @(mu) * @(i) +
+         @iexp ir @(i) @(i) + 
+         @iexp ii @(ir) 1 + 
+         @callproc doElement @(j) @(ir) @(ii) C @(k)+kk*@(mn_) pr pi 
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif m_ = mu
+         @iexp ir @(mu) @(mu) + 
+            C@(j) += @(ir);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef ii
+   @undef ir
+   @undef m
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP handles cleanup of diagonal subblocks when mu=ma*nu
+@SKIP IN: mu, nu, beta, alpha,
+@BEGINPROC doCuDiBlockmn m_ n_ ma_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define jj @dum@
+   @define t @dum@
+   @define sc @dum@
+   @define m @dum@
+      unsigned int kk;
+      switch (j%@(ma_))
+      {
+      @iexp m @(ma_) -1 +
+      @iexp sc 0
+      @iwhile sc < @(m)
+      case @(sc):
+         @iexp j 0
+         @iwhile j < @(n_)  
+            @iexp i 0 
+            @iwhile i < @(m_) 
+               @iexp k @(j) @(mu) * @(i) +
+               @iexp t @(nu) @(sc) *
+               @iexp t @(t) @(j) +
+@ROUT C2blk    
+               @iif i < @(t) 
+               @iexp jj @(i) 1 +    
+            pr[@(k)] = 0.0;
+            pi[@(k)] = 0.0;
+               @endiif
+@ROUT C2blk blk2C
+               @iif i } @(t)
+                  @skip "upper limit"
+                  @iexp t @(sc) 1 +
+                  @iexp t @(t) @(nu) *
+                  @iif i < @(t)
+                     @iexp ir @(i) @(i) + 
+                     @iexp ii @(ir) 1 + 
+            @callproc doElement @(j) @(ir) @(ii) C @(k) pr pi
+                  @endiif
+               @endiif
+               @iexp i @(i) 1 +
+            @endiwhile
+            @iexp j @(j) 1 +
+         @endiwhile
+            @skip "now from nu to mu "
+            @iexp jj @(sc) 1 +
+            @iexp jj @(jj) @(n_) *
+            for (kk=@(jj); kk < mr; kk++ )
+            {
+               @iexp jj 0
+               @iwhile jj < @(n_)
+                  @iexp t @(jj) @(m_) * 
+                  @callproc doElement @(jj) (2*kk) (2*kk+1) C @(t)+kk pr pi
+                  @iexp jj @(jj) 1 +
+               @endiwhile
+            }
+            break;
+         @iexp sc @(sc) 1 +
+      @endiwhile
+      default:;
+      }
+   @undef m
+   @undef sc
+   @undef t
+   @undef jj
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@ROUT blk2C C2blk
+@iif TRI = 0 
+/*
+ * Main Loop:
+ @iif bvML = 0
+ * Both Rolled
+ @endiif
+ @iif ML_MUR ! 0
+ * Mu unrolled
+ @endiif
+ @iif ML_NUR ! 0
+ * Nu unrolled
+ @endiif
+ */
+@iif cpvl = 1
+void @(rtnm)
+(
+   const size_t M,      /* number of rows in A */
+   const size_t N,      /* number of columns in A */
+   const @(typ) *alpha, /* scalar for b */
+   @ROUT blk2C
+   const @(typ) *rC,    /* real block stored in @(mu)x@(nu)-major order */
+   const @(typ) *iC,    /* imag block stored in @(mu)x@(nu)-major order */
+   const @(typ) *beta,  /* scalar for C */
+   @(typ) *C,           /* matrix to be copied to access-major format */
+   const size_t ldc     /* stride between row elements */
+   @ROUT C2blk
+   const @(typ) *C,     /* matrix to be copied to access-major format */
+   const size_t ldc,    /* stride between row elements */
+   const @(typ) *beta,  /* scalar for C */
+   @(typ) *rC,          /* real block stored in @(mu)x@(nu)-major order */
+   @(typ) *iC           /* imag block stored in @(mu)x@(nu)-major order */
+   @ROUT C2blk blk2C
+)
+@endiif
+@iif cpvl > 1
+static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha, 
+                         const @(typ) *b, const SCALAR beta, 
+                         @(typ) *C, ATL_CSZT ldc)
+@endiif
+{
+@SKIP *********************** GEMM copy: complex type **************************
+   const unsigned int mf = M/@(mu), nf = N/@(nu);
+   const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
+   const unsigned int pansz = (nr) ? (nf+1)*@(bs) : nf*@(bs); /* bs=@(bs) */
+   unsigned int i, j;
+   @iif alpX ! 0
+   const register @(typ) ra=(*alpha), ia=alpha[1];
+   @endiif
+   @iif betX ! 0
+   const register @(typ) rb=(*beta), ib=beta[1];
+   @endiif
+   @iif ML_MUR = 0
+   unsigned int ii, mu;
+   const size_t incC = (ldc*@(nu) - ((M+@(mu)-1)/@(mu))*@(mu))<<1; 
+   const size_t ldc2 = ldc+ldc;
+   @endiif
+   @iif ML_MUR ! 0
+   const size_t incC = (ldc*@(nu) - m)<<1, ldc2 = ldc+ldc;
+   @endiif
+   @iif ML_NUR = 0
+   unsigned int jj, nu;
+   @endiif
+@ROUT blk2C `   @declare "   @(typ) " n n ";"`
+@ROUT C2blk `   @declare "   const @(typ) " n n ";"`
+      *C0=C
+      @define j @1@
+      @iwhile j < @(nu)
+         @iexp i @(j) -1 +
+         *C@(j)=C@(i)+ldc2
+         @iexp j @(j) 1 +
+      @endiwhile
+   @enddeclare
+   @iif ML_NUR ! 0
+   for (j=nf; j; j--, rC += @(bs), iC += @(bs))
+   {
+   @endiif
+   @iif ML_NUR = 0
+   for (j=0; j < N; j+=nu, rC += @(bs), iC += @(bs))
+   {
+@ROUT blk2C `      const @(typ) *pr0, *pi0;`
+@ROUT C2blk `      @(typ) *pr0, *pi0;`
+   @endiif
+@ROUT blk2C `      const @(typ) *pr = rC, *pi = iC;`
+@ROUT C2blk `      @(typ) *pr = rC, *pi = iC;`
+   @iif ML_NUR = 0
+      nu = N - j;
+      nu = (nu > @(nu)) ? @(nu) : nu;
+   @endiif
+   @iif ML_MUR ! 0
+      for (i=mf; i; i--, pr += pansz, pi += pansz)
+      {
+      @iif ML_MUNU ! 0
+         @callproc doBlock @(mu) @(nu)
+      @endiif
+      @iif ML_MUNU = 0
+         @callproc doBlockMuUR @(mu) 1
+      @endiif
+      }
+   @endiif
+   @iif ML_MUR = 0
+      for (i=0; i < M; i += mu, pr += pansz, pi += pansz)
+      {
+         mu = M-i;
+         mu = (mu >= @(mu)) ? @(mu) : mu;
+         @iif ML_NO = 0
+         @callproc doBlockNuUR @(nu)
+      @iexp k @(mu) @(mu) +
+      @iexp j 0
+      @iwhile j < @(nu)
+         C@(j) += @(k);
+         @iexp j @(j) 1 +
+      @endiwhile
+         @endiif 
+         @iif ML_NO ! 0 
+         @callproc doBlockRolled C mu nu 1 
+         @endiif
+      }
+   @endiif
+@SKIP --- M cleanup: MU_UR and MUNU_UR  
+   @iif ML_MUR ! 0 
+      @iif CU_MUR = 0
+      { /* clean up in M dimension */
+         @iif ML_MUNU ! 0
+         @callproc doBlockRolled C0 mr @(nu) 0  
+         @endiif
+         @iif ML_MUNU = 0
+         @callproc doBlockRolled C mr nu 0  
+         @endiif
+      }
+      @endiif
+      @iif CU_MUR ! 0
+      switch(mr)
+      {
+   @iexp m 1
+   @iwhile m < @(mu)
+      case @(m):
+         @iif ML_MUNU ! 0
+      @callproc doBlock @(m) @(nu)
+         @endiif
+         @iif ML_MUNU = 0
+      @callproc doBlockMuUR @(m) 0
+         @endiif
+      @iexp m @(m) 1 +
+         break;
+   @endiwhile
+      default:;
+      }
+      @endiif
+   @endiif
+   @iif ML_NUR ! 0
+   @iexp j 0
+   @iwhile j < @(nu)
+      C@(j) += incC;
+      @iexp j @(j) 1 +
+   @endiwhile
+   @endiif
+   @iif ML_NUR = 0
+      C += incC;
+   @endiif
+   }
+@SKIP --- N cleanup
+   @iif ML_NUR ! 0
+      @iif nu > 1
+         @iif CU_NUR = 0
+   { /* Cleanup in N dimension */
+@ROUT blk2C `      const @(typ) *pr = rC, *pi = iC;`
+@ROUT C2blk `      @(typ) *pr = rC, *pi = rC;`
+            @iif ML_MUNU ! 0
+      unsigned int mu;
+            @endiif
+      C += ((ldc * n)<<1);  
+      for (i=0; i < M; i += mu, pr += pansz, pi += pansz)
+      {
+         mu = ((M-i) >= @(mu)) ? @(mu) : (M-i);
+         @callproc doBlockRolled C mu nr 1
+      }
+   }
+         @endiif
+         @iif CU_NUR ! 0
+   switch(nr)
+   {
+@ROUT blk2C `      const @(typ) *pr, *pi;`
+@ROUT C2blk `      @(typ) *pr, *pi;`
+   @iexp n 1
+   @iwhile n < @(nu)
+   case @(n):
+      pr = rC; pi = iC;
+            @iif ML_MUNU ! 0
+      for (i=0; i < mf; i++, pr += pansz, pi += pansz)
+      {
+         @callproc doBlock @(mu) @(n)
+      }
+      switch(mr)
+      {
+   @iexp m 1
+   @iwhile m < @(mu)
+      case @(m):
+      @callproc doBlock @(m) @(n)
+      @iexp m @(m) 1 +
+         break;
+   @endiwhile
+      default:;
+      }
+            @endiif
+            @iif ML_MUNU = 0
+      for (i=0; i < M; i += mu, pr += pansz, pi += pansz)
+      {
+         mu = ((M-i) >= @(mu)) ? @(mu) : (M-i);
+         @callproc doBlockNuUR @(n)          
+      @iexp k @(mu) @(mu) +
+      @iexp j 0
+      @iwhile j < @(n)
+         C@(j) += @(k);
+         @iexp j @(j) 1 +
+      @endiwhile
+      }
+            @endiif
+      break;
+      @iexp n @(n) 1 +
+   @endiwhile
+   default:;
+   }
+         @endiif
+      @endiif
+   @endiif
+}
+@endiif
+@SKIP ***************** SYRK copy: complex type ********************************
+@iif TRI = 1
 @SKIP handles diagonal block when mu=nu
 @SKIP IN: mu, nu, beta, alpha
 @BEGINPROC doDiBlock n_
@@ -2433,92 +2455,6 @@ void Mjoin(ATL_USERCPMM,_L2UT)
    @undef j
    @undef i 
 @ENDPROC
-@SKIP handles full block
-@BEGINPROC doBlock m_ n_
-   @define i @dum@
-   @define j @dum@
-   @define k @dum@
-   @define ir @dum@
-   @define ii @dum@
-   @iexp j 0
-   @iwhile j < @(n_)
-      @iexp i 0
-      @iwhile i < @(m_)
-         @iexp ir @(i) @(i) +
-         @iexp ii @(ir) 1 +
-         @iexp k @(j) @(mu) * @(i) +
-         @SKIP @callproc doElement @(j) @(ir) @(ii) @(k) 
-         @callproc doElementUR @(j) @(ir) @(ii) C @(k) pr pi 
-         @iexp i @(i) 1 +
-      @endiwhile
-      @iexp i @(mu) @(mu) +
-      @iif m_ = mu
-            C@(j) += @(i);
-      @endiif
-      @iexp j @(j) 1 +
-   @endiwhile
-   @undef ii
-   @undef ir
-   @undef k
-   @undef j
-   @undef i
-@ENDPROC
-@SKIP handles block Mu unrolled 
-@BEGINPROC doBlockMuUR m_ cinc_
-   @define i @dum@
-         C0 = C; pr0 = pr; pi0 = pi;  
-         for (jj=0; jj < nu; jj++, C0 += ldc2, pr0 += @(mu), pi0 += @(mu))
-         {
-      @iexp i 0
-      @iwhile i < @(m_)
-         @iexp ir @(i) @(i) +
-         @iexp ii @(ir) 1 +
-         @callproc doElementUR 0 @(ir) @(ii) C @(i) pr0 pi0 
-         @iexp i @(i) 1 +
-      @endiwhile
-         }
-      @iif cinc_ ! 0
-         @iexp i @(mu) @(mu) +
-         C += @(i);
-      @endiif
-   @undef i
-@ENDPROC
-@SKIP handles block Nu unrolled, m_=0 means NU cleanup rolled 
-@BEGINPROC doBlockNuUR nu_
-   @define j @dum@
-         for (ii=0; ii < mu; ii++)
-         {
-            @iexp j 0
-            @iwhile j < @(nu_)
-               @callproc doElementUR @(j) 2*ii 2*ii+1 C @(mu)*@(j)+ii pr pi
-               @iexp j @(j) 1 +
-            @endiwhile
-         }
-   @undef j
-@ENDPROC
-@SKIP handles rolled blocks only   
-@BEGINPROC doBlockRolled C_ mu_ nu_ cinc_  
-   @define i @dum@
-         { /* rolled block copy */
-            unsigned int ii, jj; 
-@ROUT blk2C `            @(typ) *rC0 = @(C_);`
-@ROUT C2blk `            const @(typ) *rC0 = @(C_);`
-@ROUT blk2C `            const @(typ) *rw = pr, *iw = pi;`
-@ROUT C2blk `            @(typ) *rw = pr, *iw = pi;`
-            for (jj=0; jj < @(nu_); jj++, rC0 += ldc2, rw += @(mu), iw += @(mu))
-            {
-               for (ii=0; ii < @(mu_); ii++)
-               {
-                  @callproc doElementUR 0 2*ii 2*ii+1 rC ii rw iw 
-               }
-            }
-      @iif cinc_ ! 0
-         @iexp i @(mu) @(mu) +
-            @(C_) += @(i);
-      @endiif
-         }
-   @undef i
-@ENDPROC
 @SKIP handles diagonal subblocks when mu=ma*nu
 @SKIP IN: mu, nu, beta, alpha
 @BEGINPROC doDiBlockmn m_ n_ ma_
@@ -2547,13 +2483,13 @@ void Mjoin(ATL_USERCPMM,_L2UT)
                   @iexp jj @(m_) -1 +    
                   @iexp ir @(jj) @(jj) + 
                   @iexp ii @(ir) 1 + 
-                  @callproc doElement @(j) @(ir) @(ii) @(k) 
+                  @callproc doElement @(j) @(ir) @(ii) C @(k) pr pi 
 @ROUT C2blk blk2C
                @endiif
                @iif i } @(t)
                   @iexp ir @(i) @(i) + 
                   @iexp ii @(ir) 1 + 
-                  @callproc doElement @(j) @(ir) @(ii) @(k)
+                  @callproc doElement @(j) @(ir) @(ii) C @(k) pr pi
                @endiif
                @iexp i @(i) 1 +
             @endiwhile
@@ -2607,7 +2543,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
 @ROUT blk2C C2blk
          @iexp ir @(r) @(r) + 
          @iexp ii @(ir) 1 + 
-         @callproc doElement @(c) @(ir) @(ii) @(k)+kk*@(mul_) 
+         @callproc doElement @(c) @(ir) @(ii) C @(k)+kk*@(mul_) pr pi 
 @ROUT blk2C
          @endiif
 @ROUT blk2C C2blk
@@ -2644,7 +2580,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
          @iexp k @(j) @(mu) * @(i) +
          @iexp ir @(i) @(i) + 
          @iexp ii @(ir) 1 + 
-         @callproc doElement @(j) @(ir) @(ii) @(k)+kk*@(mn_) 
+         @callproc doElement @(j) @(ir) @(ii) C @(k)+kk*@(mn_) pr pi 
          @iexp i @(i) 1 +
       @endiwhile
       @iif m_ = mu
@@ -2698,7 +2634,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
                   @iif i < @(t)
                      @iexp ir @(i) @(i) + 
                      @iexp ii @(ir) 1 + 
-            @callproc doElement @(j) @(ir) @(ii) @(k)
+            @callproc doElement @(j) @(ir) @(ii) C @(k) pr pi
                   @endiif
                @endiif
                @iexp i @(i) 1 +
@@ -2713,7 +2649,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
                @iexp jj 0
                @iwhile jj < @(n_)
                   @iexp t @(jj) @(m_) * 
-                  @callproc doElement @(jj) (2*kk) (2*kk+1) @(t)+kk
+                  @callproc doElement @(jj) (2*kk) (2*kk+1) C @(t)+kk pr pi
                   @iexp jj @(jj) 1 +
                @endiwhile
             }
@@ -2730,19 +2666,6 @@ void Mjoin(ATL_USERCPMM,_L2UT)
    @undef j
    @undef i
 @ENDPROC
-@ROUT blk2C C2blk
-/*
- * Main Loop:
- @iif bvML = 0
- * Both Rolled
- @endiif
- @iif ML_MUR ! 0
- * Mu unrolled
- @endiif
- @iif ML_NUR ! 0
- * Nu unrolled
- @endiif
- */
 @iif cpvl = 1
 void @(rtnm)
 (
@@ -2770,195 +2693,6 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
                          @(typ) *C, ATL_CSZT ldc)
 @endiif
 {
-@SKIP *********************** GEMM copy: complex type **************************
-@iif TRI = 0 
-   const unsigned int mf = M/@(mu), nf = N/@(nu);
-   const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
-   const unsigned int pansz = (nr) ? (nf+1)*@(bs) : nf*@(bs); /* bs=@(bs) */
-   unsigned int i, j;
-   @iif alpX ! 0
-   const register @(typ) ra=(*alpha), ia=alpha[1];
-   @endiif
-   @iif betX ! 0
-   const register @(typ) rb=(*beta), ib=beta[1];
-   @endiif
-   @iif ML_MUR = 0
-   unsigned int ii, mu;
-   const size_t incC = (ldc*@(nu) - ((M+@(mu)-1)/@(mu))*@(mu))<<1; 
-   const size_t ldc2 = ldc+ldc;
-   @endiif
-   @iif ML_MUR ! 0
-   const size_t incC = (ldc*@(nu) - m)<<1, ldc2 = ldc+ldc;
-   @endiif
-   @iif ML_NUR = 0
-   unsigned int jj, nu;
-   @endiif
-@ROUT blk2C `   @declare "   @(typ) " n n ";"`
-@ROUT C2blk `   @declare "   const @(typ) " n n ";"`
-      *C0=C
-      @define j @1@
-      @iwhile j < @(nu)
-         @iexp i @(j) -1 +
-         *C@(j)=C@(i)+ldc2
-         @iexp j @(j) 1 +
-      @endiwhile
-   @enddeclare
-   @iif ML_NUR ! 0
-   for (j=nf; j; j--, rC += @(bs), iC += @(bs))
-   {
-   @endiif
-   @iif ML_NUR = 0
-   for (j=0; j < N; j+=nu, rC += @(bs), iC += @(bs))
-   {
-@ROUT blk2C `      const @(typ) *pr0, *pi0;`
-@ROUT C2blk `      @(typ) *pr0, *pi0;`
-   @endiif
-@ROUT blk2C `      const @(typ) *pr = rC, *pi = iC;`
-@ROUT C2blk `      @(typ) *pr = rC, *pi = iC;`
-   @iif ML_NUR = 0
-      nu = N - j;
-      nu = (nu > @(nu)) ? @(nu) : nu;
-   @endiif
-   @iif ML_MUR ! 0
-      for (i=mf; i; i--, pr += pansz, pi += pansz)
-      {
-      @iif ML_MUNU ! 0
-         @callproc doBlock @(mu) @(nu)
-      @endiif
-      @iif ML_MUNU = 0
-         @callproc doBlockMuUR @(mu) 1
-      @endiif
-      }
-   @endiif
-   @iif ML_MUR = 0
-      for (i=0; i < M; i += mu, pr += pansz, pi += pansz)
-      {
-         mu = M-i;
-         mu = (mu >= @(mu)) ? @(mu) : mu;
-         @iif ML_NO = 0
-         @callproc doBlockNuUR @(nu)
-      @iexp k @(mu) @(mu) +
-      @iexp j 0
-      @iwhile j < @(nu)
-         C@(j) += @(k);
-         @iexp j @(j) 1 +
-      @endiwhile
-         @endiif 
-         @iif ML_NO ! 0 
-         @callproc doBlockRolled C mu nu 1 
-         @endiif
-      }
-   @endiif
-@SKIP --- M cleanup: MU_UR and MUNU_UR  
-   @iif ML_MUR ! 0 
-      @iif CU_MUR = 0
-      { /* clean up in M dimension */
-         @iif ML_MUNU ! 0
-         @callproc doBlockRolled C0 mr @(nu) 0  
-         @endiif
-         @iif ML_MUNU = 0
-         @callproc doBlockRolled C mr nu 0  
-         @endiif
-      }
-      @endiif
-      @iif CU_MUR ! 0
-      switch(mr)
-      {
-   @iexp m 1
-   @iwhile m < @(mu)
-      case @(m):
-         @iif ML_MUNU ! 0
-      @callproc doBlock @(m) @(nu)
-         @endiif
-         @iif ML_MUNU = 0
-      @callproc doBlockMuUR @(m) 0
-         @endiif
-      @iexp m @(m) 1 +
-         break;
-   @endiwhile
-      default:;
-      }
-      @endiif
-   @endiif
-   @iif ML_NUR ! 0
-   @iexp j 0
-   @iwhile j < @(nu)
-      C@(j) += incC;
-      @iexp j @(j) 1 +
-   @endiwhile
-   @endiif
-   @iif ML_NUR = 0
-      C += incC;
-   @endiif
-   }
-@SKIP --- N cleanup
-   @iif ML_NUR ! 0
-      @iif nu > 1
-         @iif CU_NUR = 0
-   { /* Cleanup in N dimension */
-@ROUT blk2C `      const @(typ) *pr = rC, *pi = iC;`
-@ROUT C2blk `      @(typ) *pr = rC, *pi = rC;`
-            @iif ML_MUNU ! 0
-      unsigned int mu;
-            @endiif
-      C += ((ldc * n)<<1);  
-      for (i=0; i < M; i += mu, pr += pansz, pi += pansz)
-      {
-         mu = ((M-i) >= @(mu)) ? @(mu) : (M-i);
-         @callproc doBlockRolled C mu nr 1
-      }
-   }
-         @endiif
-         @iif CU_NUR ! 0
-   switch(nr)
-   {
-@ROUT blk2C `      const @(typ) *pr, *pi;`
-@ROUT C2blk `      @(typ) *pr, *pi;`
-   @iexp n 1
-   @iwhile n < @(nu)
-   case @(n):
-      pr = rC; pi = iC;
-            @iif ML_MUNU ! 0
-      for (i=0; i < mf; i++, pr += pansz, pi += pansz)
-      {
-         @callproc doBlock @(mu) @(n)
-      }
-      switch(mr)
-      {
-   @iexp m 1
-   @iwhile m < @(mu)
-      case @(m):
-      @callproc doBlock @(m) @(n)
-      @iexp m @(m) 1 +
-         break;
-   @endiwhile
-      default:;
-      }
-            @endiif
-            @iif ML_MUNU = 0
-      for (i=0; i < M; i += mu, pr += pansz, pi += pansz)
-      {
-         mu = ((M-i) >= @(mu)) ? @(mu) : (M-i);
-         @callproc doBlockNuUR @(n)          
-      @iexp k @(mu) @(mu) +
-      @iexp j 0
-      @iwhile j < @(n)
-         C@(j) += @(k);
-         @iexp j @(j) 1 +
-      @endiwhile
-      }
-            @endiif
-      break;
-      @iexp n @(n) 1 +
-   @endiwhile
-   default:;
-   }
-         @endiif
-      @endiif
-   @endiif
-@endiif
-@SKIP ***************** SYRK copy: complex type ********************************
-@iif TRI = 1
    const unsigned int mf = M/@(mu), nf = N/@(nu);
    const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
    @iif mEn = 1
@@ -3185,10 +2919,8 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    }
    @endiif
 @endiif
-@endiif
 }
 @SKIP ***************** SYRK L2UT : complex type *******************************
-@iif TRI = 1
 @SKIP handles single element 
 @BEGINPROC doElementT c_ ir_ ii_ k_ 
          @iif alpha = 1

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -44,6 +44,45 @@
       @define mEn @1@
    @endiif
 @endiif
+@SKIP ****************** bitvector for parameterized unrolling *****************
+@BEGINSKIP
+   Now we created two flags: one for main loop and other for cleanup loop
+   bvML : bitvector, default 3, with following meanings:
+      0 : no unroll in any dimension
+      1 : unroll MU dimension
+      2 : unroll NU dimension
+      3 : unroll both dimension
+   bvCU : bitvector, default 0, with following meanings: 
+      0 : no unroll in any dimension
+      1 : unroll MU dimension
+      2 : unroll NU dimension
+      3 : unroll both dimension
+@ENDSKIP
+@SKIP **** made fully unrolled mainloop (bvML=3) as the default case
+@ifdef ! bvML
+   @iexp bvML 3  
+@endifdef
+@SKIP **** made fully unrolled cleanup loop (bvCU=3) as the  default case 
+@ifdef ! bvCU
+   @iexp bvCU 3 
+@endifdef
+@BEGINSKIP
+   to make code more readable, I create two flag to represent to each bits
+   ML_NUR, ML_MUR
+   CU_NUR, CU_MUR
+   NOTE: if ML is rolled CU is ignored 
+@ENDSKIP
+@iexp ML_MUR @(bvML) 1 &
+@iexp ML_NUR @(bvML) 2 &
+@iexp ML_MUNU @(bvML) 3 =
+@iexp ML_NO @(bvML) 0 = 
+@print ML_MUR=@(ML_MUR) ML_NUR=@(ML_NUR) ML_MUNU=@(ML_MUNU) 
+@iexp CU_MUR @(bvCU) 1 &
+@iexp CU_NUR @(bvCU) 2 &
+@iexp CU_MUNU @(bvCU) 3 =
+@iexp CU_NO @(bvCU) 0 = 
+@print CU_MUR = @(CU_MUR) CU_NUR = @(CU_NUR)
+@SKIP **************************************************************************
 @ROUT blk2C C2blk
 #include <stddef.h>
 @ifdef ! cpvl
@@ -124,6 +163,64 @@
             @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
 @ROUT blk2C `            C@(c)[@(r)] = beta*C@(c)[@(r)] + alpha*p[@(k)];`
 @ROUT C2blk `            p[@(k)] = beta*p[@(k)] + alpha*C@(c)[@(r)];`
+            @endiif
+         @endiif
+@ENDPROC
+@SKIP this proc handles only one element
+@SKIP IN : alpha, beta 
+@BEGINPROC doElementUR r c C_ k p_
+         @iif alpha = 1
+            @iif beta = 0
+@ROUT blk2C `                  @(C_)@(c)[@(r)] = @(p_)[@(k)];`
+@ROUT C2blk `                  @(p_)[@(k)] = @(C_)@(c)[@(r)];`
+            @endiif
+            @iif beta = 1
+@ROUT blk2C `                  @(C_)@(c)[@(r)] += @(p_)[@(k)];`
+@ROUT C2blk `                  @(p_)[@(k)] += @(C_)@(c)[@(r)];`
+            @endiif
+            @iif beta = -1
+@ROUT blk2C `                  @(C_)@(c)[@(r)] = @(p_)[@(k)] - @(C_)@(c)[@(r)];`
+@ROUT C2blk `                  @(p_)[@(k)] = @(C_)@(c)[@(r)] - @(p_)[@(k)];`
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `                  @(C_)@(c)[@(r)] = beta*@(C_)@(c)[@(r)] + @(p_)[@(k)];`
+@ROUT C2blk `                  @(p_)[@(k)] = beta*@(p_)[@(k)] + @(C_)@(c)[@(r)];`
+            @endiif
+         @endiif
+         @iif alpha = -1
+            @iif beta = 0
+@ROUT blk2C `                  @(C_)@(c)[@(r)] = -@(p_)[@(k)];`
+@ROUT C2blk `                  @(p_)[@(k)] = -@(C_)@(c)[@(r)];`
+            @endiif
+            @iif beta = 1
+@ROUT blk2C `                  @(C_)@(c)[@(r)] -= @(p_)[@(k)];`
+@ROUT C2blk `                  @(p_)[@(k)] -= @(C_)@(c)[@(r)];`
+            @endiif
+            @iif beta = -1
+@ROUT blk2C `                  @(C_)@(c)[@(r)] = -@(C_)@(c)[@(r)] - @(p_)[@(k)];`
+@ROUT C2blk `                  @(p_)[@(k)] = -@(C_)@(c)[@(r)] - @(p_)[@(k)];`
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `                  @(C_)@(c)[@(r)] = beta*@(C_)@(c)[@(r)] - @(p_)[@(k)];`
+@ROUT C2blk `                  @(p_)[@(k)] = beta*@(p_)[@(k)] - @(C_)@(c)[@(r)];`
+            @endiif
+         @endiif
+         @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
+            @iif beta = 0
+@ROUT blk2C `                  @(C_)@(c)[@(r)] = alpha*@(p_)[@(k)];`
+@ROUT C2blk `                  @(p_)[@(k)] = alpha*@(C_)@(c)[@(r)];`
+            @endiif
+            @iif beta = 1
+@ROUT blk2C `                  @(C_)@(c)[@(r)] += alpha*@(p_)[@(k)];`
+@ROUT C2blk `                  @(p_)[@(k)] += alpha*@(C_)@(c)[@(r)];`
+            @endiif
+            @iif beta = -1
+@ROUT blk2C `                  @(C_)@(c)[@(r)] = alpha*@(p_)[@(k)] - @(C_)@(c)[@(r)];`
+@ROUT C2blk `                  @(p_)[@(k)] = alpha*@(C_)@(c)[@(r)] - @(p_)[@(k)];`
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `                  @(C_)@(c)[@(r)] = beta*@(C_)@(c)[@(r)] + alpha*@(p_)[@(k)];`
+@ROUT C2blk `                  @(p_)[@(k)] = beta*@(p_)[@(k)] + alpha*@(C_)@(c)[@(r)];`
             @endiif
          @endiif
 @ENDPROC
@@ -332,7 +429,7 @@
    @undef i
 @ENDPROC
 @SKIP handles square blocks 
-@BEGINPROC doBlock m_ n_
+@BEGINPROC doBlock m_ n_ p_
    @define i @dum@
    @define j @dum@
    @define k @dum@
@@ -341,7 +438,7 @@
       @iexp i 0
       @iwhile i < @(m_)
          @iexp k @(j) @(mu) * @(i) +
-         @callproc doElement @(i) @(j) @(k) 
+         @callproc doElementUR @(i) @(j) @(k) 
          @iexp i @(i) 1 +
       @endiwhile
       @iif m_ = mu
@@ -352,6 +449,56 @@
    @undef k
    @undef j
    @undef i
+@ENDPROC
+@SKIP handles rolled blocks only   
+@BEGINPROC doBlockRolled C_ mu_ nu_ cinc_  
+         { /* rolled block copy */
+            unsigned int ii, jj; 
+@ROUT blk2C `            @(typ) *rC0 = @(C_);`
+@ROUT C2blk `            const @(typ) *rC0 = @(C_);`
+@ROUT blk2C `            const @(typ) *pr = p;`
+@ROUT C2blk `            @(typ) *pr = p;`
+            for (jj=0; jj < @(nu_); jj++, rC0 += ldc, pr += @(mu))
+            {
+               for (ii=0; ii < @(mu_); ii++)
+               {
+                  @callproc doElementUR ii 0 rC ii pr 
+               }
+            }
+      @iif cinc_ ! 0
+            @(C_) += @(mu);
+      @endiif
+         }
+@ENDPROC
+@SKIP handles block Mu unrolled 
+@BEGINPROC doBlockMuUR m_ cinc_  
+   @define i @dum@
+         C0 = C; p0 = p;  
+         for (jj=0; jj < nu; jj++, C0 += ldc, p0 += @(mu))
+         {
+      @iexp i 0
+      @iwhile i < @(m_)
+         @callproc doElementUR @(i) 0 C @(i) p0 
+         @iexp i @(i) 1 +
+      @endiwhile
+         }
+      @iif cinc_ ! 0
+         C += @(mu);
+      @endiif
+   @undef i
+@ENDPROC
+@SKIP handles block Nu unrolled, m_=0 means NU cleanup rolled 
+@BEGINPROC doBlockNuUR nu_
+   @define j @dum@
+         for (ii=0; ii < mu; ii++)
+         {
+            @iexp j 0
+            @iwhile j < @(nu_)
+               @callproc doElementUR ii @(j) C @(mu)*@(j)+ii p
+               @iexp j @(j) 1 +
+            @endiwhile
+         }
+   @undef j
 @ENDPROC
 @SKIP full blocks with multiplication 
 @BEGINPROC donaBlock m_ n_ mn_
@@ -377,6 +524,18 @@
    @undef j
    @undef i
 @ENDPROC
+/*
+ * Main Loop:
+ @iif bvML = 0
+ * Both Rolled
+ @endiif
+ @iif ML_MUR ! 0
+ * Mu unrolled
+ @endiif
+ @iif ML_NUR ! 0
+ * Nu unrolled
+ @endiif
+ */
 @iif cpvl = 1
 void @(rtnm)
 (
@@ -405,11 +564,27 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 {
 @SKIP ********************** GEMM copy: real type ******************************
 @iif TRI = 0
+   unsigned int i, j;
    const unsigned int mf = M/@(mu), nf = N/@(nu);
    const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
    const unsigned int pansz = (nr) ? (nf+1)*@(bs) : nf*@(bs); /* bs=@(bs) */
+   @SKIP *** NU_UR NO_UR cases: MU_UR = 0 
+   @iif ML_MUR = 0
+   const size_t incC = ldc*@(nu) - ((M+@(mu)-1)/@(mu))*@(mu);
+   unsigned int ii, mu;
+   @endiif
+   @iif ML_MUR ! 0
    const size_t incC = ldc*@(nu) - m;
-   unsigned int i, j;
+   @endiif
+   @SKIP *** MU_UR and MN_UR cases  
+   @iif ML_NUR = 0
+   unsigned int jj, nu;
+   @endiif
+   @iif ML_NUR = 0
+@ROUT C2BLK `   const @(typ) *C0 ; `          
+@ROUT BLK2C `   @(typ) *C0; `          
+   @endiif
+   @iif ML_NUR ! 0
 @ROUT blk2C `   @declare "   @(typ) " n n ";"`
 @ROUT C2blk `   @declare "   const @(typ) " n n ";"`
       *C0=C
@@ -420,32 +595,117 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iexp j @(j) 1 +
       @endiwhile
    @enddeclare
+   @endiif 
+   @SKIP *** end of declaration, handle main loop now  
+   @SKIP *** NU_UR and MN_UR cases 
+   @iif ML_NUR ! 0
    for (j=nf; j; j--, b += @(bs))
    {
-@ROUT blk2C `      const @(typ) *p = b;`
-@ROUT C2blk `      @(typ) *p = b;`
+   @endiif
+   @SKIP *** MU_UR and NO_UR cases 
+   @iif ML_NUR = 0
+   for (j=0; j < N; j += nu, b += @(bs))
+   {
+      @ROUT blk2C `      const @(typ) *p0;`
+      @ROUT C2blk `      @(typ) *p0;`
+   @endiif
+   @SKIP *** common on all cases 
+      @ROUT blk2C `      const @(typ) *p = b;`
+      @ROUT C2blk `      @(typ) *p = b;`
+   @SKIP *** MU_UR and NO_UR cases 
+   @iif ML_NUR = 0
+      nu = ((N-j) >= @(nu)) ? @(nu) : (N-j);
+   @endiif
+   @SKIP *** MU_UR and MN_UR cases 
+   @iif ML_MUR ! 0
       for (i=mf; i; i--, p += pansz)
       {
-         @callproc doBlock @(mu) @(nu)
+      @iif ML_MUNU ! 0
+         @callproc doBlock @(mu) @(nu) p
+      @endiif
+      @iif ML_MUNU = 0
+         @callproc doBlockMuUR @(mu) 1 
+      @endiif
       }
+   @endiif 
+   @iif ML_MUR = 0
+      for (i=0; i < M; i += mu, p += pansz)
+      {
+         mu = ((M-i) >= @(mu)) ? @(mu) : (M-i);
+         @iif ML_NO = 0
+         @callproc doBlockNuUR @(nu)
+      @iexp j 0
+      @iwhile j < @(nu)
+         C@(j) += @(mu);
+         @iexp j @(j) 1 +
+      @endiwhile
+         @endiif 
+         @iif ML_NO ! 0 
+         @callproc doBlockRolled C mu nu 1 
+         @endiif
+      }
+   @endiif
+@SKIP --- M cleanup: MU_UR and MUNU_UR   
+   @iif ML_MUR ! 0
+      @iif CU_MUR = 0
+      { /* clean up in M dimension */
+         @iif ML_MUNU ! 0
+         @callproc doBlockRolled C0 mr @(nu) 0  
+         @endiif
+         @iif ML_MUNU = 0
+         @callproc doBlockRolled C mr nu 0  
+         @endiif
+      }
+      @endiif
+      @iif CU_MUR ! 0
       switch(mr)
       {
    @iexp m 1
    @iwhile m < @(mu)
       case @(m):
-      @callproc doBlock @(m) @(nu)
+         @iif ML_MUNU ! 0
+      @callproc doBlock @(m) @(nu) p
+         @endiif
+         @iif ML_MUNU = 0
+      @callproc doBlockMuUR @(m) 0 
+         @endiif
       @iexp m @(m) 1 +
          break;
    @endiwhile
       default:;
       }
+      @endiif
+   @endiif
+   @iif ML_NUR ! 0
    @iexp j 0
    @iwhile j < @(nu)
       C@(j) += incC;
       @iexp j @(j) 1 +
    @endiwhile
+   @endiif
+   @iif ML_NUR = 0
+      C += incC;
+   @endiif
    }
-@iif nu > 1
+@SKIP --- N cleanup
+   @iif ML_NUR ! 0
+      @iif nu > 1
+         @iif CU_NUR = 0
+   { /* Cleanup in N dimension */
+@ROUT blk2C `      const @(typ) *p = b;`
+@ROUT C2blk `      @(typ) *p = b;`
+            @iif ML_MUNU ! 0
+      unsigned int mu;
+            @endiif
+      C += ldc * n;  
+      for (i=0; i < M; i += mu, p += pansz)
+      {
+         mu = ((M-i) >= @(mu)) ? @(mu) : (M-i);
+         @callproc doBlockRolled C mu nr 1
+      }
+   }
+         @endiif
+         @iif CU_NUR ! 0
    switch(nr)
    {
 @ROUT blk2C `      const @(typ) *p;`
@@ -454,27 +714,43 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @iwhile n < @(nu)
    case @(n):
       p = b;
+            @iif ML_MUNU ! 0
       for (i=0; i < mf; i++, p += pansz)
       {
-         @callproc doBlock @(mu) @(n)
+         @callproc doBlock @(mu) @(n) p
       }
       switch(mr)
       {
    @iexp m 1
    @iwhile m < @(mu)
       case @(m):
-      @callproc doBlock @(m) @(n)
+      @callproc doBlock @(m) @(n) p
       @iexp m @(m) 1 +
          break;
    @endiwhile
       default:;
       }
+            @endiif
+            @iif ML_MUNU = 0
+      for (i=0; i < M; i += mu, p += pansz)
+      {
+         mu = ((M-i) >= @(mu)) ? @(mu) : (M-i);
+         @callproc doBlockNuUR @(n)          
+      @iexp j 0
+      @iwhile j < @(n)
+         C@(j) += @(mu);
+         @iexp j @(j) 1 +
+      @endiwhile
+      }
+            @endiif
       break;
       @iexp n @(n) 1 +
    @endiwhile
    default:;
    }
-@endiif
+         @endiif
+      @endiif
+   @endiif
 @endiif
 @SKIP ******************** SYRK copy: real type ********************************
 @iif TRI = 1
@@ -564,7 +840,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @endiif
 @iif na = 1
       {
-         @callproc doBlock @(mu) @(nu)
+         @callproc doBlock @(mu) @(nu) p
       }
 @endiif
 @iif na ! 1
@@ -579,7 +855,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @iwhile m < @(mu)
       case @(m):
 @iif na = 1
-      @callproc doBlock @(m) @(nu)
+      @callproc doBlock @(m) @(nu) p
 @endiif
 @iif na ! 1
       @callproc donaBlock @(m) @(mu) @(mumu)
@@ -1414,6 +1690,235 @@ void Mjoin(ATL_USERCPMM,_L2UT)
             @endiif
          @endiif
 @ENDPROC
+@SKIP handles single element 
+@BEGINPROC doElementUR c_ ir_ ii_ C_ k_ pr_ pi_
+         @iif alpha = 1
+            @iif beta = 0
+@ROUT blk2C 
+                  @(C_)@(c_)[@(ir_)]   = @(pr_)[@(k_)];
+                  @(C_)@(c_)[@(ii_)]   = @(pi_)[@(k_)];
+@ROUT C2blk 
+                  @(pr_)[@(k_)]  = @(C_)@(c_)[@(ir_)];
+                  @(pi_)[@(k_)]  = @(C_)@(c_)[@(ii_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+                  @(C_)@(c_)[@(ir_)]   += @(pr_)[@(k_)];
+                  @(C_)@(c_)[@(ii_)]   += @(pi_)[@(k_)];
+@ROUT C2blk 
+                  @(pr_)[@(k_)]  += @(C_)@(c_)[@(ir_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+                  @(C_)@(c_)[@(ir_)]   = @(pr_)[@(k_)] - @(C_)@(c_)[@(ir_)];
+                  @(C_)@(c_)[@(ii_)]   = @(pi_)[@(k_)] - @(C_)@(c_)[@(ii_)];
+@ROUT C2blk 
+                  @(pr_)[@(k_)]  = @(C_)@(c_)[@(ir_)] - @(pr_)[@(k_)];
+                  @(pi_)[@(k_)]  = @(C_)@(c_)[@(ii_)] - @(pi_)[@(k_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+               { 
+                  const register @(typ) rc=@(C_)@(c_)[@(ir_)], 
+                        ic=@(C_)@(c_)[@(ii_)];
+                  register @(typ) rr=@(pr_)[@(k_)], ir=@(pi_)[@(k_)];
+                  rr += rc * rb;
+                  ir += ic * rb;
+                  rr -= ic * ib;
+                  ir += rc * ib;
+                  @(C_)@(c_)[@(ir_)] = rr;
+                  @(C_)@(c_)[@(ii_)] = ir;
+               }
+@ROUT C2blk 
+               { 
+                  const register @(typ) rc=@(pr_)[@(k_)], ic=@(pi_)[@(k_)];
+                  register @(typ) rr=@(C_)@(c_)[@(ir_)], ir=@(C_)@(c_)[@(ii_)];
+                  rr += rc * rb;
+                  ir += ic * rb;
+                  rr -= ic * ib;
+                  ir += rc * ib;
+                  @(pr_)[@(k_)] = rr;
+                  @(pi_)[@(k_)] = ic;
+               }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+         @iif alpha = -1
+            @iif beta = 0
+@ROUT blk2C 
+               @(C_)@(c_)[@(ir_)]   = -@(pr_)[@(k_)];
+               @(C_)@(c_)[@(ii_)]   = -@(pi_)[@(k_)];
+@ROUT C2blk 
+               @(pr_)[@(k_)]  = -@(C_)@(c_)[@(ir_)];
+               @(pi_)[@(k_)]  = -@(C_)@(c_)[@(ii_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+               @(C_)@(c_)[@(ir_)]   -= @(pr_)[@(k_)];
+               @(C_)@(c_)[@(ii_)]   -= @(pi_)[@(k_)];
+@ROUT C2blk 
+               @(pr_)[@(k_)]  -= @(C_)@(c_)[@(ir_)];
+               @(pi_)[@(k_)]  -= @(C_)@(c_)[@(ii_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+               @(C_)@(c_)[@(ir_)]   = -@(C_)@(c_)[@(ir_)] - @(pr_)[@(k_)];
+               @(C_)@(c_)[@(ii_)]   = -@(C_)@(c_)[@(ii_)] - @(pi_)[@(k_)];
+@ROUT C2blk 
+               @(pr_)[@(k_)]  = -@(C_)@(c_)[@(ir_)] - @(pr_)[@(k_)];
+               @(pi_)[@(k_)]  = -@(C_)@(c_)[@(ii_)] - @(pi_)[@(k_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+               { 
+                  const register @(typ) rc=@(C_)@(c_)[@(ir_)], 
+                        ic=@(C_)@(c_)[@(ii_)];
+                  register @(typ) rr = -@(pr_)[@(k_)], ir = -@(pi_)[@(k_)];
+                  rr += rc * rb;
+                  ir += ic * rb;
+                  rr -= ic * ib;
+                  ir += rc * ib;
+                  @(C_)@(c_)[@(ir_)] = rr;
+                  @(C_)@(c_)[@(ii_)] = ir;
+               }
+@ROUT C2blk 
+               { 
+                  const register @(typ) rc=@(pr_)[@(k_)], ic=@(pi_)[@(k_)];
+                  register @(typ) rr = -@(C_)@(c_)[@(ir_)], 
+                           ir = -@(C_)@(c_)[@(ii_)];
+                  rr += rc * rb;
+                  ir += ic * rb;
+                  rr -= ic * ib;
+                  ir += rc * ib;
+                  @(pr_)[@(k_)] = rr;
+                  @(pi_)[@(k_)] = ic;
+               }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+         @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
+            @iif beta = 0
+@ROUT blk2C 
+               { 
+                  const register @(typ) rc=@(pr_)[@(k_)], ic=@(pi_)[@(k_)];
+                  register @(typ) rr, ir;
+                  rr = rc * ra;
+                  ir = ic * ra;
+                  rr -= ic * ia;
+                  ir += rc * ia;
+                  @(C_)@(c_)[@(ir_)] = rr;
+                  @(C_)@(c_)[@(ii_)] = ir;
+               }
+@ROUT C2blk 
+               { 
+                  const register @(typ) rc=@(C_)@(c_)[@(ir_)], 
+                        ic=@(C_)@(c_)[@(ii_)];
+                  register @(typ) rr, ir;
+                  rr  = rc * ra;
+                  ir  = ic * ra;
+                  rr -= ic * ia;
+                  ir += rc * ia;
+                  @(pr_)[@(k_)] = rr;
+                  @(pi_)[@(k_)] = ir;
+               }
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+               { 
+                  const register @(typ) rc=@(pr_)[@(k_)], ic=@(pi_)[@(k_)];
+                  register @(typ) rr=@(C_)@(c_)[@(ir_)], ir=@(C_)@(c_)[@(ii_)];
+                  rr += rc * ra;
+                  ir += ic * ra;
+                  rr -= ic * ia;
+                  ir += rc * ia;
+                  @(C_)@(c_)[@(ir_)] = rr;
+                  @(C_)@(c_)[@(ii_)] = ir;
+               }
+@ROUT C2blk 
+               { 
+                  const register @(typ) rc=@(C_)@(c_)[@(ir_)], 
+                        ic=@(C_)@(c_)[@(ii_)];
+                  register @(typ) rr=@(pr_)[@(k_)], ir=@(pi_)[@(k_)];
+                  rr += rc * ra;
+                  ir += ic * ra;
+                  rr -= ic * ia;
+                  ir += rc * ia;
+                  @(pr_)[@(k_)] = rr;
+                  @(pi_)[@(k_)] = ir;
+               }
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+               { 
+                  const register @(typ) rc=@(pr_)[@(k_)], ic=@(pi_)[@(k_)];
+                  register @(typ) rr = -@(C_)@(c_)[@(ir_)], 
+                           ir = -@(C_)@(c_)[@(ii_)];
+                  rr += rc * ra;
+                  ir += ic * ra;
+                  rr -= ic * ia;
+                  ir += rc * ia;
+                  @(C_)@(c_)[@(ir_)] = rr;
+                  @(C_)@(c_)[@(ii_)] = ir;
+               }
+@ROUT C2blk 
+               { 
+                  const register @(typ) rc=@(C_)@(c_)[@(ir_)], 
+                        ic=@(C_)@(c_)[@(ii_)];
+                  register @(typ) rr = -@(pr_)[@(k_)], ir = -@(pi_)[@(k_)];
+                  rr += rc * ra;
+                  ir += ic * ra;
+                  rr -= ic * ia;
+                  ir += rc * ia;
+                  @(pr_)[@(k_)] = rr;
+                  @(pi_)[@(k_)] = ir;
+               }
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+               {
+                  register @(typ) rc=@(C_)@(c_)[@(ir_)], ic=@(C_)@(c_)[@(ii_)];
+                  register @(typ) rB=@(pr_)[@(k_)], iB=@(pi_)[@(k_)], r0, i0, 
+                           r1, i1;
+                  r0  = rb * rc;
+                  r1  = ra * rB;
+                  i0  = rb * ic;
+                  i1  = ra * iB;
+                  r0 -= ib * ic;
+                  i1 += ib * rc;
+                  r1 -= ia * iB;
+                  i1 += ia * rB;
+                  @(C_)@(c_)[@(ir_)] = r0 + r1;
+                  @(C_)@(c_)[@(ii_)] = i0 + i1;
+               }
+@ROUT C2blk 
+               {
+                  register @(typ) rB=@(C_)@(c_)[@(ir_)], iB=@(C_)@(c_)[@(ii_)];
+                  register @(typ) rc=@(pr_)[@(k_)], ic=@(pi_)[@(k_)], r0, i0, 
+                           r1, i1;
+                  r0  = rb * rc;
+                  r1  = ra * rB;
+                  i0  = rb * ic;
+                  i1  = ra * iB;
+                  r0 -= ib * ic;
+                  i1 += ib * rc;
+                  r1 -= ia * iB;
+                  i1 += ia * rB;
+                  @(pr_)[@(k_)] = r0 + r1;
+                  @(pi_)[@(k_)] = i0 + i1;
+               }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+@ENDPROC
 @SKIP handles diagonal block when mu=nu
 @SKIP IN: mu, nu, beta, alpha
 @BEGINPROC doDiBlock n_
@@ -1692,7 +2197,8 @@ void Mjoin(ATL_USERCPMM,_L2UT)
          @iexp ir @(i) @(i) +
          @iexp ii @(ir) 1 +
          @iexp k @(j) @(mu) * @(i) +
-         @callproc doElement @(j) @(ir) @(ii) @(k) 
+         @SKIP @callproc doElement @(j) @(ir) @(ii) @(k) 
+         @callproc doElementUR @(j) @(ir) @(ii) C @(k) pr pi 
          @iexp i @(i) 1 +
       @endiwhile
       @iexp i @(mu) @(mu) +
@@ -1705,6 +2211,62 @@ void Mjoin(ATL_USERCPMM,_L2UT)
    @undef ir
    @undef k
    @undef j
+   @undef i
+@ENDPROC
+@SKIP handles block Mu unrolled 
+@BEGINPROC doBlockMuUR m_ cinc_
+   @define i @dum@
+         C0 = C; pr0 = pr; pi0 = pi;  
+         for (jj=0; jj < nu; jj++, C0 += ldc2, pr0 += @(mu), pi0 += @(mu))
+         {
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp ir @(i) @(i) +
+         @iexp ii @(ir) 1 +
+         @callproc doElementUR 0 @(ir) @(ii) C @(i) pr0 pi0 
+         @iexp i @(i) 1 +
+      @endiwhile
+         }
+      @iif cinc_ ! 0
+         @iexp i @(mu) @(mu) +
+         C += @(i);
+      @endiif
+   @undef i
+@ENDPROC
+@SKIP handles block Nu unrolled, m_=0 means NU cleanup rolled 
+@BEGINPROC doBlockNuUR nu_
+   @define j @dum@
+         for (ii=0; ii < mu; ii++)
+         {
+            @iexp j 0
+            @iwhile j < @(nu_)
+               @callproc doElementUR @(j) 2*ii 2*ii+1 C @(mu)*@(j)+ii pr pi
+               @iexp j @(j) 1 +
+            @endiwhile
+         }
+   @undef j
+@ENDPROC
+@SKIP handles rolled blocks only   
+@BEGINPROC doBlockRolled C_ mu_ nu_ cinc_  
+   @define i @dum@
+         { /* rolled block copy */
+            unsigned int ii, jj; 
+@ROUT blk2C `            @(typ) *rC0 = @(C_);`
+@ROUT C2blk `            const @(typ) *rC0 = @(C_);`
+@ROUT blk2C `            const @(typ) *rw = pr, *iw = pi;`
+@ROUT C2blk `            @(typ) *rw = pr, *iw = pi;`
+            for (jj=0; jj < @(nu_); jj++, rC0 += ldc2, rw += @(mu), iw += @(mu))
+            {
+               for (ii=0; ii < @(mu_); ii++)
+               {
+                  @callproc doElementUR 0 2*ii 2*ii+1 rC ii rw iw 
+               }
+            }
+      @iif cinc_ ! 0
+         @iexp i @(mu) @(mu) +
+            @(C_) += @(i);
+      @endiif
+         }
    @undef i
 @ENDPROC
 @SKIP handles diagonal subblocks when mu=ma*nu
@@ -1919,6 +2481,18 @@ void Mjoin(ATL_USERCPMM,_L2UT)
    @undef i
 @ENDPROC
 @ROUT blk2C C2blk
+/*
+ * Main Loop:
+ @iif bvML = 0
+ * Both Rolled
+ @endiif
+ @iif ML_MUR ! 0
+ * Mu unrolled
+ @endiif
+ @iif ML_NUR ! 0
+ * Nu unrolled
+ @endiif
+ */
 @iif cpvl = 1
 void @(rtnm)
 (
@@ -1951,13 +2525,23 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    const unsigned int mf = M/@(mu), nf = N/@(nu);
    const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
    const unsigned int pansz = (nr) ? (nf+1)*@(bs) : nf*@(bs); /* bs=@(bs) */
-   const size_t incC = (ldc*@(nu) - m)<<1, ldc2 = ldc+ldc;
    unsigned int i, j;
    @iif alpX ! 0
    const register @(typ) ra=(*alpha), ia=alpha[1];
    @endiif
    @iif betX ! 0
    const register @(typ) rb=(*beta), ib=beta[1];
+   @endiif
+   @iif ML_MUR = 0
+   unsigned int ii, mu;
+   const size_t incC = (ldc*@(nu) - ((M+@(mu)-1)/@(mu))*@(mu))<<1; 
+   const size_t ldc2 = ldc+ldc;
+   @endiif
+   @iif ML_MUR ! 0
+   const size_t incC = (ldc*@(nu) - m)<<1, ldc2 = ldc+ldc;
+   @endiif
+   @iif ML_NUR = 0
+   unsigned int jj, nu;
    @endiif
 @ROUT blk2C `   @declare "   @(typ) " n n ";"`
 @ROUT C2blk `   @declare "   const @(typ) " n n ";"`
@@ -1969,38 +2553,113 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iexp j @(j) 1 +
       @endiwhile
    @enddeclare
+   @iif ML_NUR ! 0
    for (j=nf; j; j--, rC += @(bs), iC += @(bs))
    {
+   @endiif
+   @iif ML_NUR = 0
+   for (j=0; j < N; j+=nu, rC += @(bs), iC += @(bs))
+   {
+@ROUT blk2C `      const @(typ) *pr0, *pi0;`
+@ROUT C2blk `      @(typ) *pr0, *pi0;`
+   @endiif
 @ROUT blk2C `      const @(typ) *pr = rC, *pi = iC;`
 @ROUT C2blk `      @(typ) *pr = rC, *pi = iC;`
-@iif TRI = 1
-      unsigned int psz = pansz+@(bs), incC = incC0 - (mf-j)*(@(mu)+@(mu));
-      @callproc doDiBlock @(nu)
-      pr += pansz; pi += pansz;
-      for (i=j+1; i < mf; i++, pr += psz, pi += psz, psz += @(bs))
-@endiif
+   @iif ML_NUR = 0
+      nu = N - j;
+      nu = (nu > @(nu)) ? @(nu) : nu;
+   @endiif
+   @iif ML_MUR ! 0
       for (i=mf; i; i--, pr += pansz, pi += pansz)
       {
+      @iif ML_MUNU ! 0
          @callproc doBlock @(mu) @(nu)
+      @endiif
+      @iif ML_MUNU = 0
+         @callproc doBlockMuUR @(mu) 1
+      @endiif
       }
+   @endiif
+   @iif ML_MUR = 0
+      for (i=0; i < M; i += mu, pr += pansz, pi += pansz)
+      {
+         mu = M-i;
+         mu = (mu >= @(mu)) ? @(mu) : mu;
+         @iif ML_NO = 0
+         @callproc doBlockNuUR @(nu)
+      @iexp k @(mu) @(mu) +
+      @iexp j 0
+      @iwhile j < @(nu)
+         C@(j) += @(k);
+         @iexp j @(j) 1 +
+      @endiwhile
+         @endiif 
+         @iif ML_NO ! 0 
+         @callproc doBlockRolled C mu nu 1 
+         @endiif
+      }
+   @endiif
+@SKIP --- M cleanup: MU_UR and MUNU_UR  
+   @iif ML_MUR ! 0 
+      @iif CU_MUR = 0
+      { /* clean up in M dimension */
+         @iif ML_MUNU ! 0
+         @callproc doBlockRolled C0 mr @(nu) 0  
+         @endiif
+         @iif ML_MUNU = 0
+         @callproc doBlockRolled C mr nu 0  
+         @endiif
+      }
+      @endiif
+      @iif CU_MUR ! 0
       switch(mr)
       {
    @iexp m 1
    @iwhile m < @(mu)
       case @(m):
+         @iif ML_MUNU ! 0
       @callproc doBlock @(m) @(nu)
+         @endiif
+         @iif ML_MUNU = 0
+      @callproc doBlockMuUR @(m) 0
+         @endiif
       @iexp m @(m) 1 +
          break;
    @endiwhile
       default:;
       }
+      @endiif
+   @endiif
+   @iif ML_NUR ! 0
    @iexp j 0
    @iwhile j < @(nu)
       C@(j) += incC;
       @iexp j @(j) 1 +
    @endiwhile
+   @endiif
+   @iif ML_NUR = 0
+      C += incC;
+   @endiif
    }
-@iif nu > 1
+@SKIP --- N cleanup
+   @iif ML_NUR ! 0
+      @iif nu > 1
+         @iif CU_NUR = 0
+   { /* Cleanup in N dimension */
+@ROUT blk2C `      const @(typ) *pr = rC, *pi = iC;`
+@ROUT C2blk `      @(typ) *pr = rC, *pi = rC;`
+            @iif ML_MUNU ! 0
+      unsigned int mu;
+            @endiif
+      C += ((ldc * n)<<1);  
+      for (i=0; i < M; i += mu, pr += pansz, pi += pansz)
+      {
+         mu = ((M-i) >= @(mu)) ? @(mu) : (M-i);
+         @callproc doBlockRolled C mu nr 1
+      }
+   }
+         @endiif
+         @iif CU_NUR ! 0
    switch(nr)
    {
 @ROUT blk2C `      const @(typ) *pr, *pi;`
@@ -2009,6 +2668,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @iwhile n < @(nu)
    case @(n):
       pr = rC; pi = iC;
+            @iif ML_MUNU ! 0
       for (i=0; i < mf; i++, pr += pansz, pi += pansz)
       {
          @callproc doBlock @(mu) @(n)
@@ -2024,12 +2684,28 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @endiwhile
       default:;
       }
+            @endiif
+            @iif ML_MUNU = 0
+      for (i=0; i < M; i += mu, pr += pansz, pi += pansz)
+      {
+         mu = ((M-i) >= @(mu)) ? @(mu) : (M-i);
+         @callproc doBlockNuUR @(n)          
+      @iexp k @(mu) @(mu) +
+      @iexp j 0
+      @iwhile j < @(n)
+         C@(j) += @(k);
+         @iexp j @(j) 1 +
+      @endiwhile
+      }
+            @endiif
       break;
       @iexp n @(n) 1 +
    @endiwhile
    default:;
    }
-@endiif
+         @endiif
+      @endiif
+   @endiif
 @endiif
 @SKIP ***************** SYRK copy: complex type ********************************
 @iif TRI = 1

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -27,6 +27,7 @@
 @ifdef ! SYRKU
    @SKIP @define SYRKU @1@  
    @define SYRKU @0@  
+   @SKIP @define SYRKU @0@  
 @endifdef
    @iif SYRKU = 0
       @define ma @1@
@@ -480,7 +481,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @endiif
 @iif TRI = 1
 @iif SYRKU = 0
-@SKIP ******************** Restricted old SYRK copy: real type *****************
+@SKIP ***************** Restricted old SYRK copy: real type ********************
 @SKIP handles diagonal blocks when mu = nu 
 @SKIP IN: mu, nu, beta, alpha
 @BEGINPROC doDiBlock n_
@@ -1693,9 +1694,11 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iif ML_MUNU ! 0
             @callproc doTrBlocksRolled mu @(nu) 0
          @endiif
-         @iif ML_MUR ! 0
-            @callproc doTrBlocksRolled mu nu 0
-         @endiif 
+         @iif ML_MUNU = 0
+            @iif ML_MUR ! 0
+               @callproc doTrBlocksRolled mu nu 0
+            @endiif 
+         @endiif
       }
       @endiif 
    }
@@ -1816,7 +1819,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @undef i
 @ENDPROC
 @SKIP handles rolled blocks
-@BEGINPROC doTrBlocksRolled 
+@BEGINPROC doTrBlockTsRolled 
       for (i=0; j > (i+nu-1); i=in, b += @(bs))
       {
 @ROUT C2BLK `        @(typ) *rw0 = b; `
@@ -1839,8 +1842,9 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       }
 @ENDPROC
 @SKIP handles fully unrolled blocks 
-@BEGINPROC doTrBlocksUR 
+@BEGINPROC doTrBlockTsUR 
    @define i @dum@
+   @define j @dum@
       for (i=0; j > (i+nu-1); i=in, b += @(bs))
       {
 @ROUT blk2C `        @declare "         @(typ) " n n ";"`
@@ -1857,6 +1861,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @SKIP *** MU & NU interchanged 
          @callproc doBlockT @(nu) @(mu) b 0
       }
+   @undef j
    @undef i
 @ENDPROC
 @SKIP handles MU unrolled blocks NOT.. MU & NU interchanged... 
@@ -1866,7 +1871,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       since MU & NU interchanged for L2UT... That means, MuUR actually unrolls
       NU with respect to normal copies
 @ENDSKIP   ******************************************************************** 
-@BEGINPROC doTrBlocksMuUR mu_ nu_ 
+@BEGINPROC doTrBlockTsMuUR mu_ nu_ 
    @define i @dum@
    @define k @dum@
       for (i=0; j > (i+nu-1); i=in, b += @(bs) )
@@ -1890,7 +1895,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @undef k
    @undef i
 @ENDPROC
-@BEGINPROC doTrBlocksNuUR mu_ nu_ 
+@BEGINPROC doTrBlockTsNuUR mu_ nu_ 
    @define i @dum@
       for (i=0; j > (i+nu-1); i=in, b += @(bs) )
       {
@@ -1921,7 +1926,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @undef i
 @ENDPROC
 @SKIP handles diagonal crossing blocks, implement rolled version first
-@BEGINPROC doDiagBlock mu_ 
+@BEGINPROC doDiagBlockT mu_ 
       for ( ; i < jn; i=in, b += @(bs))
       {
 @ROUT C2BLK `        @(typ) *rw0 = b; `
@@ -2014,14 +2019,14 @@ void Mjoin(ATL_USERCPMM,_L2UT)
  *    access of C-workspace is consecutive
  */
       @iif ML_MUNU = 1
-         @callproc doTrBlocksUR 
+         @callproc doTrBlockTsUR 
       @endiif
       @SKIP ML_NO = 1 => ML_NUR and ML_MUR can not both be 0 
       @iif ML_NUR = 0
-         @callproc doTrBlocksMuUR mu @(nu)
+         @callproc doTrBlockTsMuUR mu @(nu)
       @endiif
       @iif ML_MUR = 0 
-         @callproc doTrBlocksNuUR @(mu) nu
+         @callproc doTrBlockTsNuUR @(mu) nu
       @endiif
 @BEGINSKIP
       NOTE: Since cleanup in M dimension will always be handled by diagonal 
@@ -2032,10 +2037,10 @@ void Mjoin(ATL_USERCPMM,_L2UT)
  *    intersection occurs at later blocks
  */
       @iif ML_NUR = 0
-         @callproc doDiagBlock mu 
+         @callproc doDiagBlockT mu 
       @endiif
       @iif ML_NUR ! 0
-         @callproc doDiagBlock @(mu) 
+         @callproc doDiagBlockT @(mu) 
       @endiif
    }
 /*
@@ -2058,11 +2063,11 @@ void Mjoin(ATL_USERCPMM,_L2UT)
  *                       => j > i+nu-1
  *    access of C-workspace is consecutive
  */      
-      @callproc doTrBlocksRolled 
+      @callproc doTrBlockTsRolled 
 /*
  *    intersection occurs at later blocks
  */
-      @callproc doDiagBlock mu 
+      @callproc doDiagBlockT mu 
    }
 }
 @ROUT C2blk `#endif`
@@ -2300,6 +2305,330 @@ void Mjoin(ATL_USERCPMM,_L2UT)
                   @(pr_)[@(k_)] = r0 + r1;
                   @(pi_)[@(k_)] = i0 + i1;
                }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+@ENDPROC
+@SKIP handles single Transpose element 
+@BEGINPROC doElementT c_ ir_ ii_ C_ k_ rC_ iC_ 
+         @iif alpha = 1
+            @iif beta = 0
+@ROUT blk2C 
+            @(C_)@(c_)[@(ir_)] = @(rC_)[@(k_)];
+            #ifdef Conj_
+               @(C_)@(c_)[@(ii_)] = -@(iC_)[@(k_)];
+            #else
+               @(C_)@(c_)[@(ii_)] = @(iC_)[@(k_)];
+            #endif
+@ROUT C2blk 
+            @(rC_)[@(k_)] = @(C_)@(c_)[@(ir_)];
+            #ifdef Conj_
+               @(iC_)[@(k_)] = -@(C_)@(c_)[@(ii_)];
+            #else
+               @(iC_)[@(k_)] = @(C_)@(c_)[@(ii_)];
+            #endif
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            @(C_)@(c_)[@(ir_)] += @(rC_)[@(k_)];
+            #ifdef Conj_
+               @(C_)@(c_)[@(ii_)] -= @(iC_)[@(k_)];
+            #else
+               @(C_)@(c_)[@(ii_)] += @(iC_)[@(k_)];
+            #endif
+@ROUT C2blk 
+            @(rC_)[@(k_)] += @(C_)@(c_)[@(ir_)];
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            @(C_)@(c_)[@(ir_)] = @(rC_)[@(k_)] - @(C_)@(c_)[@(ir_)];
+            #ifdef Conj_
+               @(C_)@(c_)[@(ii_)] = -@(iC_)[@(k_)] - @(C_)@(c_)[@(ii_)];
+            #else
+               @(C_)@(c_)[@(ii_)] = @(iC_)[@(k_)] - @(C_)@(c_)[@(ii_)];
+            #endif
+@ROUT C2blk 
+            @(rC_)[@(k_)] = @(C_)@(c_)[@(ir_)] - @(rC_)[@(k_)];
+            #ifdef Conj_
+               @(iC_)[@(k_)] = @(C_)@(c_)[@(ii_)] + @(iC_)[@(k_)];
+            #else
+               @(iC_)[@(k_)] = @(C_)@(c_)[@(ii_)] - @(iC_)[@(k_)];
+            #endif
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=@(C_)@(c_)[@(ir_)], ic=@(C_)@(c_)[@(ii_)];
+               register @(typ) rr=@(rC_)[@(k_)];
+               #ifdef Conj_
+                  register @(typ) ir = -@(iC_)[@(k_)];
+               #else
+                  register @(typ) ir =  @(iC_)[@(k_)];
+               #endif
+               rr += rc * rb;
+               ir += ic * rb;
+               rr -= ic * ib;
+               ir += rc * ib;
+               @(C_)@(c_)[@(ir_)] = rr;
+               @(C_)@(c_)[@(ii_)] = ir;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=@(rC_)[@(k_)], ic=@(iC_)[@(k_)];
+               register @(typ) rr=@(C_)@(c_)[@(ir_)];
+               #ifdef Conj_
+                  register @(typ) ir = -@(C_)@(c_)[@(ii_)];
+               #else
+                  register @(typ) ir =  @(C_)@(c_)[@(ii_)];
+               #endif
+               rr += rc * rb;
+               ir += ic * rb;
+               rr -= ic * ib;
+               ir += rc * ib;
+               @(rC_)[@(k_)] = rr;
+               @(iC_)[@(k_)] = ic;
+            }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+         @iif alpha = -1
+            @iif beta = 0
+@ROUT blk2C 
+            @(C_)@(c_)[@(ir_)] = -@(rC_)[@(k_)];
+            #ifdef Conj_
+               @(C_)@(c_)[@(ii_)] = @(iC_)[@(k_)];
+            #else
+               @(C_)@(c_)[@(ii_)] = -@(iC_)[@(k_)];
+            #endif
+@ROUT C2blk 
+            @(rC_)[@(k_)] = -@(C_)@(c_)[@(ir_)];
+            #ifdef Conj_
+               @(iC_)[@(k_)] = @(C_)@(c_)[@(ii_)];
+            #else
+               @(iC_)[@(k_)] = -@(C_)@(c_)[@(ii_)];
+            #endif
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            @(C_)@(c_)[@(ir_)] -= @(rC_)[@(k_)];
+            #ifdef Conj_
+               @(C_)@(c_)[@(ii_)] += @(iC_)[@(k_)];
+            #else
+               @(C_)@(c_)[@(ii_)] -= @(iC_)[@(k_)];
+            #endif
+@ROUT C2blk 
+            @(rC_)[@(k_)] -= @(C_)@(c_)[@(ir_)];
+            #ifdef Conj_
+               @(iC_)[@(k_)] += @(C_)@(c_)[@(ii_)];
+            #else
+               @(iC_)[@(k_)] -= @(C_)@(c_)[@(ii_)];
+            #endif
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            @(C_)@(c_)[@(ir_)] = -@(C_)@(c_)[@(ir_)] - @(rC_)[@(k_)];
+            #ifdef Conj_
+               @(C_)@(c_)[@(ii_)] = @(iC_)[@(k_)] - @(C_)@(c_)[@(ii_)];
+            #else
+               @(C_)@(c_)[@(ii_)] = -@(C_)@(c_)[@(ii_)] - @(iC_)[@(k_)];
+            #endif
+@ROUT C2blk 
+            @(rC_)[@(k_)] = -@(C_)@(c_)[@(ir_)] - @(rC_)[@(k_)];
+            #ifdef Conj_
+               @(iC_)[@(k_)] = @(C_)@(c_)[@(ii_)] - @(iC_)[@(k_)];
+            #else
+               @(iC_)[@(k_)] = -@(C_)@(c_)[@(ii_)] - @(iC_)[@(k_)];
+            #endif
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=@(C_)@(c_)[@(ir_)], ic=@(C_)@(c_)[@(ii_)];
+               register @(typ) rr = -@(rC_)[@(k_)];
+               #ifdef Conj_
+                  register @(typ) ir = @(iC_)[@(k_)];
+               #else
+                  register @(typ) ir = -@(iC_)[@(k_)];
+               #endif
+               rr += rc * rb;
+               ir += ic * rb;
+               rr -= ic * ib;
+               ir += rc * ib;
+               @(C_)@(c_)[@(ir_)] = rr;
+               @(C_)@(c_)[@(ii_)] = ir;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=@(rC_)[@(k_)], ic=@(iC_)[@(k_)];
+               register @(typ) rr = -@(C_)@(c_)[@(ir_)];
+               #ifdef Conj_
+                  register @(typ) ir =  @(C_)@(c_)[@(ii_)];
+               #else
+                  register @(typ) ir = -@(C_)@(c_)[@(ii_)];
+               #endif
+               rr += rc * rb;
+               ir += ic * rb;
+               rr -= ic * ib;
+               ir += rc * ib;
+               @(rC_)[@(k_)] = rr;
+               @(iC_)[@(k_)] = ic;
+            }
+@ROUT blk2C C2blk
+            @endiif
+         @endiif
+         @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
+            @iif beta = 0
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=@(rC_)[@(k_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -@(iC_)[@(k_)];
+               #else
+                  const register @(typ) ic =  @(iC_)[@(k_)];
+               #endif
+               register @(typ) rr, ir;
+               rr = rc * ra;
+               ir = ic * ra;
+               rr -= ic * ia;
+               ir += rc * ia;
+               @(C_)@(c_)[@(ir_)] = rr;
+               @(C_)@(c_)[@(ii_)] = ir;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=@(C_)@(c_)[@(ir_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -@(C_)@(c_)[@(ii_)];
+               #else
+                  const register @(typ) ic =  @(C_)@(c_)[@(ii_)];
+               #endif
+               register @(typ) rr, ir;
+               rr  = rc * ra;
+               ir  = ic * ra;
+               rr -= ic * ia;
+               ir += rc * ia;
+               @(rC_)[@(k_)] = rr;
+               @(iC_)[@(k_)] = ir;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = 1
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=@(rC_)[@(k_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -@(iC_)[@(k_)];
+               #else
+                  const register @(typ) ic =  @(iC_)[@(k_)];
+               #endif
+               register @(typ) rr=@(C_)@(c_)[@(ir_)], ir=@(C_)@(c_)[@(ii_)];
+               rr += rc * ra;
+               ir += ic * ra;
+               rr -= ic * ia;
+               ir += rc * ia;
+               @(C_)@(c_)[@(ir_)] = rr;
+               @(C_)@(c_)[@(ii_)] = ir;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=@(C_)@(c_)[@(ir_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -@(C_)@(c_)[@(ii_)];
+               #else
+                  const register @(typ) ic =  @(C_)@(c_)[@(ii_)];
+               #endif
+               register @(typ) rr=@(rC_)[@(k_)], ir=@(iC_)[@(k_)];
+               rr += rc * ra;
+               ir += ic * ra;
+               rr -= ic * ia;
+               ir += rc * ia;
+               @(rC_)[@(k_)] = rr;
+               @(iC_)[@(k_)] = ir;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif beta = -1
+@ROUT blk2C 
+            { 
+               const register @(typ) rc=@(rC_)[@(k_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -@(iC_)[@(k_)];
+               #else
+                  const register @(typ) ic =  @(iC_)[@(k_)];
+               #endif
+               register @(typ) rr = -@(C_)@(c_)[@(ir_)], ir = -@(C_)@(c_)[@(ii_)];
+               rr += rc * ra;
+               ir += ic * ra;
+               rr -= ic * ia;
+               ir += rc * ia;
+               @(C_)@(c_)[@(ir_)] = rr;
+               @(C_)@(c_)[@(ii_)] = ir;
+            }
+@ROUT C2blk 
+            { 
+               const register @(typ) rc=@(C_)@(c_)[@(ir_)];
+               #ifdef Conj_
+                  const register @(typ) ic = -@(C_)@(c_)[@(ii_)];
+               #else
+                  const register @(typ) ic =  @(C_)@(c_)[@(ii_)];
+               #endif
+               register @(typ) rr = -@(rC_)[@(k_)], ir = -@(iC_)[@(k_)];
+               rr += rc * ra;
+               ir += ic * ra;
+               rr -= ic * ia;
+               ir += rc * ia;
+               @(rC_)[@(k_)] = rr;
+               @(iC_)[@(k_)] = ir;
+            }
+@ROUT blk2C C2blk
+            @endiif
+            @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C 
+            {
+               register @(typ) rc=@(C_)@(c_)[@(ir_)], ic=@(C_)@(c_)[@(ii_)];
+               register @(typ) rB=@(rC_)[@(k_)], r0, i0, r1, i1;
+               #ifdef Conj_
+                  register @(typ) iB = -@(iC_)[@(k_)];
+               #else
+                  register @(typ) iB =  @(iC_)[@(k_)];
+               #endif
+               r0  = rb * rc;
+               r1  = ra * rB;
+               i0  = rb * ic;
+               i1  = ra * iB;
+               r0 -= ib * ic;
+               i1 += ib * rc;
+               r1 -= ia * iB;
+               i1 += ia * rB;
+               @(C_)@(c_)[@(ir_)] = r0 + r1;
+               @(C_)@(c_)[@(ii_)] = i0 + i1;
+            }
+@ROUT C2blk 
+            {
+               register @(typ) rB=@(C_)@(c_)[@(ir_)];
+               #ifdef Conj_
+                  register @(typ) iB = -@(C_)@(c_)[@(ii_)];
+               #else
+                  register @(typ) iB =  @(C_)@(c_)[@(ii_)];
+               #endif
+               register @(typ) rc=@(rC_)[@(k_)], ic=@(iC_)[@(k_)], r0, i0, r1, i1;
+               r0  = rb * rc;
+               r1  = ra * rB;
+               i0  = rb * ic;
+               i1  = ra * iB;
+               r0 -= ib * ic;
+               i1 += ib * rc;
+               r1 -= ia * iB;
+               i1 += ia * rB;
+               @(rC_)[@(k_)] = r0 + r1;
+               @(iC_)[@(k_)] = i0 + i1;
+            }
 @ROUT blk2C C2blk
             @endiif
          @endiif
@@ -2636,6 +2965,8 @@ void @(rtnm)
    @ROUT C2blk blk2C
 )
 @endiif
+@SKIP *** NOTE: copied following declaration of a2c_1 from old version, don't 
+@SKIP     think it is used anymore
 @iif cpvl > 1
 static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha, 
                          const @(typ) *b, const SCALAR beta, 
@@ -3565,7 +3896,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 }
 @SKIP ***************** SYRK L2UT : complex type *******************************
 @SKIP handles single element 
-@BEGINPROC doElementT c_ ir_ ii_ k_ 
+@BEGINPROC doElementTm c_ ir_ ii_ k_ 
          @iif alpha = 1
             @iif beta = 0
 @ROUT blk2C 
@@ -3902,7 +4233,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iexp ir @(i) @(i) +
          @iexp ii @(ir) 1 +
          @iexp k @(i) @(mu) * @(j) +
-            @callproc doElementT @(j) @(ir) @(ii) @(k) 
+            @callproc doElementTm @(j) @(ir) @(ii) @(k) 
          @iexp i @(i) 1 +
       @endiwhile
       @iexp i @(mu) @(mu) +
@@ -3931,7 +4262,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iexp ir @(i) @(i) +
          @iexp ii @(ir) 1 +
          @iexp k @(i) @(mu) * @(j) +
-         @callproc doElementT @(j) @(ir) @(ii) kk+@(k)  
+         @callproc doElementTm @(j) @(ir) @(ii) kk+@(k)  
          @iexp i @(i) 1 +
       @endiwhile
       @iexp i @(m_) @(m_) +
@@ -3958,7 +4289,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iexp ir @(i) @(i) +
          @iexp ii @(ir) 1 +
          @iexp k @(i) @(mu_) * @(j) +
-         @callproc doElementT @(j) @(ir) @(ii) @(k)  
+         @callproc doElementTm @(j) @(ir) @(ii) @(k)  
          @iexp i @(i) 1 +
       @endiwhile
       @iexp i @(inc_) @(inc_) +
@@ -3993,13 +4324,13 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @endiif
          @iexp ii @(ir) 1 +
          @iexp k @(i) @(mu) * @(j) +
-            @callproc doElementT @(h) @(ir) @(ii) @(k) 
+            @callproc doElementTm @(h) @(ir) @(ii) @(k) 
 @ROUT blk2C 
          @iexp ir @(i) @(i) +
          @iexp ii @(ir) 1 +
          @iexp k @(i) @(mu) * @(j) +
          @iif j } i
-            @callproc doElementT @(j) @(ir) @(ii) @(k) 
+            @callproc doElementTm @(j) @(ir) @(ii) @(k) 
          @endiif
 @ROUT blk2C C2blk
          @iexp i @(i) 1 +
@@ -4035,7 +4366,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iif j } i
          @iexp ir @(r) @(r) +
          @iexp ii @(ir) 1 +
-      @callproc doElementT @(c) @(ir) @(ii) kk+@(k)
+      @callproc doElementTm @(c) @(ir) @(ii) kk+@(k)
          @endiif
 @ROUT C2blk
          @iif j < i
@@ -4048,7 +4379,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @endiif
          @iexp ir @(r) @(r) +
          @iexp ii @(ir) 1 +
-      @callproc doElementT @(c) @(ir) @(ii) kk+@(k)
+      @callproc doElementTm @(c) @(ir) @(ii) kk+@(k)
 @ROUT blk2C C2blk
          @iexp i @(i) 1 +
       @endiwhile
@@ -4088,7 +4419,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iif j } i
             @iexp ir @(i) @(i) +
             @iexp ii @(ir) 1 +
-            @callproc doElementT @(j) @(ir) @(ii) @(k)
+            @callproc doElementTm @(j) @(ir) @(ii) @(k)
          @endiif
          @iexp i @(i) 1 +
       @endiwhile
@@ -4134,7 +4465,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
             @iif i < @(t)
                @iexp ir @(i) @(i) +
                @iexp ii @(ir) 1 +
-         @callproc doElementT @(j) @(ir) @(ii) @(k)  
+         @callproc doElementTm @(j) @(ir) @(ii) @(k)  
             @endiif   
          @endiif
          @iexp i @(i) 1 +
@@ -4389,6 +4720,181 @@ void Mjoin(ATL_USERCPMM,_L2UT)
 @endiif
 @iif SYRKU ! 0
 @SKIP ***************** Unrestricted SYRK copy: complex type *******************
+@SKIP handles full block
+@BEGINPROC doBlockU m_ n_ rC_ iC_ cinc_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp ir @(i) @(i) +
+         @iexp ii @(ir) 1 +
+         @iexp k @(j) @(mu) * @(i) +
+         @callproc doElement @(j) @(ir) @(ii) C @(k) @(rC_) @(iC_) 
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif cinc_ ! 0
+         @iexp i @(mu) @(mu) +
+         @iif m_ = mu
+            C@(j) += @(i);
+         @endiif
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef ii
+   @undef ir
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP handles rolled rectangual blocks, used for cleanup as well
+@BEGINPROC doTrBlocksRolled mu_ nu_ tstmu_
+         unsigned int mu=N-i, ii, jj, nblks;
+@ROUT C2BLK `         const @(typ) *C0 = C + (i<<1); `          
+@ROUT BLK2C `         @(typ) *C0 = C + (i<<1); `          
+@ROUT C2BLK `         @(typ) *pr = rw + cinc, *pi = iw + cinc; `          
+@ROUT BLK2C `         const @(typ) *pr = rw + cinc, *pi = iw + cinc; `     
+   @iif tstmu_ = 1
+         mu = (mu >= @(mu)) ? @(mu) : mu;
+   @endiif
+         in = i + mu;
+         for (jj=0; jj < @(nu_); jj++, C0 += ldc2, pr += @(mu), pi += @(mu))
+         {
+            for (ii=0; ii < @(mu_); ii++)
+            {
+               unsigned int rk = ii + ii, ik = rk + 1;
+               @callproc doElement 0 rk ik C ii pr pi 
+            }
+         }
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan; iw += rwpan;
+@ENDPROC
+@SKIP handles unrolled rectangual blocks, used for cleanup as well
+@BEGINPROC doTrBlocksUR 
+      for (; (i+@(mu)) < N; i = in)
+      {
+         unsigned int nblks;
+@ROUT C2BLK `         @(typ) *pr = rw + cinc, *pi = iw + cinc; `          
+@ROUT BLK2C `         const @(typ) *pr = rw + cinc, *pi = iw + cinc; `          
+@ROUT blk2C `        @declare "         @(typ) " n n ";"`
+@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
+         *C0=C+(i<<1)
+         @define j @1@
+         @iwhile j < @(nu)
+            @iexp i @(j) -1 +
+            *C@(j)=C@(i)+ldc2
+            @iexp j @(j) 1 +
+         @endiwhile
+      @enddeclare
+         in = i + @(mu);
+         @callproc doBlockU @(mu) @(nu) pr pi 1 
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan; iw += rwpan;
+      }
+@ENDPROC
+@BEGINPROC doTrBlocksMuUR mu_ nu_
+   @define i @dum@
+   @define ir @dum@
+   @define ii @dum@
+         for (; (i+@(mu)) < N; i = in)
+         {
+            unsigned int jj, nblks;
+@ROUT C2BLK `            const @(typ) *C0 = C + (i<<1); `          
+@ROUT BLK2C `            @(typ) *C0 = C + (i<<1); `          
+@ROUT C2BLK `            @(typ) *pr = rw + cinc, *pi = iw + cinc; `          
+@ROUT BLK2C `            const @(typ) *pr = rw + cinc, *pi = iw + cinc; `          
+            in = i + @(mu);
+            for (jj=0; jj < @(nu_); jj++, C0 += ldc2, pr += @(mu), pi += @(mu))
+            {
+            @iexp i 0
+            @iwhile i < @(mu_)
+               @iexp ir @(i) @(i) +
+               @iexp ii @(ir) 1 +
+               @callproc doElement 0 @(ir) @(ii) C @(i) pr pi 
+               @iexp i @(i) 1 +
+            @endiwhile
+            } 
+            nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+            rwpan = nblks*@(bs);
+            rw += rwpan; iw += rwpan;
+         }
+   @undef ii
+   @undef ir
+   @undef i
+@ENDPROC
+@BEGINPROC doTrBlocksNuUR mu_ nu_ 
+      for (; i < N; i = in)
+      {
+         unsigned int ii, nblks, mu=N-i;
+@ROUT C2BLK `         @(typ) *pr = rw + cinc, *pi = iw + cinc; `          
+@ROUT BLK2C `         const @(typ) *pr = rw + cinc, *pi = iw + cinc; `          
+@ROUT blk2C `        @declare "         @(typ) " n n ";"`
+@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
+         *C0=C+(i<<1)
+         @define j @1@
+         @iwhile j < @(nu)
+            @iexp i @(j) -1 +
+            *C@(j)=C@(i)+ldc2
+            @iexp j @(j) 1 +
+         @endiwhile
+      @enddeclare
+         mu = (mu >= @(mu)) ? @(mu) : mu;
+         in = i + mu;
+         for (ii=0; ii < @(mu_); ii++)
+         {
+            unsigned int rk = (ii<<1), ik = (ii<<1)+1;
+            @iexp j 0
+            @iwhile j < @(nu_)
+               @callproc doElement @(j) rk ik C @(mu)*@(j)+ii pr pi
+               @iexp j @(j) 1 +
+            @endiwhile
+         }
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan; iw += rwpan;
+      }
+@ENDPROC
+@SKIP handles diagonal crossing blocks, implement rolled version first
+@BEGINPROC doDiagBlock mu_ nu_
+/*
+ *    Handling of diagonal blocks for this colpan 
+ */
+      for (; i < jn; i = in)
+      {
+         unsigned int mu=N-i, ii, jj, nblks;
+@ROUT C2BLK `         const @(typ) *C0 = C + (i<<1); `          
+@ROUT BLK2C `         @(typ) *C0 = C + (i<<1); `          
+@ROUT C2BLK `         @(typ) *pr = rw + cinc, *pi = iw + cinc; `          
+@ROUT BLK2C `         const @(typ) *pr = rw + cinc, *pi = iw + cinc; `          
+         mu = (mu >= @(mu)) ? @(mu) : mu;
+         in = i + mu;
+@SKIP /* based on full/cleanup, nu can be const or var */
+         for (jj=0; jj < @(nu_); jj++, C0 += ldc2, pr += @(mu), pi += @(mu)) 
+         {
+            const unsigned int J=j+jj;
+            for (ii=0; ii < mu; ii++)
+            {
+               unsigned int rk = (ii<<1), ik = (ii<<1)+1;
+               const unsigned int I=i+ii;
+               if (I >= J)
+               {
+                  @callproc doElement 0 rk ik C ii pr pi 
+               }
+            }
+         }
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan; iw += rwpan; /* finished all blocks in rowpanel */
+         rW = (in <= jn) ? rw : rW;
+         iW = (in <= jn) ? iw : iW;
+      }
+@ENDPROC
 /*
  * Main Loop:
  @iif bvML = 0
@@ -4439,8 +4945,8 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    const register @(typ) rb=(*beta), ib=beta[1];
    @endiif
    const size_t incC = (ldc*@(nu))<<1, ldc2 = ldc+ldc;
-@ROUT C2BLK `   @(typ) *rW=b, *rw; `
-@ROUT BLK2C `   const @(typ) *rW=b, *rw; `
+@ROUT C2BLK `   @(typ) *rW=rC, *iW=iC, *rw, *iw; `
+@ROUT BLK2C `   const @(typ) *rW=rC, *iW=iC, *rw, *iw; `
 /*
  * NOTE: we assume N=M, always square for syrk 
  */
@@ -4471,6 +4977,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       @endiif
       i = (j/@(mu))*@(mu);
       rw = rW;
+      iw = iW;
 /*
  *    handle the diagonal-crossing blocks first
  *    NOTE: this can be full-MU block or partial----> no unrolling right now 
@@ -4503,9 +5010,11 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iif ML_MUNU = 1
             @callproc doTrBlocksRolled mu @(nu) 0
          @endiif
-         @iif ML_MUR = 1
-            @callproc doTrBlocksRolled mu nu 0
-         @endiif 
+         @iif ML_MUNU = 0
+            @iif ML_MUR = 1
+               @callproc doTrBlocksRolled mu nu 0
+            @endiif 
+         @endiif
       }
       @endiif 
    }
@@ -4531,6 +5040,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       jn = j + nu;
       i = (j/@(mu))*@(mu);
       rw = rW;
+      iw = iW;
       @callproc doDiagBlock mu nu 
 /*
  *    full blocks before diagonal 
@@ -4542,6 +5052,309 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    }
    @endiif
 }
+@SKIP ***************** Unrestricted SYRK L2UT : complex type ******************
+@SKIP handles full subblock
+@BEGINPROC doBlockT m_ n_ rC_ iC_ cinc_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define ir @dum@
+   @define ii @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp ir @(i) @(i) +
+         @iexp ii @(ir) 1 +
+         @iexp k @(i) @(mu) * @(j) +
+            @callproc doElementT @(j) @(ir) @(ii) C @(k) @(rC_) @(iC_) 
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif cinc_ ! 0
+         @iexp i @(mu) @(mu) +
+         @iif m_ = mu
+            C@(j) += @(i);
+         @endiif
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef ii
+   @undef ir
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP handles rolled blocks
+@BEGINPROC doTrBlockTsRolled 
+      for (i=0; j > (i+nu-1); i=in, rC += @(bs), iC += @(bs))
+      {
+@ROUT C2BLK `        @(typ) *rw0 = rC, *iw0 = iC; `
+@ROUT BLK2C `        const @(typ) *rw0 = rC, *iw0 = iC; `
+@ROUT C2BLK `        const @(typ) *C0 = C+(i<<1); `
+@ROUT BLK2C `        @(typ) *C0 = C+(i<<1); `
+         unsigned int ii, jj;
+         size_t nu = N-i;
+         nu = (nu >= @(nu)) ? @(nu) : nu;
+         in = i + nu;
+         for (jj=0; jj < mu; jj++, C0 += ldc2, rw0++, iw0++)
+         {
+@ROUT C2BLK `           @(typ) *pr = rw0, *pi = iw0; `
+@ROUT BLK2C `           const @(typ) *pr = rw0, *pi = iw0; `
+            for (ii=0; ii < nu; ii++, pr += @(mu), pi += @(mu))
+            {
+               unsigned int rk = (ii<<1), ik = (ii<<1)+1; 
+               @callproc doElementT 0 rk ik C 0 pr pi 
+            }
+         }
+      }
+@ENDPROC
+@SKIP handles fully unrolled blocks 
+@BEGINPROC doTrBlockTsUR 
+   @define i @dum@
+   @define j @dum@
+      for (i=0; j > (i+nu-1); i=in, rC += @(bs), iC += @(bs))
+      {
+@ROUT blk2C `        @declare "         @(typ) " n n ";"`
+@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
+         *C0=C+(i<<1)
+         @define j @1@
+         @iwhile j < @(mu)
+            @iexp i @(j) -1 +
+            *C@(j)=C@(i)+ldc2
+            @iexp j @(j) 1 +
+         @endiwhile
+      @enddeclare
+         in = i + @(nu);
+         @SKIP *** MU & NU interchanged 
+         @callproc doBlockT @(nu) @(mu) rC iC 0
+      }
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP handles MU unrolled blocks NOT.. MU & NU interchanged... 
+@BEGINSKIP ********************************************************************
+      NOTE: L2UT code is located in the same file as the normal copy..
+      So, to make it similar as the normal copy, we are unrolling NU direction 
+      since MU & NU interchanged for L2UT... That means, MuUR actually unrolls
+      NU with respect to normal copies
+@ENDSKIP   ******************************************************************** 
+@BEGINPROC doTrBlockTsMuUR mu_ nu_ 
+   @define i @dum@
+   @define k @dum@
+   @define ir @dum@
+   @define ii @dum@
+      for (i=0; j > (i+nu-1); i=in, rC += @(bs), iC += @(bs) )
+      {
+@ROUT C2BLK `        @(typ) *pr = rC, *pi = iC; `
+@ROUT BLK2C `        const @(typ) *pr = rC, *pi = iC; `
+@ROUT C2BLK `        const @(typ) *C0 = C+(i<<1); `
+@ROUT BLK2C `        @(typ) *C0 = C+(i<<1); `
+         unsigned int jj;
+         in = i + @(nu);
+         for (jj=0; jj < @(mu_); jj++, C0 += ldc2, pr++, pi++)
+         {
+            @iexp i 0
+            @iwhile i < @(nu_)
+               @iexp k @(mu) @(i) *
+               @iexp ir @(i) @(i) +
+               @iexp ii @(ir) 1 +
+               @callproc doElementT 0 @(ir) @(ii) C @(k) pr pi 
+               @iexp i @(i) 1 +
+            @endiwhile
+         }
+      }
+   @undef ii
+   @undef ir
+   @undef k
+   @undef i
+@ENDPROC
+@BEGINPROC doTrBlockTsNuUR mu_ nu_ 
+      for (i=0; j > (i+nu-1); i=in, rC += @(bs), iC += @(bs) )
+      {
+         unsigned int ii;
+@ROUT C2BLK `         @(typ) *pr = rC, *pi = iC; `          
+@ROUT BLK2C `         const @(typ) *pr = rC, *pi = iC; `          
+@ROUT blk2C `        @declare "         @(typ) " n n ";"`
+@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
+         *C0=C+(i<<1)
+         @define j @1@
+         @iwhile j < @(mu)
+            @iexp i @(j) -1 +
+            *C@(j)=C@(i)+ldc2
+            @iexp j @(j) 1 +
+         @endiwhile
+      @enddeclare
+         nu = (nu >= @(nu)) ? @(nu) : nu;
+         in = i + nu;
+         for (ii=0; ii < nu; ii++, p+=@(mu))
+         {
+            unsigned int rk = (ii<<1), ik = (ii<<1)+1;
+            @iexp j 0
+            @iwhile j < @(mu_)
+               @callproc doElementT @(j) rk ik C @(j) pr pi
+               @iexp j @(j) 1 +
+            @endiwhile
+         }
+      }
+@ENDPROC
+@SKIP handles diagonal crossing blocks, implement rolled version first
+@BEGINPROC doDiagBlockT mu_ 
+      for ( ; i < jn; i=in, rC += @(bs), iC += @(bs))
+      {
+@ROUT C2BLK `        @(typ) *rw0 = rC, *iw0 = iC; `
+@ROUT BLK2C `        const @(typ) *rw0 = rC, *iw0 = iC; `
+@ROUT C2BLK `        const @(typ) *C0 = C+(i<<1); `
+@ROUT BLK2C `        @(typ) *C0 = C+(i<<1); `
+         unsigned int ii, jj;
+         size_t nu = N-i;
+         nu = (nu >= @(nu)) ? @(nu) : nu;
+         in = i + nu;
+         for (jj=0; jj < @(mu_); jj++, C0 += ldc2, rw0++, iw0++)
+         {
+@ROUT C2BLK `           @(typ) *pr = rw0, *pi = iw0; `
+@ROUT BLK2C `           const @(typ) *pr = rw0, *pi = iw0; `
+            size_t J=j+jj;
+            for (ii=0; ii < nu; ii++, pr += @(mu), pi += @(mu))
+            {
+               unsigned int rk = (ii<<1), ik = (ii<<1)+1;
+               size_t I=i+ii;
+               if (I <= J)
+               {
+                  @callproc doElementT 0 rk ik C 0 pr pi 
+               }
+            }
+         }
+      }
+@ENDPROC
+@ROUT C2blk `#if 0`
+#ifndef Mjoin
+   #define Mjoin(pre, nam) my_join(pre, nam)
+   #define my_join(pre, nam) pre ## nam
+#endif
+/*
+ * The block is assumed to store L, this function does a transpose while
+ * copying so that it is transferred with Upper portion of C
+ */
+#ifdef Conj_
+void Mjoin(ATL_USERCPMM,_L2UH)
+#else
+void Mjoin(ATL_USERCPMM,_L2UT)
+#endif
+(
+   const size_t M,      /* number of rows in A */
+   const size_t N,      /* number of columns in A */
+   const @(typ) *alpha, /* scalar for b */
+   @ROUT blk2C
+   const @(typ) *rC,    /* real block stored in @(mu)x@(nu)-major order */
+   const @(typ) *iC,    /* imag block stored in @(mu)x@(nu)-major order */
+   const @(typ) *beta,  /* scalar for C */
+   @(typ) *C,           /* matrix to be copied to access-major format */
+   const size_t ldc     /* stride between row elements */
+   @ROUT C2blk
+   const @(typ) *C,     /* matrix to be copied to access-major format */
+   const size_t ldc,    /* stride between row elements */
+   const @(typ) *beta,  /* scalar for C */
+   @(typ) *rC,          /* real block stored in @(mu)x@(nu)-major order */
+   @(typ) *iC           /* imag block stored in @(mu)x@(nu)-major order */
+   @ROUT C2blk blk2C
+)
+{
+   size_t j, jn;
+   const size_t incCm = (ldc*@(mu))<<1, ldc2 = ldc + ldc;
+   @iif alpX ! 0
+   const register @(typ) ra=(*alpha), ia=alpha[1];
+   @endiif
+   @iif betX ! 0
+   const register @(typ) rb=(*beta), ib=beta[1];
+   @endiif
+/*
+ * NOTE: we assume N=M, always square for syrk 
+ * MU & NU interchanged 
+ */
+   @iif ML_NO = 0
+      @iif ML_NUR ! 0
+   const size_t nf = N/@(mu);
+   const size_t n = nf*@(mu), nr = N-n;
+      @endiif
+/*
+ * since it's upper transpose case, the direction of @(mu) and NU interchanged
+ */
+      @iif ML_NUR = 0
+   for (j=0; j < N; j = jn, C += incCm)
+      @endiif
+      @iif ML_NUR ! 0
+   for (j=0; j < n; j = jn, C += incCm)
+      @endiif
+   {
+      size_t i, in, nu;
+      @iif ML_NUR = 0
+      size_t mu = N-j;
+      mu = (mu >= @(mu)) ? @(mu) : mu;
+      jn = j + mu;
+      @endiif
+      @iif ML_NUR ! 0
+      jn = j + @(mu);
+      @endiif
+      nu = @(nu);
+/*
+ *    for upper triangle, blocks whose do not intersect with diagonal follow:
+ *               y0 > x1 => j > (in-1)
+ *                       => j > i+nu-1
+ *    access of C-workspace is consecutive
+ */
+      @iif ML_MUNU = 1
+         @callproc doTrBlockTsUR 
+      @endiif
+      @SKIP ML_NO = 1 => ML_NUR and ML_MUR can not both be 0 
+      @iif ML_NUR = 0
+         @callproc doTrBlockTsMuUR mu @(nu)
+      @endiif
+      @iif ML_MUR = 0 
+         @callproc doTrBlockTsNuUR @(mu) nu
+      @endiif
+@BEGINSKIP
+      NOTE: Since cleanup in M dimension will always be handled by diagonal 
+      crossing block, we should not need any clean up in that direction 
+      for full block...
+@ENDSKIP
+/*
+ *    intersection occurs at later blocks
+ */
+      @iif ML_NUR = 0
+         @callproc doDiagBlockT mu 
+      @endiif
+      @iif ML_NUR ! 0
+         @callproc doDiagBlockT @(mu) 
+      @endiif
+   }
+/*
+ * cleanup in N dimension 
+ */
+   if (j < N)
+   @endiif
+   @iif ML_NO ! 0
+   for (j=0; j < N; j = jn, C += incCm)
+   @endiif
+   {
+      size_t i, in, nu;
+      size_t mu = N-j;
+      mu = (mu >= @(mu)) ? @(mu) : mu;
+      jn = j + mu;
+      nu = @(nu);
+/*
+ *    for upper triangle, blocks whose do not intersect with diagonal follow:
+ *               y0 > x1 => j > (in-1)
+ *                       => j > i+nu-1
+ *    access of C-workspace is consecutive
+ */      
+      @callproc doTrBlockTsRolled 
+/*
+ *    intersection occurs at later blocks
+ */
+      @callproc doDiagBlockT mu 
+   }
+}
+@ROUT C2blk `#endif`
 @endiif
 @endiif
 @ROUT blk2C_x87

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -19,29 +19,40 @@
 @endifdef
 @SKIP TRI = 1 means lower triangular C (SYRK)
 @iif TRI = 1
-   @define ma @1@
-   @define na @1@
-   @iif mu ! nu
-      @iif mu > nu
-         @iexp ma @(nu) @(mu) / 
-         @iexp mma @(ma) @(nu) *
-         @iif mu ! mma
-           @abort "mu (@(mu)) must be multiple of nu (@(nu))" 
+@BEGINSKIP ====================================================================
+********** SYRK COPY: from now on, we are using unrestricted syrk copies
+********** If you want to enable restricted copy for testing or timing purpose
+********** init SYRKU with 0
+@ENDSKIP   ====================================================================
+@ifdef ! SYRKU
+   @SKIP @define SYRKU @1@  
+   @define SYRKU @0@  
+@endifdef
+   @iif SYRKU = 0
+      @define ma @1@
+      @define na @1@
+      @iif mu ! nu
+         @iif mu > nu
+            @iexp ma @(nu) @(mu) / 
+            @iexp mma @(ma) @(nu) *
+            @iif mu ! mma
+            @SKIP @abort "mu (@(mu)) must be multiple of nu (@(nu))" 
+            @endiif
+            @skip @print ************ma = @(ma)
          @endiif
-         @skip @print ************ma = @(ma)
-      @endiif
-      @iif nu > mu
-         @iexp na @(mu) @(nu) / 
-         @iexp nna @(na) @(mu) *
-         @iif nu ! nna
-           @abort "nu (@(nu)) must be multiple of mu (@(mu))"  
+         @iif nu > mu
+            @iexp na @(mu) @(nu) / 
+            @iexp nna @(na) @(mu) *
+            @iif nu ! nna
+            @abort "nu (@(nu)) must be multiple of mu (@(mu))"  
+            @endiif
+            @skip @print ************na = @(na)
          @endiif
-         @skip @print ************na = @(na)
+         @define mEn @0@
       @endiif
-      @define mEn @0@
-   @endiif
-   @iif mu = nu
-      @define mEn @1@
+      @iif mu = nu
+         @define mEn @1@
+      @endiif
    @endiif
 @endiif
 @SKIP ****************** bitvector for parameterized unrolling *****************
@@ -467,8 +478,9 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @endiif
 }
 @endiif
-@SKIP ******************** Restricted SYRK copy: real type *********************
 @iif TRI = 1
+@iif SYRKU = 0
+@SKIP ******************** Restricted SYRK copy: real type *********************
 @SKIP handles diagonal blocks when mu = nu 
 @SKIP IN: mu, nu, beta, alpha
 @BEGINPROC doDiBlock n_
@@ -1434,6 +1446,472 @@ void Mjoin(ATL_USERCPMM,_L2UT)
 @endiif
 }
 @ROUT C2blk `#endif`
+@endiif
+@SKIP ********************** Unrestricted SYRK copy: Real Type *****************
+@iif SYRKU ! 0
+@SKIP handles rolled rectangual blocks, used for cleanup as well
+@BEGINPROC doTrBlocksRolled mu_ nu_ tstmu_
+         unsigned int mu=N-i, ii, jj, nblks;
+@ROUT C2BLK `         const @(typ) *C0 = C + i; `          
+@ROUT BLK2C `         @(typ) *C0 = C + i; `          
+@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
+@ROUT BLK2C `         const @(typ) *p = rw + cinc; `     
+   @iif tstmu_ = 1
+         mu = (mu >= @(mu)) ? @(mu) : mu;
+   @endiif
+         in = i + mu;
+         for (jj=0; jj < @(nu_); jj++, C0 += ldc, p += @(mu))
+         {
+            for (ii=0; ii < @(mu_); ii++)
+            {
+               @callproc doElement ii 0 C ii p 
+            }
+         }
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan;
+@ENDPROC
+@SKIP handles unrolled rectangual blocks, used for cleanup as well
+@BEGINPROC doTrBlocksUR 
+      for (; (i+@(mu)) < N; i = in)
+      {
+         unsigned int nblks;
+@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
+@ROUT BLK2C `         const @(typ) *p = rw + cinc; `          
+@ROUT blk2C `        @declare "         @(typ) " n n ";"`
+@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
+         *C0=C+i
+         @define j @1@
+         @iwhile j < @(nu)
+            @iexp i @(j) -1 +
+            *C@(j)=C@(i)+ldc
+            @iexp j @(j) 1 +
+         @endiwhile
+      @enddeclare
+         in = i + @(mu);
+         @callproc doBlock @(mu) @(nu) p 
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan;
+      }
+@ENDPROC
+@BEGINPROC doTrBlocksMuUR mu_ nu_
+         for (; (i+@(mu)) < N; i = in)
+         {
+            unsigned int jj, nblks;
+@ROUT C2BLK `            const @(typ) *C0 = C + i; `          
+@ROUT BLK2C `            @(typ) *C0 = C + i; `          
+@ROUT C2BLK `            @(typ) *p = rw + cinc; `          
+@ROUT BLK2C `            const @(typ) *p = rw + cinc; `          
+            in = i + @(mu);
+            for (jj=0; jj < @(nu_); jj++, C0 += ldc, p += @(mu))
+            {
+            @iexp i 0
+            @iwhile i < @(mu_)
+               @callproc doElement @(i) 0 C @(i) p 
+               @iexp i @(i) 1 +
+            @endiwhile
+            } 
+            nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+            rwpan = nblks*@(bs);
+            rw += rwpan;
+         }
+@ENDPROC
+@BEGINPROC doTrBlocksNuUR mu_ nu_ 
+      for (; i < N; i = in)
+      {
+         unsigned int ii, nblks, mu=N-i;
+@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
+@ROUT BLK2C `         const @(typ) *p = rw + cinc; `          
+@ROUT blk2C `        @declare "         @(typ) " n n ";"`
+@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
+         *C0=C+i
+         @define j @1@
+         @iwhile j < @(nu)
+            @iexp i @(j) -1 +
+            *C@(j)=C@(i)+ldc
+            @iexp j @(j) 1 +
+         @endiwhile
+      @enddeclare
+         mu = (mu >= @(mu)) ? @(mu) : mu;
+         in = i + mu;
+         for (ii=0; ii < @(mu_); ii++)
+         {
+            @iexp j 0
+            @iwhile j < @(nu_)
+               @callproc doElement ii @(j) C @(mu)*@(j)+ii p
+               @iexp j @(j) 1 +
+            @endiwhile
+         }
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan;
+      }
+@ENDPROC
+@SKIP handles diagonal crossing blocks, implement rolled version first
+@BEGINPROC doDiagBlock mu_ nu_
+/*
+ *    Handling of diagonal blocks for this colpan 
+ */
+      for (; i < jn; i = in)
+      {
+         unsigned int mu=N-i, ii, jj, nblks;
+@ROUT C2BLK `         const @(typ) *C0 = C + i; `          
+@ROUT BLK2C `         @(typ) *C0 = C + i; `          
+@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
+@ROUT BLK2C `         const @(typ) *p = rw + cinc; `          
+         mu = (mu >= @(mu)) ? @(mu) : mu;
+         in = i + mu;
+@SKIP /* based on full/cleanup, nu can be const or var */
+         for (jj=0; jj < @(nu_); jj++, C0 += ldc, p += @(mu)) 
+         {
+            const unsigned int J=j+jj;
+            for (ii=0; ii < mu; ii++)
+            {
+               const unsigned int I=i+ii;
+               if (I >= J)
+               {
+                  @callproc doElement ii 0 C ii p 
+               }
+            }
+         }
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan; /* finished all blocks in rowpanel */
+         rW = (in <= jn) ? rw : rW;
+      }
+@ENDPROC
+@BEGINSKIP
+*** We are only unrolling the main loop here, parameterized for both dimension  
+@ENDSKIP
+/*
+ * Main Loop:
+ @iif bvML = 0
+ * Both Rolled
+ @endiif
+ @iif ML_MUR ! 0
+ * Mu unrolled
+ @endiif
+ @iif ML_NUR ! 0
+ * Nu unrolled
+ @endiif
+ */
+@iif cpvl = 1
+void @(rtnm)
+(
+   const size_t M,      /* number of rows in A */
+   const size_t N,      /* number of columns in A */
+   @ROUT blk2C
+   const @(typ) alpha,  /* scalar for b */
+   const @(typ) *b,     /* matrix stored in @(mu)x@(nu)-major order */
+   const @(typ) beta,   /* scalar for C */
+   @(typ) *C,           /* matrix to be copied to access-major format */
+   const size_t ldc     /* stride between row elements */
+   @ROUT C2blk
+   const @(typ) alpha,  /* scalar for C */
+   const @(typ) *C,     /* matrix to be copied to access-major format */
+   const size_t ldc,    /* stride between row elements */
+   const @(typ) beta,   /* scalar for b */
+   @(typ) *b            /* matrix stored in @(mu)x@(nu)-major order */
+   @ROUT C2blk blk2C
+)
+@endiif
+@iif cpvl > 1
+static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha, 
+                         const @(typ) *b, const SCALAR beta, 
+                         @(typ) *C, ATL_CSZT ldc)
+@endiif
+{
+   int j, jn, cinc, rwpan;
+   unsigned int pansz = @(bs);
+   const size_t incC = ldc*@(nu);
+@ROUT C2BLK `   @(typ) *rW=b, *rw; `
+@ROUT BLK2C `   const @(typ) *rW=b, *rw; `
+/*
+ * NOTE: we assume N=M, always square for syrk 
+ */
+   @iif ML_NO = 0 
+      @iif ML_NUR ! 0
+   const unsigned int nf = N/@(nu);
+   const unsigned int n = nf*@(nu), nr = N-n;
+      @endiif
+/*
+ * NU colpan: Full panel, without cleanup (N direction)
+ */
+      @iif ML_NUR ! 0 
+   for (cinc=j=0; j < n; j = jn, C += incC, cinc += @(bs))
+      @endiif
+   @SKIP ***** Nu rolled, no need of Nu cleanup 
+      @iif ML_NUR = 0
+   for (cinc=j=0; j < N; j = jn, C += incC, cinc += @(bs))
+      @endiif
+   {
+      unsigned int i, in, nd;
+      @iif ML_NUR = 0
+      unsigned int nu = N-j;
+      nu = (nu >= @(nu)) ? @(nu) : nu;
+      jn = j + nu;      /* main loop, full NU block */
+      @endiif
+      @iif ML_NUR ! 0
+      jn = j + @(nu);      /* main loop, full NU block */
+      @endiif
+      i = (j/@(mu))*@(mu);
+      rw = rW;
+/*
+ *    handle the diagonal-crossing blocks first
+ *    NOTE: this can be full-MU block or partial----> no unrolling right now 
+ */
+      @iif ML_NUR ! 0
+         @callproc doDiagBlock mu @(nu)
+      @endiif
+      @iif ML_NUR = 0
+         @callproc doDiagBlock mu nu
+      @endiif
+/*
+ *    Full block after diagonal crossing, n=m  
+ */
+      @iif ML_MUNU = 1
+         @callproc doTrBlocksUR
+      @endiif
+      @SKIP only MU unrolling.. ML_MU true for both MU and MUNU
+      @iif ML_NUR = 0
+         @callproc doTrBlocksMuUR @(mu) nu
+      @endiif
+      @iif ML_MUR = 0 
+         @callproc doTrBlocksNuUR mu @(nu)
+      @endiif
+      @iif ML_MUR = 1 
+/*
+ *    MU cleanup 
+ */   
+      if (i < N)
+      {
+         @iif ML_MUNU = 1
+            @callproc doTrBlocksRolled mu @(nu) 0
+         @endiif
+         @iif ML_MUR = 1
+            @callproc doTrBlocksRolled mu nu 0
+         @endiif 
+      }
+      @endiif 
+   }
+   @endiif
+@BEGINSKIP
+*
+*  Following codes execute for three cases: 
+*     NU unrolled, both unrolled and no unroll 
+*     So, condition: if ML_MUR = 0 || ML_MUNU = 1 
+@ENDSKIP
+   @iif @iexp 1 @(ML_MUNU) = 0 @(ML_MUR) = |
+      @iif ML_NO = 0
+/*
+ * cleanup in N dimension
+ */
+   if (j < N)
+      @endiif
+      @iif ML_NO = 1
+   for (cinc=j=0; j < N; j = jn, C += incC, cinc += @(bs)) 
+      @endiif 
+   {
+      unsigned int  i, in, nu = N-j, nd, nblks;
+      jn = j + nu;
+      i = (j/@(mu))*@(mu);
+      rw = rW;
+      @callproc doDiagBlock mu nu 
+/*
+ *    full blocks before diagonal 
+ */
+      for (; i < N; i = in)
+      {
+         @callproc doTrBlocksRolled mu nu 1
+      }
+   }
+   @endiif
+}
+@SKIP ************** Unrestricted SYRK L2UT ************************************ 
+@SKIP this proc handles single element
+@SKIP IN : alpha, beta, C, b 
+@BEGINPROC doElementT r_ c_ C_ k_ b_
+   @iif alpha = 1
+      @iif beta = 0
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] = @(b_)[@(k_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] = @(C_)@(c_)[@(r_)];`
+      @endiif
+      @iif beta = 1
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] += @(b_)[@(k_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] += @(C_)@(c_)[@(r_)];`
+      @endiif
+      @iif beta = -1
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] = @(b_)[@(k_)] - @(C_)@(c_)[@(r_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] = @(C_)@(c_)[@(r_)] - @(b_)[@(k_)];`
+      @endiif
+      @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] = beta*@(C_)@(c_)[@(r_)] + @(b_)[@(k_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] = beta*@(b_)[@(k_)] + @(C_)@(c_)[@(r_)];`
+      @endiif
+   @endiif
+   @iif alpha = -1
+      @iif beta = 0
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] = -@(b_)[@(k_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] = -@(C_)@(c_)[@(r_)];`
+      @endiif
+      @iif beta = 1
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] -= @(b_)[@(k_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] -= @(C_)@(c_)[@(r_)];`
+      @endiif
+      @iif beta = -1
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] = -@(C_)@(c_)[@(r_)] - @(b_)[@(k_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] = -@(C_)@(c_)[@(r_)] - @(b_)[@(k_)];`
+      @endiif
+      @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] = beta*@(C_)@(c_)[@(r_)] - @(b_)[@(k_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] = beta*@(b_)[@(k_)] - @(C_)@(c_)[@(r_)];`
+      @endiif
+   @endiif
+   @iif @iexp @(alpha) 1 ! @(alpha) -1 ! &
+      @iif beta = 0
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] = alpha*@(b_)[@(k_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] = alpha*@(C_)@(c_)[@(r_)];`
+      @endiif
+      @iif beta = 1
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] += alpha*@(b_)[@(k_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] += alpha*@(C_)@(c_)[@(r_)];`
+      @endiif
+      @iif beta = -1
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] = alpha*@(b_)[@(k_)] - @(C_)@(c_)[@(r_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] = alpha*@(C_)@(c_)[@(r_)] - @(b_)[@(k_)];`
+      @endiif
+      @iif @iexp @(beta) 0 ! @(beta) 1 ! & @(beta) -1 ! &
+@ROUT blk2C `                  @(C_)@(c_)[@(r_)] = beta*@(C_)@(c_)[@(r_)] + alpha*@(b_)[@(k_)];`
+@ROUT C2blk `                  @(b_)[@(k_)] = beta*@(b_)[@(k_)] + alpha*@(C_)@(c_)[@(r_)];`
+      @endiif
+   @endiif
+@ENDPROC
+@SKIP handles full block 
+@BEGINPROC doBlockT m_ n_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp k @(i) @(mu) * @(j) +
+         @callproc doElementT @(i) @(j) C @(k) b  
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif m_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@ROUT C2blk `#if 0`
+#ifndef Mjoin
+   #define Mjoin(pre, nam) my_join(pre, nam)
+   #define my_join(pre, nam) pre ## nam
+#endif
+/*
+ * The block is assumed to store L, this function does a transpose while
+ * copying so that it is transferred with Upper portion of C
+ */
+void Mjoin(ATL_USERCPMM,_L2UT)
+(
+   const size_t M,      /* number of rows in A */
+   const size_t N,      /* number of columns in A */
+   @ROUT blk2C
+   const @(typ) alpha,  /* scalar for b */
+   const @(typ) *b,     /* matrix stored in @(mu)x@(nu)-major order */
+   const @(typ) beta,   /* scalar for C */
+   @(typ) *C,           /* matrix to be copied to access-major format */
+   const size_t ldc     /* stride between row elements */
+   @ROUT C2blk
+   const @(typ) alpha,  /* scalar for C */
+   const @(typ) *C,     /* matrix to be copied to access-major format */
+   const size_t ldc,    /* stride between row elements */
+   const @(typ) beta,   /* scalar for b */
+   @(typ) *b            /* matrix stored in @(mu)x@(nu)-major order */
+   @ROUT C2blk blk2C
+)
+{
+   size_t j, jn;
+   const size_t incCm = ldc*@(mu);
+/*
+ * NOTE: we assume N=M, always square for syrk 
+ */
+   const size_t nf = N/@(nu);
+   const size_t n = nf*@(nu), nr = N-n;
+/*
+ * since it's upper transpose case, the direction of @(mu) and NU interchanged
+ */
+   for (j=0; j < N; j = jn, C += incCm)
+   {
+      size_t i, in, nu;
+      size_t mu = N-j;
+      mu = (mu >= @(mu)) ? @(mu) : mu;
+      jn = j + mu;
+      nu = @(nu);
+/*
+ *    for upper triangle, blocks whose do not intersect with diagonal follow:
+ *               y0 > x1 => j > (in-1)
+ *                       => j > i+nu-1
+ *    access of C-workspace is consecutive
+ */
+      for (i=0; j > (i+nu-1); i=in, b += @(bs) )
+      {
+@ROUT C2BLK `        @(typ) *rw0 = b; `
+@ROUT BLK2C `        const @(typ) *rw0 = b; `
+@ROUT C2BLK `        const @(typ) *C0 = C+i; `
+@ROUT BLK2C `        @(typ) *C0 = C+i; `
+         unsigned int ii, jj;
+         size_t nu = N-i;
+         nu = (nu >= @(nu)) ? @(nu) : nu;
+         in = i + nu;
+         for (jj=0; jj < mu; jj++, C0 += ldc, rw0++)
+         {
+@ROUT C2BLK `           @(typ) *pr = rw0; `
+@ROUT BLK2C `           const @(typ) *pr = rw0; `
+            for (ii=0; ii < nu; ii++, pr += @(mu))
+            {
+               @callproc doElementT ii 0 C 0 pr 
+            }
+         }
+      }
+/*
+ *    intersection occurs at later blocks
+ */
+      for ( ; i < jn; i=in, b += @(bs))
+      {
+@ROUT C2BLK `        @(typ) *rw0 = b; `
+@ROUT BLK2C `        const @(typ) *rw0 = b; `
+@ROUT C2BLK `        const @(typ) *C0 = C+i; `
+@ROUT BLK2C `        @(typ) *C0 = C+i; `
+         unsigned int ii, jj;
+         size_t nu = N-i;
+         nu = (nu >= @(nu)) ? @(nu) : nu;
+         in = i + nu;
+         for (jj=0; jj < mu; jj++, C0 += ldc, rw0++)
+         {
+@ROUT C2BLK `           @(typ) *pr = rw0; `
+@ROUT BLK2C `           const @(typ) *pr = rw0; `
+            size_t J=j+jj;
+            for (ii=0; ii < nu; ii++, pr += @(mu))
+            {
+               size_t I=i+ii;
+               if (I <= J)
+               {
+                  @callproc doElementT ii 0 C 0 pr 
+               }
+            }
+         }
+      }
+   }
+}
+@ROUT C2blk `#endif`
+@endiif
 @endiif
 @SKIP ******************** Complex data type ***********************************
 @PRE C Z

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -1293,10 +1293,8 @@ void Mjoin(ATL_USERCPMM,_L2UT)
          @iif ma ! 1
       b = p;
       kk = j % @(ma);
-         @endiif
-      @endiif
-      @iif ma ! 0
       kk *= @(nu);
+         @endiif
       @endiif
       for (i=0; i < j; i++, b += @(bs))
       {
@@ -1304,7 +1302,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
          @callproc doBlockT @(mu) @(nu)
       @endiif
       @iif mEn = 0
-         @iif ma ! 0
+         @iif ma ! 1
          @callproc doBlockTkk @(nu) @(nu) 
          @endiif
       @endiif
@@ -4077,8 +4075,6 @@ void Mjoin(ATL_USERCPMM,_L2UT)
          @iif ma ! 1
       rC = pr; iC = pi;
       kk = j % @(ma);
-         @endiif
-         @iif ma ! 0
       kk *= @(nu);
          @endiif
       @endiif
@@ -4088,7 +4084,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
          @callproc doBlockT @(mu) @(nu)
       @endiif
       @iif mEn = 0
-         @iif ma ! 0
+         @iif ma ! 1
          @callproc doBlockTkk @(nu) @(nu) 
          @endiif
       @endiif

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -480,7 +480,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @endiif
 @iif TRI = 1
 @iif SYRKU = 0
-@SKIP ******************** Restricted SYRK copy: real type *********************
+@SKIP ******************** Restricted old SYRK copy: real type *****************
 @SKIP handles diagonal blocks when mu = nu 
 @SKIP IN: mu, nu, beta, alpha
 @BEGINPROC doDiBlock n_
@@ -1471,6 +1471,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
 @ENDPROC
 @SKIP handles unrolled rectangual blocks, used for cleanup as well
 @BEGINPROC doTrBlocksUR 
+   @define i @dum@
       for (; (i+@(mu)) < N; i = in)
       {
          unsigned int nblks;
@@ -1492,8 +1493,10 @@ void Mjoin(ATL_USERCPMM,_L2UT)
          rwpan = nblks*@(bs);
          rw += rwpan;
       }
+   @undef i
 @ENDPROC
 @BEGINPROC doTrBlocksMuUR mu_ nu_
+   @define i @dum@
          for (; (i+@(mu)) < N; i = in)
          {
             unsigned int jj, nblks;
@@ -1514,8 +1517,10 @@ void Mjoin(ATL_USERCPMM,_L2UT)
             rwpan = nblks*@(bs);
             rw += rwpan;
          }
+   @undef i
 @ENDPROC
 @BEGINPROC doTrBlocksNuUR mu_ nu_ 
+   @define j @dum@
       for (; i < N; i = in)
       {
          unsigned int ii, nblks, mu=N-i;
@@ -1545,6 +1550,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
          rwpan = nblks*@(bs);
          rw += rwpan;
       }
+   @undef j
 @ENDPROC
 @SKIP handles diagonal crossing blocks, implement rolled version first
 @BEGINPROC doDiagBlock mu_ nu_
@@ -1668,7 +1674,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 /*
  *    Full block after diagonal crossing, n=m  
  */
-      @iif ML_MUNU = 1
+      @iif ML_MUNU ! 0
          @callproc doTrBlocksUR
       @endiif
       @SKIP only MU unrolling.. ML_MU true for both MU and MUNU
@@ -1678,16 +1684,16 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       @iif ML_MUR = 0 
          @callproc doTrBlocksNuUR mu @(nu)
       @endiif
-      @iif ML_MUR = 1 
+      @iif ML_MUR ! 0 
 /*
  *    MU cleanup 
  */   
       if (i < N)
       {
-         @iif ML_MUNU = 1
+         @iif ML_MUNU ! 0
             @callproc doTrBlocksRolled mu @(nu) 0
          @endiif
-         @iif ML_MUR = 1
+         @iif ML_MUR ! 0
             @callproc doTrBlocksRolled mu nu 0
          @endiif 
       }
@@ -1786,7 +1792,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @endiif
 @ENDPROC
 @SKIP handles full block 
-@BEGINPROC doBlockT m_ n_
+@BEGINPROC doBlockT m_ n_ b_ cinc_
    @define i @dum@
    @define j @dum@
    @define k @dum@
@@ -1795,17 +1801,152 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       @iexp i 0
       @iwhile i < @(m_)
          @iexp k @(i) @(mu) * @(j) +
-         @callproc doElementT @(i) @(j) C @(k) b  
+         @callproc doElementT @(i) @(j) C @(k) @(b_)  
          @iexp i @(i) 1 +
       @endiwhile
-      @iif m_ = mu
+      @iif cinc_ ! 0
+         @iif m_ = mu
             C@(j) += @(mu);
+         @endiif
       @endiif
       @iexp j @(j) 1 +
    @endiwhile
    @undef k
    @undef j
    @undef i
+@ENDPROC
+@SKIP handles rolled blocks
+@BEGINPROC doTrBlocksRolled 
+      for (i=0; j > (i+nu-1); i=in, b += @(bs))
+      {
+@ROUT C2BLK `        @(typ) *rw0 = b; `
+@ROUT BLK2C `        const @(typ) *rw0 = b; `
+@ROUT C2BLK `        const @(typ) *C0 = C+i; `
+@ROUT BLK2C `        @(typ) *C0 = C+i; `
+         unsigned int ii, jj;
+         size_t nu = N-i;
+         nu = (nu >= @(nu)) ? @(nu) : nu;
+         in = i + nu;
+         for (jj=0; jj < mu; jj++, C0 += ldc, rw0++)
+         {
+@ROUT C2BLK `           @(typ) *pr = rw0; `
+@ROUT BLK2C `           const @(typ) *pr = rw0; `
+            for (ii=0; ii < nu; ii++, pr += @(mu))
+            {
+               @callproc doElementT ii 0 C 0 pr 
+            }
+         }
+      }
+@ENDPROC
+@SKIP handles fully unrolled blocks 
+@BEGINPROC doTrBlocksUR 
+   @define i @dum@
+      for (i=0; j > (i+nu-1); i=in, b += @(bs))
+      {
+@ROUT blk2C `        @declare "         @(typ) " n n ";"`
+@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
+         *C0=C+i
+         @define j @1@
+         @iwhile j < @(mu)
+            @iexp i @(j) -1 +
+            *C@(j)=C@(i)+ldc
+            @iexp j @(j) 1 +
+         @endiwhile
+      @enddeclare
+         in = i + @(nu);
+         @SKIP *** MU & NU interchanged 
+         @callproc doBlockT @(nu) @(mu) b 0
+      }
+   @undef i
+@ENDPROC
+@SKIP handles MU unrolled blocks NOT.. MU & NU interchanged... 
+@BEGINSKIP ********************************************************************
+      NOTE: L2UT code is located in the same file as the normal copy..
+      So, to make it similar as the normal copy, we are unrolling NU direction 
+      since MU & NU interchanged for L2UT... That means, MuUR actually unrolls
+      NU with respect to normal copies
+@ENDSKIP   ******************************************************************** 
+@BEGINPROC doTrBlocksMuUR mu_ nu_ 
+   @define i @dum@
+   @define k @dum@
+      for (i=0; j > (i+nu-1); i=in, b += @(bs) )
+      {
+@ROUT C2BLK `        @(typ) *pr = b; `
+@ROUT BLK2C `        const @(typ) *pr = b; `
+@ROUT C2BLK `        const @(typ) *C0 = C+i; `
+@ROUT BLK2C `        @(typ) *C0 = C+i; `
+         unsigned int jj;
+         in = i + @(nu);
+         for (jj=0; jj < @(mu_); jj++, C0 += ldc, pr++)
+         {
+            @iexp i 0
+            @iwhile i < @(nu_)
+               @iexp k @(mu) @(i) *
+               @callproc doElementT @(i) 0 C @(k) pr 
+               @iexp i @(i) 1 +
+            @endiwhile
+         }
+      }
+   @undef k
+   @undef i
+@ENDPROC
+@BEGINPROC doTrBlocksNuUR mu_ nu_ 
+   @define i @dum@
+      for (i=0; j > (i+nu-1); i=in, b += @(bs) )
+      {
+         unsigned int ii;
+@ROUT C2BLK `         @(typ) *p = b; `          
+@ROUT BLK2C `         const @(typ) *p = b; `          
+@ROUT blk2C `        @declare "         @(typ) " n n ";"`
+@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
+         *C0=C+i
+         @define j @1@
+         @iwhile j < @(mu)
+            @iexp i @(j) -1 +
+            *C@(j)=C@(i)+ldc
+            @iexp j @(j) 1 +
+         @endiwhile
+      @enddeclare
+         nu = (nu >= @(nu)) ? @(nu) : nu;
+         in = i + nu;
+         for (ii=0; ii < nu; ii++, p+=@(mu))
+         {
+            @iexp j 0
+            @iwhile j < @(mu_)
+               @callproc doElementT ii @(j) C @(j) p
+               @iexp j @(j) 1 +
+            @endiwhile
+         }
+      }
+   @undef i
+@ENDPROC
+@SKIP handles diagonal crossing blocks, implement rolled version first
+@BEGINPROC doDiagBlock mu_ 
+      for ( ; i < jn; i=in, b += @(bs))
+      {
+@ROUT C2BLK `        @(typ) *rw0 = b; `
+@ROUT BLK2C `        const @(typ) *rw0 = b; `
+@ROUT C2BLK `        const @(typ) *C0 = C+i; `
+@ROUT BLK2C `        @(typ) *C0 = C+i; `
+         unsigned int ii, jj;
+         size_t nu = N-i;
+         nu = (nu >= @(nu)) ? @(nu) : nu;
+         in = i + nu;
+         for (jj=0; jj < @(mu_); jj++, C0 += ldc, rw0++)
+         {
+@ROUT C2BLK `           @(typ) *pr = rw0; `
+@ROUT BLK2C `           const @(typ) *pr = rw0; `
+            size_t J=j+jj;
+            for (ii=0; ii < nu; ii++, pr += @(mu))
+            {
+               size_t I=i+ii;
+               if (I <= J)
+               {
+                  @callproc doElementT ii 0 C 0 pr 
+               }
+            }
+         }
+      }
 @ENDPROC
 @ROUT C2blk `#if 0`
 #ifndef Mjoin
@@ -1839,13 +1980,72 @@ void Mjoin(ATL_USERCPMM,_L2UT)
    const size_t incCm = ldc*@(mu);
 /*
  * NOTE: we assume N=M, always square for syrk 
+ * MU & NU interchanged 
  */
-   const size_t nf = N/@(nu);
-   const size_t n = nf*@(nu), nr = N-n;
+   @iif ML_NO = 0
+      @iif ML_NUR ! 0
+   const size_t nf = N/@(mu);
+   const size_t n = nf*@(mu), nr = N-n;
+      @endiif
 /*
  * since it's upper transpose case, the direction of @(mu) and NU interchanged
  */
+      @iif ML_NUR = 0
    for (j=0; j < N; j = jn, C += incCm)
+      @endiif
+      @iif ML_NUR ! 0
+   for (j=0; j < n; j = jn, C += incCm)
+      @endiif
+   {
+      size_t i, in, nu;
+      @iif ML_NUR = 0
+      size_t mu = N-j;
+      mu = (mu >= @(mu)) ? @(mu) : mu;
+      jn = j + mu;
+      @endiif
+      @iif ML_NUR ! 0
+      jn = j + @(mu);
+      @endiif
+      nu = @(nu);
+/*
+ *    for upper triangle, blocks whose do not intersect with diagonal follow:
+ *               y0 > x1 => j > (in-1)
+ *                       => j > i+nu-1
+ *    access of C-workspace is consecutive
+ */
+      @iif ML_MUNU = 1
+         @callproc doTrBlocksUR 
+      @endiif
+      @SKIP ML_NO = 1 => ML_NUR and ML_MUR can not both be 0 
+      @iif ML_NUR = 0
+         @callproc doTrBlocksMuUR mu @(nu)
+      @endiif
+      @iif ML_MUR = 0 
+         @callproc doTrBlocksNuUR @(mu) nu
+      @endiif
+@BEGINSKIP
+      NOTE: Since cleanup in M dimension will always be handled by diagonal 
+      crossing block, we should not need any clean up in that direction 
+      for full block...
+@ENDSKIP
+/*
+ *    intersection occurs at later blocks
+ */
+      @iif ML_NUR = 0
+         @callproc doDiagBlock mu 
+      @endiif
+      @iif ML_NUR ! 0
+         @callproc doDiagBlock @(mu) 
+      @endiif
+   }
+/*
+ * cleanup in N dimension 
+ */
+   if (j < N)
+   @endiif
+   @iif ML_NO ! 0
+   for (j=0; j < N; j = jn, C += incCm)
+   @endiif
    {
       size_t i, in, nu;
       size_t mu = N-j;
@@ -1857,55 +2057,12 @@ void Mjoin(ATL_USERCPMM,_L2UT)
  *               y0 > x1 => j > (in-1)
  *                       => j > i+nu-1
  *    access of C-workspace is consecutive
- */
-      for (i=0; j > (i+nu-1); i=in, b += @(bs) )
-      {
-@ROUT C2BLK `        @(typ) *rw0 = b; `
-@ROUT BLK2C `        const @(typ) *rw0 = b; `
-@ROUT C2BLK `        const @(typ) *C0 = C+i; `
-@ROUT BLK2C `        @(typ) *C0 = C+i; `
-         unsigned int ii, jj;
-         size_t nu = N-i;
-         nu = (nu >= @(nu)) ? @(nu) : nu;
-         in = i + nu;
-         for (jj=0; jj < mu; jj++, C0 += ldc, rw0++)
-         {
-@ROUT C2BLK `           @(typ) *pr = rw0; `
-@ROUT BLK2C `           const @(typ) *pr = rw0; `
-            for (ii=0; ii < nu; ii++, pr += @(mu))
-            {
-               @callproc doElementT ii 0 C 0 pr 
-            }
-         }
-      }
+ */      
+      @callproc doTrBlocksRolled 
 /*
  *    intersection occurs at later blocks
  */
-      for ( ; i < jn; i=in, b += @(bs))
-      {
-@ROUT C2BLK `        @(typ) *rw0 = b; `
-@ROUT BLK2C `        const @(typ) *rw0 = b; `
-@ROUT C2BLK `        const @(typ) *C0 = C+i; `
-@ROUT BLK2C `        @(typ) *C0 = C+i; `
-         unsigned int ii, jj;
-         size_t nu = N-i;
-         nu = (nu >= @(nu)) ? @(nu) : nu;
-         in = i + nu;
-         for (jj=0; jj < mu; jj++, C0 += ldc, rw0++)
-         {
-@ROUT C2BLK `           @(typ) *pr = rw0; `
-@ROUT BLK2C `           const @(typ) *pr = rw0; `
-            size_t J=j+jj;
-            for (ii=0; ii < nu; ii++, pr += @(mu))
-            {
-               size_t I=i+ii;
-               if (I <= J)
-               {
-                  @callproc doElementT ii 0 C 0 pr 
-               }
-            }
-         }
-      }
+      @callproc doDiagBlock mu 
    }
 }
 @ROUT C2blk `#endif`
@@ -2445,6 +2602,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
 @ENDPROC
 @ROUT blk2C C2blk
 @iif TRI = 0 
+@SKIP *********************** GEMM copy: complex type **************************
 /*
  * Main Loop:
  @iif bvML = 0
@@ -2484,7 +2642,6 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
                          @(typ) *C, ATL_CSZT ldc)
 @endiif
 {
-@SKIP *********************** GEMM copy: complex type **************************
    const unsigned int mf = M/@(mu), nf = N/@(nu);
    const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
    const unsigned int pansz = (nr) ? (nf+1)*@(bs) : nf*@(bs); /* bs=@(bs) */
@@ -2673,6 +2830,8 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @endiif
 @SKIP ***************** SYRK copy: complex type ********************************
 @iif TRI = 1
+@SKIP ***************** Restricted old SYRK copy: complex type *****************
+@iif SYRKU = 0 
 @SKIP handles diagonal block when mu=nu
 @SKIP IN: mu, nu, beta, alpha
 @BEGINPROC doDiBlock n_
@@ -4226,8 +4385,165 @@ void Mjoin(ATL_USERCPMM,_L2UT)
 @endiif
 }
 @ROUT C2blk `#endif`
+@SKIP ***************** END of old SYRK L2UT: complex type **********************
 @endiif
-@SKIP ***************** END of SYRK L2UT: complex type**************************
+@iif SYRKU ! 0
+@SKIP ***************** Unrestricted SYRK copy: complex type *******************
+/*
+ * Main Loop:
+ @iif bvML = 0
+ * Both Rolled
+ @endiif
+ @iif ML_MUR ! 0
+ * Mu unrolled
+ @endiif
+ @iif ML_NUR ! 0
+ * Nu unrolled
+ @endiif
+ */
+@iif cpvl = 1
+void @(rtnm)
+(
+   const size_t M,      /* number of rows in A */
+   const size_t N,      /* number of columns in A */
+   const @(typ) *alpha, /* scalar for b */
+   @ROUT blk2C
+   const @(typ) *rC,    /* real block stored in @(mu)x@(nu)-major order */
+   const @(typ) *iC,    /* imag block stored in @(mu)x@(nu)-major order */
+   const @(typ) *beta,  /* scalar for C */
+   @(typ) *C,           /* matrix to be copied to access-major format */
+   const size_t ldc     /* stride between row elements */
+   @ROUT C2blk
+   const @(typ) *C,     /* matrix to be copied to access-major format */
+   const size_t ldc,    /* stride between row elements */
+   const @(typ) *beta,  /* scalar for C */
+   @(typ) *rC,          /* real block stored in @(mu)x@(nu)-major order */
+   @(typ) *iC           /* imag block stored in @(mu)x@(nu)-major order */
+   @ROUT C2blk blk2C
+)
+@endiif
+@SKIP *** NOTE: copied following declaration of a2c_1 from old version, don't 
+@SKIP     think it is used anymore
+@iif cpvl > 1
+static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha, 
+                         const @(typ) *b, const SCALAR beta, 
+                         @(typ) *C, ATL_CSZT ldc)
+@endiif
+{
+   int j, jn, cinc, rwpan;
+   unsigned int pansz = @(bs);
+   @iif alpX ! 0
+   const register @(typ) ra=(*alpha), ia=alpha[1];
+   @endiif
+   @iif betX ! 0
+   const register @(typ) rb=(*beta), ib=beta[1];
+   @endiif
+   const size_t incC = (ldc*@(nu))<<1, ldc2 = ldc+ldc;
+@ROUT C2BLK `   @(typ) *rW=b, *rw; `
+@ROUT BLK2C `   const @(typ) *rW=b, *rw; `
+/*
+ * NOTE: we assume N=M, always square for syrk 
+ */
+   @iif ML_NO = 0 
+      @iif ML_NUR ! 0
+   const unsigned int nf = N/@(nu);
+   const unsigned int n = nf*@(nu), nr = N-n;
+      @endiif
+/*
+ * NU colpan: Full panel, without cleanup (N direction)
+ */
+      @iif ML_NUR ! 0 
+   for (cinc=j=0; j < n; j = jn, C += incC, cinc += @(bs))
+      @endiif
+   @SKIP ***** Nu rolled, no need of Nu cleanup 
+      @iif ML_NUR = 0
+   for (cinc=j=0; j < N; j = jn, C += incC, cinc += @(bs))
+      @endiif
+   {
+      unsigned int i, in, nd;
+      @iif ML_NUR = 0
+      unsigned int nu = N-j;
+      nu = (nu >= @(nu)) ? @(nu) : nu;
+      jn = j + nu;      /* main loop, full NU block */
+      @endiif
+      @iif ML_NUR ! 0
+      jn = j + @(nu);      /* main loop, full NU block */
+      @endiif
+      i = (j/@(mu))*@(mu);
+      rw = rW;
+/*
+ *    handle the diagonal-crossing blocks first
+ *    NOTE: this can be full-MU block or partial----> no unrolling right now 
+ */
+      @iif ML_NUR ! 0
+         @callproc doDiagBlock mu @(nu)
+      @endiif
+      @iif ML_NUR = 0
+         @callproc doDiagBlock mu nu
+      @endiif
+/*
+ *    Full block after diagonal crossing, n=m  
+ */
+      @iif ML_MUNU = 1
+         @callproc doTrBlocksUR
+      @endiif
+      @SKIP only MU unrolling.. ML_MU true for both MU and MUNU
+      @iif ML_NUR = 0
+         @callproc doTrBlocksMuUR @(mu) nu
+      @endiif
+      @iif ML_MUR = 0 
+         @callproc doTrBlocksNuUR mu @(nu)
+      @endiif
+      @iif ML_MUR = 1 
+/*
+ *    MU cleanup 
+ */   
+      if (i < N)
+      {
+         @iif ML_MUNU = 1
+            @callproc doTrBlocksRolled mu @(nu) 0
+         @endiif
+         @iif ML_MUR = 1
+            @callproc doTrBlocksRolled mu nu 0
+         @endiif 
+      }
+      @endiif 
+   }
+   @endiif
+@BEGINSKIP
+*
+*  Following codes execute for three cases: 
+*     NU unrolled, both unrolled and no unroll 
+*     So, condition: if ML_MUR = 0 || ML_MUNU = 1 
+@ENDSKIP
+   @iif @iexp 1 @(ML_MUNU) = 0 @(ML_MUR) = |
+      @iif ML_NO = 0
+/*
+ * cleanup in N dimension
+ */
+   if (j < N)
+      @endiif
+      @iif ML_NO = 1
+   for (cinc=j=0; j < N; j = jn, C += incC, cinc += @(bs)) 
+      @endiif 
+   {
+      unsigned int  i, in, nu = N-j, nd, nblks;
+      jn = j + nu;
+      i = (j/@(mu))*@(mu);
+      rw = rW;
+      @callproc doDiagBlock mu nu 
+/*
+ *    full blocks before diagonal 
+ */
+      for (; i < N; i = in)
+      {
+         @callproc doTrBlocksRolled mu nu 1
+      }
+   }
+   @endiif
+}
+@endiif
+@endiif
 @ROUT blk2C_x87
 @BEGINPROC GetAOff i_ j_
    @define of @1@

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -628,7 +628,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @undef i
 @ENDPROC
 @SKIP diagonal block when nu > mu and nu = na * mu
-@BEGINPROC doDikkBlockna n_ mul_
+@BEGINPROC doDikkBlockna n_ 
    @define i @dum@
    @define j @dum@
    @define k @dum@
@@ -655,7 +655,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @endiif
 @ROUT blk2C C2blk
          @skip @iexp m @(n_) @(n_) *
-         @callproc doElement @(r) @(c) C @(k)+kk*@(mul_) p 
+         @callproc doElement @(r) @(c) C @(k)+kk p 
 @ROUT blk2C
          @endiif
 @ROUT blk2C C2blk
@@ -674,7 +674,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @undef i
 @ENDPROC
 @SKIP full blocks with multiplication 
-@BEGINPROC donaBlock m_ n_ mn_
+@BEGINPROC donaBlock m_ n_ 
    @define i @dum@
    @define j @dum@
    @define k @dum@
@@ -684,7 +684,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       @iexp i 0
       @iwhile i < @(m_)
          @iexp k @(j) @(mu) * @(i) +
-         @callproc doElement @(i) @(j) C @(k)+kk*@(mn_) p 
+         @callproc doElement @(i) @(j) C @(k)+kk p 
          @iexp i @(i) 1 +
       @endiwhile
       @iif m_ = mu
@@ -802,7 +802,8 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       unsigned int psz = pansz, incC = incC0 - (mf-j)*@(mu);
          kk = j % @(na);
       @iexp mumu @(mu) @(mu) *
-      @callproc doDikkBlockna @(mu) @(mumu)
+         kk *= @(mumu);
+      @callproc doDikkBlockna @(mu) 
       p += pansz;
       for (i=j+1; i < mf; i++, p += psz )
       @endiif
@@ -814,7 +815,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @endiif
 @iif na ! 1
       {
-         @callproc donaBlock @(mu) @(mu) @(mumu)
+         @callproc donaBlock @(mu) @(mu) 
          psz += ((i%@(na))==0?@(bs):0);
       }
 @endiif
@@ -827,7 +828,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       @callproc doBlock @(m) @(nu) p
 @endiif
 @iif na ! 1
-      @callproc donaBlock @(m) @(mu) @(mumu)
+      @callproc donaBlock @(m) @(mu) 
 @endiif
       @iexp m @(m) 1 +
          break;
@@ -921,6 +922,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @iif na ! 1
 @iif mu > 1
    kk = mnf % @(na);
+   kk *= @(mumu);
    switch(mnr)
    {
 @ROUT blk2C `      const @(typ) *p;`
@@ -929,7 +931,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @iwhile n < @(mu)
    case @(n):
       p = b;
-      @callproc doDikkBlockna @(n) @(mumu)
+      @callproc doDikkBlockna @(n) 
          break;
       @iexp n @(n) 1 +
    @endiwhile
@@ -1084,7 +1086,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       @iexp i 0
       @iwhile i < @(m_)
          @iexp k @(i) @(mu) * @(j) +
-         @callproc doElementT @(i) @(j) kk*@(nu)+@(k)  
+         @callproc doElementT @(i) @(j) kk+@(k)  
          @iexp i @(i) 1 +
       @endiwhile
             C@(j) += @(m_);
@@ -1146,7 +1148,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iexp r @(i)
          @iexp c @(j)
          @iif j } i
-      @callproc doElementT @(r) @(c) kk*@(nu)+@(k)
+      @callproc doElementT @(r) @(c) kk+@(k)
          @endiif
 @ROUT C2blk
          @iif j < i
@@ -1157,7 +1159,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
             @iexp r @(i)
             @iexp c @(j)
          @endiif
-      @callproc doElementT @(r) @(c) kk*@(nu)+@(k)
+      @callproc doElementT @(r) @(c) kk+@(k)
 @ROUT blk2C C2blk
          @iexp i @(i) 1 +
       @endiwhile
@@ -1281,6 +1283,9 @@ void Mjoin(ATL_USERCPMM,_L2UT)
       kk = j % @(ma);
          @endiif
       @endiif
+      @iif ma ! 0
+      kk *= @(nu);
+      @endiif
       for (i=0; i < j; i++, b += @(bs))
       {
       @iif mEn = 1
@@ -1379,6 +1384,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
       @iif ma ! 1
    b = p;
    kk = nf % @(ma);
+   kk *= @(nu);
    switch(nr)
    {
          @iexp n 1
@@ -1808,7 +1814,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
    @undef i
 @ENDPROC
 @SKIP diagonal block when nu > mu and nu = na * mu
-@BEGINPROC doDikkBlockna n_ mul_
+@BEGINPROC doDikkBlockna n_ 
    @define i @dum@
    @define j @dum@
    @define k @dum@
@@ -1838,7 +1844,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
 @ROUT blk2C C2blk
          @iexp ir @(r) @(r) + 
          @iexp ii @(ir) 1 + 
-         @callproc doElement @(c) @(ir) @(ii) C @(k)+kk*@(mul_) pr pi 
+         @callproc doElement @(c) @(ir) @(ii) C @(k)+kk pr pi 
 @ROUT blk2C
          @endiif
 @ROUT blk2C C2blk
@@ -1861,7 +1867,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
    @undef i
 @ENDPROC
 @SKIP full blocks with multiplication 
-@BEGINPROC donaBlock m_ n_ mn_
+@BEGINPROC donaBlock m_ n_ _
    @define i @dum@
    @define j @dum@
    @define k @dum@
@@ -1875,7 +1881,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
          @iexp k @(j) @(mu) * @(i) +
          @iexp ir @(i) @(i) + 
          @iexp ii @(ir) 1 + 
-         @callproc doElement @(j) @(ir) @(ii) C @(k)+kk*@(mn_) pr pi 
+         @callproc doElement @(j) @(ir) @(ii) C @(k)+kk pr pi 
          @iexp i @(i) 1 +
       @endiwhile
       @iif m_ = mu
@@ -1944,7 +1950,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
                @iexp jj 0
                @iwhile jj < @(n_)
                   @iexp t @(jj) @(m_) * 
-                  @callproc doElement @(jj) (2*kk) (2*kk+1) C @(t)+kk pr pi
+                  @callproc doElement @(jj) (kk<<1) ((kk<<1)+1) C @(t)+kk pr pi
                   @iexp jj @(jj) 1 +
                @endiwhile
             }
@@ -2513,7 +2519,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @undef i
 @ENDPROC
 @SKIP diagonal block when nu > mu and nu = na * mu
-@BEGINPROC doDikkBlockna n_ mul_
+@BEGINPROC doDikkBlockna n_ 
    @define i @dum@
    @define j @dum@
    @define k @dum@
@@ -2543,7 +2549,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @ROUT blk2C C2blk
          @iexp ir @(r) @(r) + 
          @iexp ii @(ir) 1 + 
-         @callproc doElement @(c) @(ir) @(ii) C @(k)+kk*@(mul_) pr pi 
+         @callproc doElement @(c) @(ir) @(ii) C @(k)+kk pr pi 
 @ROUT blk2C
          @endiif
 @ROUT blk2C C2blk
@@ -2566,7 +2572,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    @undef i
 @ENDPROC
 @SKIP full blocks with multiplication 
-@BEGINPROC donaBlock m_ n_ mn_
+@BEGINPROC donaBlock m_ n_ 
    @define i @dum@
    @define j @dum@
    @define k @dum@
@@ -2580,7 +2586,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iexp k @(j) @(mu) * @(i) +
          @iexp ir @(i) @(i) + 
          @iexp ii @(ir) 1 + 
-         @callproc doElement @(j) @(ir) @(ii) C @(k)+kk*@(mn_) pr pi 
+         @callproc doElement @(j) @(ir) @(ii) C @(k)+kk pr pi 
          @iexp i @(i) 1 +
       @endiwhile
       @iif m_ = mu
@@ -2649,7 +2655,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
                @iexp jj 0
                @iwhile jj < @(n_)
                   @iexp t @(jj) @(m_) * 
-                  @callproc doElement @(jj) (2*kk) (2*kk+1) C @(t)+kk pr pi
+                  @callproc doElement @(jj) (kk<<1) ((kk<<1)+1) C @(t)+kk pr pi
                   @iexp jj @(jj) 1 +
                @endiwhile
             }
@@ -2777,7 +2783,8 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       unsigned int psz = pansz, incC = incC0 - (mf-j)*@(mu);
       kk = j % @(na);
       @iexp mumu @(mu) @(mu) *
-      @callproc doDikkBlockna @(mu) @(mumu)
+      kk *= @(mumu);
+      @callproc doDikkBlockna @(mu) 
       pr += pansz; pi += pansz;
       for (i=j+1; i < mf; i++, pr += psz, pi += psz )
       @endiif
@@ -2789,7 +2796,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @endiif
 @iif na ! 1
       {
-         @callproc donaBlock @(mu) @(mu) @(mumu)
+         @callproc donaBlock @(mu) @(mu) 
          psz += ((i%@(na))==0?@(bs):0);
       }
 @endiif
@@ -2802,7 +2809,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
       @callproc doBlock @(m) @(nu)
 @endiif
 @iif na ! 1
-      @callproc donaBlock @(m) @(mu) @(mumu)
+      @callproc donaBlock @(m) @(mu) 
 @endiif
       @iexp m @(m) 1 +
          break;
@@ -2902,6 +2909,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @iif na ! 1
    @iif mu > 1
    kk = mnf % @(na);
+   kk *= @(mumu);
    switch(mnr)
    {
 @ROUT blk2C `      const @(typ) *pr, *pi;`
@@ -2911,7 +2919,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    case @(n):
       pr= rC;
       pi =iC;
-      @callproc doDikkBlockna @(n) @(mumu)
+      @callproc doDikkBlockna @(n) 
          break;
       @iexp n @(n) 1 +
    @endiwhile
@@ -3288,7 +3296,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iexp ir @(i) @(i) +
          @iexp ii @(ir) 1 +
          @iexp k @(i) @(mu) * @(j) +
-         @callproc doElementT @(j) @(ir) @(ii) kk*@(nu)+@(k)  
+         @callproc doElementT @(j) @(ir) @(ii) kk+@(k)  
          @iexp i @(i) 1 +
       @endiwhile
       @iexp i @(m_) @(m_) +
@@ -3392,7 +3400,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @iif j } i
          @iexp ir @(r) @(r) +
          @iexp ii @(ir) 1 +
-      @callproc doElementT @(c) @(ir) @(ii) kk*@(nu)+@(k)
+      @callproc doElementT @(c) @(ir) @(ii) kk+@(k)
          @endiif
 @ROUT C2blk
          @iif j < i
@@ -3405,7 +3413,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          @endiif
          @iexp ir @(r) @(r) +
          @iexp ii @(ir) 1 +
-      @callproc doElementT @(c) @(ir) @(ii) kk*@(nu)+@(k)
+      @callproc doElementT @(c) @(ir) @(ii) kk+@(k)
 @ROUT blk2C C2blk
          @iexp i @(i) 1 +
       @endiwhile
@@ -3592,6 +3600,9 @@ void Mjoin(ATL_USERCPMM,_L2UT)
       rC = pr; iC = pi;
       kk = j % @(ma);
          @endiif
+         @iif ma ! 0
+      kk *= @(nu);
+         @endiif
       @endiif
       for (i=0; i < j; i++, rC += @(bs), iC += @(bs))
       {
@@ -3692,6 +3703,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
       @iif ma ! 1
       rC = pr; iC = pi;
       kk = nf % @(ma);
+      kk *= @(nu);
       switch(nr)
       {
          @iexp n 1

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -468,7 +468,7 @@
       @iexp i 0
       @iwhile i < @(m_)
          @iexp k @(j) @(mu) * @(i) +
-         @callproc doElementUR @(i) @(j) @(k) 
+         @callproc doElementUR @(i) @(j) C @(k) @(p_) 
          @iexp i @(i) 1 +
       @endiwhile
       @iif m_ = mu

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -58,26 +58,37 @@
 @endiif
 @SKIP ****************** bitvector for parameterized unrolling *****************
 @BEGINSKIP
-   Now we created two flags: one for main loop and other for cleanup loop
-   bvML : bitvector, default 3, with following meanings:
-      0 : no unroll in any dimension
-      1 : unroll MU dimension
-      2 : unroll NU dimension
-      3 : unroll both dimension
-   bvCU : bitvector, default 0, with following meanings: 
-      0 : no unroll in any dimension
-      1 : unroll MU dimension
-      2 : unroll NU dimension
-      3 : unroll both dimension
+   NOTE: cpUR bit location meanings: 
+      0/1   : Main Loop, Unroll in MU dimension
+      1/2   : Main Loop, Unroll in NU dimension
+      2/4   : Cleanup Loop, Unroll in MU dimension
+      3/8   : Cleanup Loop, Unroll in NU dimension
 @ENDSKIP
-@SKIP **** made fully unrolled mainloop (bvML=3) as the default case
-@ifdef ! bvML
-   @iexp bvML 3  
+@SKIP **** made fully unroll default for both main loop and cleanup loop
+@ifdef ! cpUR
+   @iexp cpUR 15
 @endifdef
-@SKIP **** made fully unrolled cleanup loop (bvCU=3) as the  default case 
-@ifdef ! bvCU
-   @iexp bvCU 3 
-@endifdef
+@BEGINSKIP
+   We are splitting two bits each for main loop and cleanup and creating two 
+   seperate bitvectors: bvML and bvCU
+   Now we created two flags: one for main loop and other for cleanup loop
+   bvML : bitvector with following meanings:
+      0 : no unroll in any dimension
+      1 : unroll MU dimension
+      2 : unroll NU dimension
+      3 : unroll both dimension
+   bvCU : bitvector, with following meanings: 
+      0 : no unroll in any dimension
+      1 : unroll MU dimension
+      2 : unroll NU dimension
+      3 : unroll both dimension
+   NOTE: Unlike A-copy, C copy only has following valid cases:
+    (bvML,bvCU) = (0,0), (1,0), (1,1), (2,0), (2,2), (3,0), (3,1), (3,2), (3,3)
+         That means, if one dimension of mainloop is rolled, we won't have 
+         cleanup on that dimension to unroll.
+@ENDSKIP
+@iexp bvML @(cpUR) 3 &
+@iexp bvCU 2 @(cpUR) r
 @BEGINSKIP
    to make code more readable, I create two flag to represent to each bits
    ML_NUR, ML_MUR

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -300,7 +300,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
                          @(typ) *C, ATL_CSZT ldc)
 @endiif
 {
-   unsigned int i, j;
+   size_t i, j;
    const unsigned int mf = M/@(mu), nf = N/@(nu);
    const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
    const unsigned int pansz = (nr) ? (nf+1)*@(bs) : nf*@(bs); /* bs=@(bs) */
@@ -2718,7 +2718,8 @@ void Mjoin(ATL_USERCPMM,_L2UT)
             {
                for (ii=0; ii < @(mu_); ii++)
                {
-                  @callproc doElement 0 2*ii 2*ii+1 rC ii rw iw 
+                  unsigned int rk = ii<<1, ik = rk+1;
+                  @callproc doElement 0 rk ik rC ii rw iw 
                }
             }
       @iif cinc_ ! 0
@@ -4858,7 +4859,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
          in = i + mu;
          for (ii=0; ii < @(mu_); ii++)
          {
-            unsigned int rk = (ii<<1), ik = (ii<<1)+1;
+            unsigned int rk = (ii<<1), ik = rk+1;
             @iexp j 0
             @iwhile j < @(nu_)
                @callproc doElement @(j) rk ik C @(mu)*@(j)+ii pr pi
@@ -4890,7 +4891,7 @@ void Mjoin(ATL_USERCPMM,_L2UT)
             const unsigned int J=j+jj;
             for (ii=0; ii < mu; ii++)
             {
-               unsigned int rk = (ii<<1), ik = (ii<<1)+1;
+               unsigned int rk = (ii<<1), ik = rk+1;
                const unsigned int I=i+ii;
                if (I >= J)
                {
@@ -5112,7 +5113,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @ROUT BLK2C `           const @(typ) *pr = rw0, *pi = iw0; `
             for (ii=0; ii < nu; ii++, pr += @(mu), pi += @(mu))
             {
-               unsigned int rk = (ii<<1), ik = (ii<<1)+1; 
+               unsigned int rk = (ii<<1), ik = rk+1; 
                @callproc doElementT 0 rk ik C 0 pr pi 
             }
          }
@@ -5198,7 +5199,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
          in = i + nu;
          for (ii=0; ii < nu; ii++, p+=@(mu))
          {
-            unsigned int rk = (ii<<1), ik = (ii<<1)+1;
+            unsigned int rk = (ii<<1), ik = rk+1;
             @iexp j 0
             @iwhile j < @(mu_)
                @callproc doElementT @(j) rk ik C @(j) pr pi
@@ -5226,7 +5227,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
             size_t J=j+jj;
             for (ii=0; ii < nu; ii++, pr += @(mu), pi += @(mu))
             {
-               unsigned int rk = (ii<<1), ik = (ii<<1)+1;
+               unsigned int rk = (ii<<1), ik = rk+1;
                size_t I=i+ii;
                if (I <= J)
                {

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -19,6 +19,7 @@
 @endifdef
 @SKIP TRI = 1 means lower triangular C (SYRK)
 @iif TRI = 1
+   @define SYRKU @0@ 
    @define ma @1@
    @define na @1@
    @iif mu ! nu
@@ -26,7 +27,9 @@
          @iexp ma @(nu) @(mu) / 
          @iexp mma @(ma) @(nu) *
          @iif mu ! mma
-           @abort "mu (@(mu)) must be multiple of nu (@(nu))"  
+           @abort "mu (@(mu)) must be multiple of nu (@(nu))" 
+           @SKIP Now unrestricted SYRK is supported 
+           @iexp SYKRU 1 
          @endiif
          @skip @print ************ma = @(ma)
       @endiif
@@ -35,6 +38,8 @@
          @iexp nna @(na) @(mu) *
          @iif nu ! nna
            @abort "nu (@(nu)) must be multiple of mu (@(mu))"  
+           @SKIP Now unrestricted SYRK is supported 
+           @iexp SYKRU 1 
          @endiif
          @skip @print ************na = @(na)
       @endiif
@@ -428,6 +433,31 @@
    @undef j
    @undef i
 @ENDPROC
+@SKIP full blocks with multiplication 
+@BEGINPROC donaBlock m_ n_ mn_
+   @define i @dum@
+   @define j @dum@
+   @define k @dum@
+   @define m @dum@
+   @iexp j 0
+   @iwhile j < @(n_)
+      @iexp i 0
+      @iwhile i < @(m_)
+         @iexp k @(j) @(mu) * @(i) +
+         @callproc doElement @(i) @(j) @(k)+kk*@(mn_) 
+         @iexp i @(i) 1 +
+      @endiwhile
+      @iif m_ = mu
+            C@(j) += @(mu);
+      @endiif
+      @iexp j @(j) 1 +
+   @endiwhile
+   @undef m
+   @undef k
+   @undef j
+   @undef i
+@ENDPROC
+@SKIP ******** parameterized GEMM implementation ************** 
 @SKIP handles square blocks 
 @BEGINPROC doBlock m_ n_ p_
    @define i @dum@
@@ -500,29 +530,139 @@
          }
    @undef j
 @ENDPROC
-@SKIP full blocks with multiplication 
-@BEGINPROC donaBlock m_ n_ mn_
-   @define i @dum@
-   @define j @dum@
-   @define k @dum@
-   @define m @dum@
-   @iexp j 0
-   @iwhile j < @(n_)
-      @iexp i 0
-      @iwhile i < @(m_)
-         @iexp k @(j) @(mu) * @(i) +
-         @callproc doElement @(i) @(j) @(k)+kk*@(mn_) 
-         @iexp i @(i) 1 +
-      @endiwhile
-      @iif m_ = mu
-            C@(j) += @(mu);
-      @endiif
-      @iexp j @(j) 1 +
-   @endiwhile
-   @undef m
-   @undef k
-   @undef j
-   @undef i
+@SKIP ******** parameterized unrestricted SYRK implementation ************** 
+@SKIP handles rolled rectangual blocks, used for cleanup as well
+@SKIP we are skipping the i-loop to make it work with cleanup 
+@BEGINPROC doTrBlocksRolled mu_ nu_ tstmu_
+         unsigned int mu=N-i, ii, jj, nblks;
+@ROUT C2BLK `         const @(typ) *C0 = C + i; `          
+@ROUT BLK2C `         @(typ) *C0 = C + i; `          
+@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
+@ROUT BLK2C `         const @(typ) *p = rw + cinc; `     
+   @iif tstmu_ = 1
+         mu = (mu >= @(mu)) ? @(mu) : mu;
+   @endiif
+         in = i + mu;
+         for (jj=0; jj < @(nu_); jj++, C0 += ldc, p += @(mu))
+         {
+            for (ii=0; ii < @(mu_); ii++)
+            {
+               @callproc doElementUR ii 0 C ii p 
+            }
+         }
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan;
+@ENDPROC
+@SKIP handles unrolled rectangual blocks, used for cleanup as well
+@BEGINPROC doTrBlocksUR 
+      for (; (i+@(mu)) < N; i = in)
+      {
+         unsigned int nblks;
+@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
+@ROUT BLK2C `         const @(typ) *p = rw + cinc; `          
+@ROUT blk2C `        @declare "         @(typ) " n n ";"`
+@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
+         *C0=C+i
+         @define j @1@
+         @iwhile j < @(nu)
+            @iexp i @(j) -1 +
+            *C@(j)=C@(i)+ldc
+            @iexp j @(j) 1 +
+         @endiwhile
+      @enddeclare
+         in = i + @(mu);
+         @callproc doBlock @(mu) @(nu) p 
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan;
+      }
+@ENDPROC
+@BEGINPROC doTrBlocksMuUR mu_ nu_
+         for (; (i+@(mu)) < N; i = in)
+         {
+            unsigned int jj, nblks;
+@ROUT C2BLK `            const @(typ) *C0 = C + i; `          
+@ROUT BLK2C `            @(typ) *C0 = C + i; `          
+@ROUT C2BLK `            @(typ) *p = rw + cinc; `          
+@ROUT BLK2C `            const @(typ) *p = rw + cinc; `          
+            in = i + @(mu);
+            for (jj=0; jj < @(nu_); jj++, C0 += ldc, p += @(mu))
+            {
+            @iexp i 0
+            @iwhile i < @(mu_)
+               @callproc doElementUR @(i) 0 C @(i) p 
+               @iexp i @(i) 1 +
+            @endiwhile
+            } 
+            nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+            rwpan = nblks*@(bs);
+            rw += rwpan;
+         }
+@ENDPROC
+@BEGINPROC doTrBlocksNuUR mu_ nu_ 
+      for (; i < N; i = in)
+      {
+         unsigned int ii, nblks, mu=N-i;
+@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
+@ROUT BLK2C `         const @(typ) *p = rw + cinc; `          
+@ROUT blk2C `        @declare "         @(typ) " n n ";"`
+@ROUT C2blk `        @declare "         const @(typ) " n n ";"`
+         *C0=C+i
+         @define j @1@
+         @iwhile j < @(nu)
+            @iexp i @(j) -1 +
+            *C@(j)=C@(i)+ldc
+            @iexp j @(j) 1 +
+         @endiwhile
+      @enddeclare
+         mu = (mu >= @(mu)) ? @(mu) : mu;
+         in = i + mu;
+         for (ii=0; ii < @(mu_); ii++)
+         {
+            @iexp j 0
+            @iwhile j < @(nu_)
+               @callproc doElementUR ii @(j) C @(mu)*@(j)+ii p
+               @iexp j @(j) 1 +
+            @endiwhile
+         }
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan;
+      }
+@ENDPROC
+@SKIP handles diagonal crossing blocks, implement rolled version first
+@BEGINPROC doDiagBlock mu_ nu_
+/*
+ *    Handling of diagonal blocks for this colpan 
+ */
+      for (; i < jn; i = in)
+      {
+         unsigned int mu=N-i, ii, jj, nblks;
+@ROUT C2BLK `         const @(typ) *C0 = C + i; `          
+@ROUT BLK2C `         @(typ) *C0 = C + i; `          
+@ROUT C2BLK `         @(typ) *p = rw + cinc; `          
+@ROUT BLK2C `         const @(typ) *p = rw + cinc; `          
+         mu = (mu >= @(mu)) ? @(mu) : mu;
+         in = i + mu;
+@SKIP /* based on full/cleanup, nu can be const or var */
+         for (jj=0; jj < @(nu_); jj++, C0 += ldc, p += @(mu)) 
+         {
+            const unsigned int J=j+jj;
+            for (ii=0; ii < mu; ii++)
+            {
+               const unsigned int I=i+ii;
+               if (I >= J)
+               {
+                  @callproc doElementUR ii 0 C ii p 
+               }
+            }
+         }
+         nblks = (in-1+@(nu)) / @(nu);  /* # of row blocks in this panel */
+         rwpan = nblks*@(bs);
+         rw += rwpan; /* finished all blocks in rowpanel */
+         rW = (in <= jn) ? rw : rW;
+      }
 @ENDPROC
 /*
  * Main Loop:
@@ -754,6 +894,7 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
 @endiif
 @SKIP ******************** SYRK copy: real type ********************************
 @iif TRI = 1
+@iif SYRKU = 0
    const unsigned int mf = M/@(mu), nf = N/@(nu);
    const unsigned int m = mf*@(mu), n = nf*@(nu), mr = M-m, nr = N-n;
    @iif mEn = 1
@@ -967,6 +1108,115 @@ static INLINE void a2c_1(const size_t M, const size_t N, const @(typ) alpha,
    default:;
    }
 @endiif
+@endiif
+@endiif
+@iif SYRKU ! 0
+@SKIP ***************** unrestricted syrk implementation **********************
+   int j, jn, cinc, rwpan;
+   unsigned int pansz = @(bs);
+   const size_t incC = ldc*@(nu);
+@ROUT C2BLK `   @(typ) *rW=b, *rw; `
+@ROUT BLK2C `   const @(typ) *rW=b, *rw; `
+/*
+ * NOTE: we assume N=M, always square for syrk 
+ */
+   @iif ML_NO = 0 
+      @iif ML_NUR ! 0
+   const unsigned int nf = N/@(nu);
+   const unsigned int n = nf*@(nu), nr = N-n;
+      @endiif
+/*
+ * NU colpan: Full panel, without cleanup (N direction)
+ */
+      @iif ML_NUR ! 0 
+   for (cinc=j=0; j < n; j = jn, C += incC, cinc += @(bs))
+      @endiif
+   @SKIP ***** Nu rolled, no need of Nu cleanup 
+      @iif ML_NUR = 0
+   for (cinc=j=0; j < N; j = jn, C += incC, cinc += @(bs))
+      @endiif
+   {
+      unsigned int i, in, nd;
+      @iif ML_NUR = 0
+      unsigned int nu = N-j;
+      nu = (nu >= @(nu)) ? @(nu) : nu;
+      jn = j + nu;      /* main loop, full NU block */
+      @endiif
+      @iif ML_NUR ! 0
+      jn = j + @(nu);      /* main loop, full NU block */
+      @endiif
+      i = (j/@(mu))*@(mu);
+      rw = rW;
+/*
+ *    handle the diagonal-crossing blocks first
+ *    NOTE: this can be full-MU block or partial----> no unrolling right now 
+ */
+      @iif ML_NUR ! 0
+         @callproc doDiagBlock mu @(nu)
+      @endiif
+      @iif ML_NUR = 0
+         @callproc doDiagBlock mu nu
+      @endiif
+/*
+ *    Full block after diagonal crossing, n=m  
+ */
+      @iif ML_MUNU = 1
+         @callproc doTrBlocksUR
+      @endiif
+      @SKIP only MU unrolling.. ML_MU true for both MU and MUNU
+      @iif ML_NUR = 0
+         @callproc doTrBlocksMuUR @(mu) nu
+      @endiif
+      @iif ML_MUR = 0 
+         @callproc doTrBlocksNuUR mu @(nu)
+      @endiif
+      @iif ML_MUR = 1 
+/*
+ *    MU cleanup 
+ */   
+      if (i < N)
+      {
+         @iif ML_MUNU = 1
+            @callproc doTrBlocksRolled mu @(nu) 0
+         @endiif
+         @iif ML_MUR = 1
+            @callproc doTrBlocksRolled mu nu 0
+         @endiif 
+      }
+      @endiif 
+   }
+   @endiif
+@BEGINSKIP
+*
+*  Following codes execute for three cases: 
+*     NU unrolled, both unrolled and no unroll 
+*     So, condition: if ML_MUR = 0 || ML_MUNU = 1 
+@ENDSKIP
+   @iif @iexp 1 @(ML_MUNU) = 0 @(ML_MUR) = |
+      @iif ML_NO = 0
+/*
+ * cleanup in N dimension
+ */
+   if (j < N)
+      @endiif
+      @iif ML_NO = 1
+   for (cinc=j=0; j < N; j = jn, C += incC, cinc += @(bs)) 
+      @endiif 
+   {
+      unsigned int  i, in, nu = N-j, nd, nblks;
+      jn = j + nu;
+      i = (j/@(mu))*@(mu);
+      rw = rW;
+      @callproc doDiagBlock mu nu 
+/*
+ *    full blocks before diagonal 
+ */
+      for (; i < N; i = in)
+      {
+         @callproc doTrBlocksRolled mu nu 1
+      }
+   }
+   @endiif 
 @endiif
 @SKIP ********** END of SYRK copy: real type ***********************************
 @endiif

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -20,9 +20,9 @@
 @SKIP TRI = 1 means lower triangular C (SYRK)
 @iif TRI = 1
 @BEGINSKIP ====================================================================
-********** SYRK COPY: from now on, we are using unrestricted syrk copies
-********** If you want to enable restricted copy for testing or timing purpose
-********** init SYRKU with 0
+********** SYRK COPY: We will use unrestricted syrk copies later on.
+********** If you want to enable unrestricted copy, change the definition of 
+********** SYRKU with 1
 @ENDSKIP   ====================================================================
 @ifdef ! SYRKU
    @SKIP @define SYRKU @1@  

--- a/AtlasBase/Clint/micro-cpg.base
+++ b/AtlasBase/Clint/micro-cpg.base
@@ -27,7 +27,6 @@
 @ifdef ! SYRKU
    @SKIP @define SYRKU @1@  
    @define SYRKU @0@  
-   @SKIP @define SYRKU @0@  
 @endifdef
    @iif SYRKU = 0
       @define ma @1@

--- a/iFKO/FKO/src/hil_lex.l
+++ b/iFKO/FKO/src/hil_lex.l
@@ -6,7 +6,17 @@ ICON	[0-9]+
 HCON	"0x"[0-9,A-F]+
 ID	[A-Za-z][A-Za-z0-9_]*
 ROUTNAM "ROUTINE"[ \t\v]+ID
+%x C_COMMENT
 %%
+<INITIAL>{
+"/*"              BEGIN(C_COMMENT);
+}
+<C_COMMENT>{
+"*/"      BEGIN(INITIAL);
+[^*\n]+   { } /* skip comments */
+"*"       { } /* skip the lone star */
+\n        { yylineno++; } /* NOTE: we are not passing the comment to HIL here */ 
+}
 "//"[^\n]*\n    { lnno++; strcpy(yylval.str, yytext+2); return(TCOMMENT); }
 [\t \v]		{}
 [\n]    {lnno++;}
@@ -95,5 +105,4 @@ ROUTNAM "ROUTINE"[ \t\v]+ID
 "_PREFETCHR"    { return(PREFETCHR); }
 "_PREFETCHW"    { return(PREFETCHW); }
 {ID}      { sprintf(yylval.str, "%s", yytext); return(NAME); }
-
 %%

--- a/iFKO/FKO/src/optsimd.c
+++ b/iFKO/FKO/src/optsimd.c
@@ -2024,7 +2024,7 @@ int VectorizeStage1(void)
    LOOPQ *lp;
    INSTQ *ip, *ipn;
    struct ptrinfo *pi0, *pi;
-   int flag, k, i, n, j;
+   int flag, k, dk, i, n, j;
    char ln[1024];
 
    if (!optloop)
@@ -2113,7 +2113,8 @@ int VectorizeStage1(void)
    {
       sprintf(ln, "_V%d_%s", i-1, STname[sp[i]-1] ? STname[sp[i]-1] : "");
       j = lp->vvscal[i+1] = STdef(ln, k, 0);
-      SToff[j-1].sa[2] = AddDerefEntry(-REG_SP, j, -j, 0, j);
+      dk = AddDerefEntry(-REG_SP, j, -j, 0, j);
+      SToff[j-1].sa[2] = dk;
    }
    SaveFKOState(1);
    return(0);
@@ -3221,7 +3222,7 @@ int SpeculativeVectorAnalysis()
  * incremental algorithm without explicitly figuring out all the paths
  */
 {
-   int i, j, n, k;
+   int i, j, n, k, dk;
    LOOPPATH *vpath;
    LOOPQ *lp;
    short *sp;
@@ -3421,7 +3422,8 @@ int SpeculativeVectorAnalysis()
       {
          sprintf(ln, "_V%d_%s", i-1, STname[sp[i]-1] ? STname[sp[i]-1] : "");
          j = lp->vvscal[i+1] = STdef(ln, k, 0);
-         SToff[j-1].sa[2] = AddDerefEntry(-REG_SP, j, -j, 0, j);
+         dk = AddDerefEntry(-REG_SP, j, -j, 0, j);
+         SToff[j-1].sa[2] = dk;
       }
       /*
        * Save fko

--- a/iFKO/FKO/src/symtab.c
+++ b/iFKO/FKO/src/symtab.c
@@ -716,7 +716,7 @@ void CreateLocalDerefs()
  * For paras, moves para # to SToff[].sa[0].
  */
 {
-   short k;
+   short k, j;
    int fl;
    /*short st; */
    /*int i, vl, stype;*/
@@ -728,17 +728,23 @@ void CreateLocalDerefs()
       if (IS_PARA(fl))
       {
          SToff[k].sa[0] = SToff[k].i;
-         SToff[k].sa[2] = AddDerefEntry(-REG_SP, k+1, -k-1, 0, k+1);
+         j = AddDerefEntry(-REG_SP, k+1, -k-1, 0, k+1);
+         SToff[k].sa[2] = j;
          SToff[k].sa[3] = 0; /* by default 0, remain 0 for 1D array */
       }
       else if (IS_LOCAL(fl))
       {
 #if 0         
          if (!IS_VECELEM(fl))
-            SToff[k].sa[2] = AddDerefEntry(-REG_SP, k+1, -k-1, 0, k+1);
+         {
+            j = AddDerefEntry(-REG_SP, k+1, -k-1, 0, k+1);
+            SToff[k].sa[2] = j;
+         }
          else
-            SToff[k].sa[2] = AddDerefEntry(-REG_SP, SToff[k].sa[0], -k-1, 0, 
-                                           k+1);
+         {
+            j =  AddDerefEntry(-REG_SP, SToff[k].sa[0], -k-1, 0, k+1);
+            SToff[k].sa[2] = j;
+         }
 /*
  *       adding scalars for each vector elements
  *       For local, SToff[].sa[0] is unused. we used this to point the parent 
@@ -746,7 +752,8 @@ void CreateLocalDerefs()
  */
          if (IS_VEC(fl))
          {
-            SToff[k].sa[2] = AddDerefEntry(-REG_SP, k+1, -k-1, 0, k+1);
+            j = AddDerefEntry(-REG_SP, k+1, -k-1, 0, k+1);
+            SToff[k].sa[2] = j;
             SToff[k].sa[1] = 0; /* will be changed later! */
             vl = vtype2elem(FLAG2TYPE(fl));
             if (IS_VFLOAT(fl))
@@ -765,11 +772,18 @@ void CreateLocalDerefs()
             }
          }
          else if (IS_VECELEM(fl))
-            SToff[k].sa[2] = AddDerefEntry(-REG_SP, SToff[k].sa[0],-k-1,0, k+1);
+         {
+            j = AddDerefEntry(-REG_SP, SToff[k].sa[0],-k-1,0, k+1);
+            SToff[k].sa[2] = j;
+         }
          else
-            SToff[k].sa[2] = AddDerefEntry(-REG_SP, k+1, -k-1, 0, k+1);
+         {
+            j = AddDerefEntry(-REG_SP, k+1, -k-1, 0, k+1);
+            SToff[k].sa[2] = j; 
+         }
 #else
-         SToff[k].sa[2] = AddDerefEntry(-REG_SP, k+1, -k-1, 0, k+1);
+         j = AddDerefEntry(-REG_SP, k+1, -k-1, 0, k+1);
+         SToff[k].sa[2] = j;
 #endif
       }
    }


### PR DESCRIPTION
1. Implemented parameterized-unrolling for A and C copies
2. for C SYRK copies: parameterized with only the unrestricted version (only the main loop). The old restricted copy is going to be obsolete.  

NOTE: To keep the behavior same as before for now, bvML=3 and bvCU=3 are used by default (meaning all fully unrolled) and I set SYRKU=0 (to enable the restricted syrk). To use unrestricted SYRK, need to set SYRKU=1 in micro-cpg.base. 

Here are all the options:
cpUR = <bvCU , bvML>  (lower 2 bit for mainloop and upper 2 bit for cleanup)
bvML = bit vector for Main Loop, bvCU = bitvector for Cleanup Loop
0 = fully rolled. 
1 = MU Unrolled (or, NU unrolled for A no-transpose copy)
2 = NU Unrolled for C copy, KU unrolled for A copies
3 = fully unrolled 

SYRKU = 1 means unrestricted syrk copy. The difference between this version with the fixed unrestricted copy in auxil/kernel/ is: it uses same function prototype as the old syrk copies. So, it can be used to replace the old copy without any afford. bvML can be used for this copy to unrolled the main loop which is needed for old AMD machines (opt32) to get good performance. 
