### PR TITLE
Replace `fgrep` with `grep -F` where applicable 

### DIFF
--- a/AtlasBase/Clint/atlconf.base
+++ b/AtlasBase/Clint/atlconf.base
@@ -8043,7 +8043,7 @@ int GetIntProbe(int verb, char *targarg, char *prb, char *id, int N)
    i = strlen(targarg) + strlen(prb) + strlen(id) + 48;
    ln = malloc(i*sizeof(char));
    assert(ln);
-   sprintf(ln, "make IRun_%s args=\"-v %d %s\" | fgrep '%s='", 
+   sprintf(ln, "make IRun_%s args=\"-v %d %s\" | grep -F '%s='", 
            prb, verb, targarg, id);
    if (verb > 1)
       printf("cmnd=%s\n", ln);


### PR DESCRIPTION
In some distros, like archlinux and it's derivatives, `fgrep` will throw a warning before running `grep -F "$@"`, which can cause asserts to fail.

For example, in GetIntProbe:
https://github.com/math-atlas/math-atlas/blob/fe29eec83868f2b328f08c133ec92c3ffd94a326/AtlasBase/Clint/atlconf.base#L8038-L8066

https://github.com/math-atlas/math-atlas/blob/fe29eec83868f2b328f08c133ec92c3ffd94a326/AtlasBase/Clint/atlconf.base#L8046-L8050 
`atlsys_1l` will always fail because the stderr->stdout redirection is hardcoded to be enabled.

Which gets the first line of stdout, which happens to be the warning, and the assertion and with that configure fails.

---

Needs to be tested but grep&replacing most of the `fgrep`'s should be fine.